### PR TITLE
[macro-data] fix: FRED IDs, specs, Room redefinition

### DIFF
--- a/meta/00-project-room/04-macro-analysis/01-macro-sources/progress.yaml
+++ b/meta/00-project-room/04-macro-analysis/01-macro-sources/progress.yaml
@@ -1,20 +1,31 @@
 progress:
   completion: 0.0
   milestones:
-    - id: "m1-FRED-API-接入"
-      name: "FRED API 接入"
+    - id: "m1-polymarket-fetcher"
+      name: "Polymarket 事件概率抓取"
       status: pending
       completed_at: null
-    - id: "m2-BLS-数据采集"
-      name: "BLS 数据采集"
+      description: |
+        爬取 Polymarket 前 30 大宏观事件的隐含概率。
+        存储到 SQLite（event_id, title, probability, fetched_at）。
+        检测概率悬崖（前后差值 > 阈值）。
+      estimated_files: ["src/stockbee/macro_sources/polymarket.py"]
+      estimated_lines: 150
+
+    - id: "m2-economic-calendar"
+      name: "经济日历集成"
       status: pending
       completed_at: null
-    - id: "m3-美联储-RSS-解析"
-      name: "美联储 RSS 解析"
-      status: pending
-      completed_at: null
-    - id: "m4-测试"
+      description: |
+        FOMC 会议、非农、CPI 等关键事件日历。
+        标记高波动事件日。可从 FRED release calendar 或静态维护。
+      estimated_files: ["src/stockbee/macro_sources/calendar.py"]
+      estimated_lines: 100
+
+    - id: "m3-tests"
       name: "测试"
       status: pending
       completed_at: null
+      estimated_files: ["tests/test_macro_sources.py"]
+      estimated_lines: 150
   commits: []

--- a/meta/00-project-room/04-macro-analysis/01-macro-sources/room.yaml
+++ b/meta/00-project-room/04-macro-analysis/01-macro-sources/room.yaml
@@ -1,15 +1,16 @@
 room:
   id: "01-macro-sources"
-  name: "宏观数据源"
+  name: "补充宏观数据源"
   parent: "04-macro-analysis"
   type: feature
   lifecycle: planning
   priority: P0
   phase: "1"
   created_at: "2026-03-24"
-  updated_at: "2026-03-24"
+  updated_at: "2026-04-06"
   prompt_test:
     passable: false
     last_tested: null
     token_count: null
   depends_on: ['02-data-architecture/03-macro-data', '02-data-architecture/07-provider-arch']
+  note: "原定义 FRED/BLS/RSS 已被 03-macro-data 覆盖，重新定义为 Polymarket + 经济日历"

--- a/meta/00-project-room/04-macro-analysis/01-macro-sources/spec.md
+++ b/meta/00-project-room/04-macro-analysis/01-macro-sources/spec.md
@@ -1,22 +1,27 @@
-# 宏观数据源 (01-macro-sources)
+# 补充宏观数据源 (01-macro-sources)
 
 ## Intent
 
-**FRED API + BLS + 美联储 RSS 数据采集**
+**Polymarket 事件概率 + 经济日历**（原 FRED/BLS/RSS 已被 03-macro-data 覆盖）
 
-通过 MacroProvider 采集 19 个 FRED 指标，日度更新。央行语调分析覆盖 FOMC 声明。
+两个补充数据源：
+- **Polymarket 事件概率** — 爬取前 30 大宏观事件，检测"概率悬崖"，作为 MacroTiltEngine 外生因子
+- **经济日历** — FOMC/非农/CPI 等事件日，标记高波动日，避免在数据发布前后再平衡
 
-来源：Feature Hierarchy §4.1
-研究状态：研究完成 (research-macro-features.md)
+依赖：03-macro-data ✅（FRED 17 指标已连通）
+
+## Constraints
+
+_待开发时确定_
 
 ## Decisions
 
-_暂无决策记录_
+- **FRED/BLS/RSS 不在本 Room 实现** — 已被 03-macro-data 完全覆盖（2026-04-06 重新定义）
 
 ## Contracts
 
-_暂无接口约定_
+_待开发时确定_
 
 ---
-_所有 spec 状态: draft（需要 review 后升为 active）_
-_spec.md 由 room-init 自动生成，specs/*.yaml 为源数据_
+_spec 状态: active（intent 已重新定义）_
+_spec.md 最后更新: 2026-04-06_

--- a/meta/00-project-room/04-macro-analysis/01-macro-sources/specs/intent-01-macro-sources-001.yaml
+++ b/meta/00-project-room/04-macro-analysis/01-macro-sources/specs/intent-01-macro-sources-001.yaml
@@ -1,23 +1,38 @@
 spec_id: "intent-01-macro-sources-001"
 type: intent
-state: draft
+state: active
 intent:
-  summary: "FRED API + BLS + 美联储 RSS 数据采集"
+  summary: "补充宏观数据源：Polymarket 事件概率 + 经济日历"
   detail: |
-    通过 MacroProvider 采集 19 个 FRED 指标，日度更新。央行语调分析覆盖 FOMC 声明。
+    原定义（FRED API + BLS + 美联储 RSS）已被 03-macro-data 完全覆盖：
+    - FRED API: FredMacroProvider 17 指标已连通
+    - BLS: NFP/UNRATE/CPI/PPI 通过 FRED 镜像获取
+    - 美联储 RSS: Tech Design 未明确要求
 
-来源：Feature Hierarchy §4.1
-研究状态：研究完成 (research-macro-features.md)
+    重新定义为两个补充数据源：
+
+    1. Polymarket 事件概率
+       - 爬取前 30 大宏观事件的隐含概率（Tech Design §4.3）
+       - 检测"概率悬崖"（概率突然大幅变化）
+       - 作为 MacroTiltEngine 的外生补充因子
+       - 例：降息概率从 20% 跳升至 70% → 增加高 duration 金融股权重
+       - 免费 API
+
+    2. 经济日历
+       - FOMC 会议日期、非农发布日、CPI 发布日等
+       - 标记高波动事件日，供 risk control 和 portfolio rebalancing 使用
+       - 避免在重大数据发布前后执行再平衡
 constraints: []
 indexing:
   type: intent
   priority: high
-  layer: epic
+  layer: feature
   domain: "quantitative-trading"
-  tags: []
+  tags: ["polymarket", "economic-calendar", "supplementary-data"]
 provenance:
-  source_type: prd_extraction
-  confidence: 0.8
-  source_ref: "PRD + Feature Hierarchy + Tech Design"
-relations: []
+  source_type: redesign
+  confidence: 0.9
+  source_ref: "Tech Design §4.3, plan-milestones 分析 2026-04-05"
+relations:
+  - { type: depends_on, target: "intent-03-macro-data-001", reason: "FRED 数据已由 macro-data 提供" }
 anchors: []

--- a/meta/00-project-room/_tree.yaml
+++ b/meta/00-project-room/_tree.yaml
@@ -46,7 +46,7 @@ tree:
           priority: P0
           phase: 1
           children:
-            - { id: "01-macro-sources", type: feature, priority: P0, phase: 1, status: "研究完成" }
+            - { id: "01-macro-sources", type: feature, priority: P0, phase: 1, status: "待开发", note: "重新定义: Polymarket + 经济日历（原 FRED/BLS 已被 03-macro-data 覆盖）" }
             - { id: "02-macro-scoring", type: feature, priority: P0, phase: 1, status: "待研究" }
             - { id: "03-sector-tilts", type: feature, priority: P0, phase: 1, status: "待研究" }
             - { id: "04-style-tilts", type: feature, priority: P0, phase: 1, status: "待研究" }

--- a/meta/00-project-room/timeline.yaml
+++ b/meta/00-project-room/timeline.yaml
@@ -34,10 +34,10 @@ timeline:
           target_start: "2026-04-07"
           target_end: "2026-04-18"
           estimated_days: 9
-          status: planning
-          completion: 0.0
+          status: completed
+          completion: 1.0
           depends_on: ["07-provider-arch"]
-          note: "研究完成，四层漏斗+Parquet"
+          note: "已完成 2026-04-02, Alpaca API 验证通过"
 
         - room: "02-news-data"
           parent: "02-data-architecture"
@@ -56,10 +56,10 @@ timeline:
           target_start: "2026-04-07"
           target_end: "2026-04-16"
           estimated_days: 7
-          status: planning
-          completion: 0.0
+          status: completed
+          completion: 1.0
           depends_on: ["07-provider-arch"]
-          note: "研究完成，与 stock-data 并行"
+          note: "已完成 2026-04-05, FRED API 17/17 验证通过"
 
         - room: "04-factor-storage"
           parent: "02-data-architecture"
@@ -115,7 +115,7 @@ timeline:
           status: planning
           completion: 0.0
           depends_on: ["03-macro-data", "07-provider-arch"]
-          note: "研究完成"
+          note: "重新定义: Polymarket 事件概率 + 经济日历（原 FRED/BLS 已被 03-macro-data 覆盖）"
 
         - room: "02-macro-scoring"
           parent: "04-macro-analysis"
@@ -471,8 +471,8 @@ timeline:
     phase_1_rooms: 26
     phase_2_rooms: 11
     phase_3_rooms: 3
-    completed: 1
+    completed: 3
     in_progress: 0
-    planning: 25
+    planning: 23
     backlog: 14
-    completion: 0.025
+    completion: 0.075


### PR DESCRIPTION
## Summary

- **FRED ID fix**: 3 invalid series IDs corrected (14/17 → 17/17 verified via live API)
- **03-macro-data specs**: 9 active specs (intent, 4 constraints, 2 decisions, contract, change)
- **01-macro-sources redefined**: Original FRED/BLS/RSS scope already covered by 03-macro-data. Redefined as "Polymarket event probability + economic calendar"
- **commit-sync skill**: Added spec type reference table
- **timeline.yaml**: Updated stock-data/macro-data to completed, overall 2.5% → 7.5%

## Test plan
- [x] 141 tests pass
- [x] FRED API 17/17 live verification


🤖 Generated with [Claude Code](https://claude.com/claude-code)