### PR TITLE
[01-llm-routing] feat: LLM multi-model router with litellm + cost tracking

### DIFF
--- a/meta/00-project-room/03-model-system/01-llm-routing/progress.yaml
+++ b/meta/00-project-room/03-model-system/01-llm-routing/progress.yaml
@@ -17,8 +17,8 @@ progress:
 
     - id: "m2-cost-tracker"
       name: "CostTracker + 响应缓存"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-07"
       description: |
         按任务类型累计 token 用量和成本。月度预算检查 ($15)。
         响应缓存（prompt hash 复用）。SQLite 历史记录。

--- a/meta/00-project-room/03-model-system/01-llm-routing/progress.yaml
+++ b/meta/00-project-room/03-model-system/01-llm-routing/progress.yaml
@@ -1,24 +1,36 @@
 progress:
   completion: 0.0
   milestones:
-    - id: "m1-路由器实现"
-      name: "路由器实现"
+    - id: "m1-llm-router-core"
+      name: "LLMRouter + TaskConfig 路由核心"
       status: pending
       completed_at: null
-    - id: "m2-G1-G2-G3-管道"
-      name: "G1/G2/G3 管道"
+      description: |
+        LLMRouter: route(task_type, prompt, output_schema) → response
+        统一调用接口（litellm），按 TaskType 选模型，降级链。
+        TaskConfig: 5 种任务类型的模型映射 + 参数配置。
+      estimated_files:
+        - "src/stockbee/llm_routing/__init__.py"
+        - "src/stockbee/llm_routing/router.py"
+        - "src/stockbee/llm_routing/task_config.py"
+      estimated_lines: 200
+
+    - id: "m2-cost-tracker"
+      name: "CostTracker + 响应缓存"
       status: pending
       completed_at: null
-    - id: "m3-降级链"
-      name: "降级链"
-      status: pending
-      completed_at: null
-    - id: "m4-Batch-API-优化"
-      name: "Batch API 优化"
-      status: pending
-      completed_at: null
-    - id: "m5-测试"
+      description: |
+        按任务类型累计 token 用量和成本。月度预算检查 ($15)。
+        响应缓存（prompt hash 复用）。SQLite 历史记录。
+      estimated_files:
+        - "src/stockbee/llm_routing/cost_tracker.py"
+      estimated_lines: 120
+
+    - id: "m3-tests"
       name: "测试"
       status: pending
       completed_at: null
+      estimated_files:
+        - "tests/test_llm_routing.py"
+      estimated_lines: 150
   commits: []

--- a/meta/00-project-room/03-model-system/01-llm-routing/progress.yaml
+++ b/meta/00-project-room/03-model-system/01-llm-routing/progress.yaml
@@ -1,5 +1,5 @@
 progress:
-  completion: 0.0
+  completion: 1.0
   milestones:
     - id: "m1-llm-router-core"
       name: "LLMRouter + TaskConfig 路由核心"
@@ -28,8 +28,8 @@ progress:
 
     - id: "m3-tests"
       name: "测试"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-08"
       estimated_files:
         - "tests/test_llm_routing.py"
       estimated_lines: 150

--- a/meta/00-project-room/03-model-system/01-llm-routing/progress.yaml
+++ b/meta/00-project-room/03-model-system/01-llm-routing/progress.yaml
@@ -3,8 +3,8 @@ progress:
   milestones:
     - id: "m1-llm-router-core"
       name: "LLMRouter + TaskConfig 路由核心"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-07"
       description: |
         LLMRouter: route(task_type, prompt, output_schema) → response
         统一调用接口（litellm），按 TaskType 选模型，降级链。

--- a/meta/00-project-room/03-model-system/01-llm-routing/progress.yaml
+++ b/meta/00-project-room/03-model-system/01-llm-routing/progress.yaml
@@ -33,4 +33,8 @@ progress:
       estimated_files:
         - "tests/test_llm_routing.py"
       estimated_lines: 150
-  commits: []
+  commits:
+    - { date: "2026-04-07", hash: "d72471e", message: "[01-llm-routing] plan: 3 milestones" }
+    - { date: "2026-04-07", hash: "e5e4396", message: "[01-llm-routing] feat: LLMRouter + TaskConfig" }
+    - { date: "2026-04-07", hash: "8a11056", message: "[01-llm-routing] feat: CostTracker" }
+    - { date: "2026-04-08", hash: "39740a4", message: "[01-llm-routing] feat+docs: 28 tests + Room completed" }

--- a/meta/00-project-room/03-model-system/01-llm-routing/room.yaml
+++ b/meta/00-project-room/03-model-system/01-llm-routing/room.yaml
@@ -3,13 +3,16 @@ room:
   name: "LLM 多模型路由"
   parent: "03-model-system"
   type: feature
-  lifecycle: planning
+  lifecycle: active
   priority: P0
   phase: "1"
   created_at: "2026-03-24"
-  updated_at: "2026-03-24"
+  updated_at: "2026-04-08"
   prompt_test:
-    passable: false
-    last_tested: null
-    token_count: null
+    passable: true
+    last_tested: "2026-04-08"
+    token_count: 4000
   depends_on: ['02-data-architecture/02-news-data']
+  implemented_at: "2026-04-08"
+  verified_at: "2026-04-08"
+  test_count: 28

--- a/meta/00-project-room/03-model-system/01-llm-routing/spec.md
+++ b/meta/00-project-room/03-model-system/01-llm-routing/spec.md
@@ -2,25 +2,32 @@
 
 ## Intent
 
-**按任务选模型，G1/G2/G3 分级路由，降级链**
+**按任务选模型，litellm 统一接口，降级链，成本追踪**
 
-G1 GPT-4.1 nano (<$1)，G2 Claude Sonnet 4 (<$2)，G3 GPT-4.1 (<$5)，SEC GPT-4.1 long (<$3)，宏观 Claude Sonnet 4 (<$4)。降级链：主模型→备选→缓存→禁用信号。
+3 个核心组件：
+- **LLMRouter** — route(task_type, prompt) → LLMResponse。litellm 统一调用，降级链（主模型→备选→raise），JSON 解析 + schema 验证，set_completion_fn() 支持 mock 测试
+- **TaskConfig** — 5 种任务类型（G1_FILTER, G2_CLASSIFY, G3_ANALYSIS, SEC_PARSE, MACRO_ANALYSIS），每种指定模型、备选、token 限制、输出格式
+- **CostTracker** — SQLite 历史记录，按任务类型累计成本，月度预算检查（$15），prompt hash 响应缓存
 
-来源：Tech Design §3.2
-研究状态：研究完成 (research-llm-selection.md)
+实现状态：已完成 ✅（2026-04-08）
+测试覆盖：28 个单元测试（mock，不调真实 API）
 
 ## Constraints
 
-- **月度合计 < $15** — 来源: Tech Design §3.2
+- **月度 LLM 成本 < $15** — G1($1) + G2($2) + G3($5) + SEC($3) + 宏观($4)
+- **litellm 为可选依赖** — 回测/测试不需要安装
+- **Router 是 task-agnostic** — 不含 G1/G2/G3 业务逻辑，只提供路由接口
 
 ## Decisions
 
-_暂无决策记录_
+- **litellm > 直接 OpenAI+Anthropic SDK** — 一行代码切换模型，统一接口
+- **Router 不管 G1/G2/G3 业务逻辑** — prompt 模板和处理逻辑在调用方（news-data 等）
 
 ## Contracts
 
-_暂无接口约定_
+- **LLMRouter** — route(task_type, prompt, system_prompt?, output_schema?) → LLMResponse; get_config(task_type); list_task_types(); set_completion_fn(fn)
+- **CostTracker** — record_call; get_cached; is_over_budget; monthly_spent; monthly_report; cache_size
 
 ---
-_所有 spec 状态: draft（需要 review 后升为 active）_
-_spec.md 由 room-init 自动生成，specs/*.yaml 为源数据_
+_所有 spec 状态: active_
+_spec.md 最后更新: 2026-04-08_

--- a/meta/00-project-room/03-model-system/01-llm-routing/specs/change-01-llm-routing-001.yaml
+++ b/meta/00-project-room/03-model-system/01-llm-routing/specs/change-01-llm-routing-001.yaml
@@ -1,0 +1,36 @@
+spec_id: "change-01-llm-routing-001"
+type: change
+state: active
+intent:
+  summary: "01-llm-routing 模块完整实现 (2026-04-07 ~ 2026-04-08)"
+  detail: |
+    新增文件：
+    - src/stockbee/llm_routing/__init__.py
+    - src/stockbee/llm_routing/router.py — LLMRouter + LLMResponse
+    - src/stockbee/llm_routing/task_config.py — TaskType + TaskConfig + DEFAULT_TASK_CONFIGS
+    - src/stockbee/llm_routing/cost_tracker.py — CostTracker (SQLite)
+    - tests/test_llm_routing.py — 28 个测试
+
+    Git commits：
+    - d72471e plan: 3 milestones
+    - e5e4396 feat: LLMRouter + TaskConfig
+    - 8a11056 feat: CostTracker
+    - 39740a4 feat+docs: 28 tests + Room completed
+
+    验证：
+    - 28/28 测试通过（mock，不调真实 API）
+    - 169/169 全项目测试通过
+    - 路由 + 降级 + JSON 解析 + 缓存全部验证
+constraints: []
+indexing:
+  type: change
+  priority: high
+  layer: feature
+  domain: "quantitative-trading"
+  tags: ["changelog", "implementation"]
+provenance:
+  source_type: git_history
+  confidence: 1.0
+  source_ref: "git log d72471e..39740a4"
+relations: []
+anchors: []

--- a/meta/00-project-room/03-model-system/01-llm-routing/specs/constraint-01-llm-routing-001.yaml
+++ b/meta/00-project-room/03-model-system/01-llm-routing/specs/constraint-01-llm-routing-001.yaml
@@ -1,19 +1,32 @@
 spec_id: "constraint-01-llm-routing-001"
 type: constraint
-state: draft
+state: active
 intent:
-  summary: "月度合计 < $15"
-  detail: ""
-constraints: []
+  summary: "月度 LLM 成本 < $15，按任务类型分配预算"
+  detail: |
+    5 种任务类型的月度预算分配：
+    - G1_FILTER: $1（GPT-4.1 nano，标题+摘要 100-300 tokens）
+    - G2_CLASSIFY: $2（Claude Sonnet 4，摘要+正文 500-1k tokens）
+    - G3_ANALYSIS: $5（GPT-4.1，完整新闻+持仓 2-5k tokens）
+    - SEC_PARSE: $3（GPT-4.1 long context，60k tokens）
+    - MACRO_ANALYSIS: $4（Claude Sonnet 4，FRED 指标 2k tokens）
+
+    CostTracker 实时累计，is_over_budget() 超限时调用方应降级到缓存。
+constraints:
+  - "TOTAL_MONTHLY_BUDGET = $15"
+  - "CostTracker 按月累计，跨月自动归零"
+  - "超预算时 is_over_budget() 返回 True，由调用方决定降级策略"
 indexing:
   type: constraint
   priority: high
-  layer: epic
+  layer: feature
   domain: "quantitative-trading"
-  tags: []
+  tags: ["cost", "budget", "llm"]
 provenance:
-  source_type: prd_extraction
-  confidence: 0.9
-  source_ref: "Tech Design §3.2"
+  source_type: implementation_verified
+  confidence: 1.0
+  source_ref: "Tech Design §3.2, src/stockbee/llm_routing/cost_tracker.py"
 relations: []
-anchors: []
+anchors:
+  - { file: "src/stockbee/llm_routing/cost_tracker.py", type: implementation }
+  - { file: "src/stockbee/llm_routing/task_config.py", type: implementation }

--- a/meta/00-project-room/03-model-system/01-llm-routing/specs/constraint-01-llm-routing-002.yaml
+++ b/meta/00-project-room/03-model-system/01-llm-routing/specs/constraint-01-llm-routing-002.yaml
@@ -1,0 +1,27 @@
+spec_id: "constraint-01-llm-routing-002"
+type: constraint
+state: active
+intent:
+  summary: "litellm 为可选依赖，Router task-agnostic"
+  detail: |
+    - litellm 未安装时 _default_completion 抛出 ImportError 并给出安装提示
+    - 通过 set_completion_fn() 可替换底层调用，测试时不需要 litellm
+    - Router 不包含 G1/G2/G3 的 prompt 模板或处理逻辑
+    - 调用方（news-data、macro-analysis 等）负责构建 prompt 并选择 TaskType
+constraints:
+  - "litellm 未安装时给出明确 ImportError 提示"
+  - "Router 接口只有 route(task_type, prompt) — 不做业务判断"
+  - "28 个测试全部使用 mock，不依赖外部 API"
+indexing:
+  type: constraint
+  priority: medium
+  layer: feature
+  domain: "quantitative-trading"
+  tags: ["litellm", "dependency", "agnostic"]
+provenance:
+  source_type: implementation_verified
+  confidence: 1.0
+  source_ref: "src/stockbee/llm_routing/router.py"
+relations: []
+anchors:
+  - { file: "src/stockbee/llm_routing/router.py", type: implementation }

--- a/meta/00-project-room/03-model-system/01-llm-routing/specs/constraint-01-llm-routing-003.yaml
+++ b/meta/00-project-room/03-model-system/01-llm-routing/specs/constraint-01-llm-routing-003.yaml
@@ -1,0 +1,31 @@
+spec_id: "constraint-01-llm-routing-003"
+type: constraint
+state: active
+intent:
+  summary: "降级链：主模型 → 备选 → RuntimeError，可配置重试次数"
+  detail: |
+    降级流程：
+    1. 主模型重试 max_retries 次（默认 2）
+    2. 全部失败 → 备选模型重试 max_retries 次
+    3. 全部失败 → raise RuntimeError
+
+    最后一次重试的异常会被 log（exc_info=True），之前的只 log warning。
+    调用方可在 RuntimeError 外层实现缓存回退（通过 CostTracker.get_cached）。
+constraints:
+  - "主模型失败自动降级到 fallback_model"
+  - "fallback_model=None 时跳过降级步骤"
+  - "全部失败 raise RuntimeError（不静默吞错）"
+  - "exc_info 只在最后一次重试时打印（避免日志爆炸）"
+indexing:
+  type: constraint
+  priority: high
+  layer: feature
+  domain: "quantitative-trading"
+  tags: ["fallback", "retry", "error-handling"]
+provenance:
+  source_type: implementation_verified
+  confidence: 1.0
+  source_ref: "src/stockbee/llm_routing/router.py:128-162"
+relations: []
+anchors:
+  - { file: "src/stockbee/llm_routing/router.py", type: implementation }

--- a/meta/00-project-room/03-model-system/01-llm-routing/specs/contract-01-llm-routing-001.yaml
+++ b/meta/00-project-room/03-model-system/01-llm-routing/specs/contract-01-llm-routing-001.yaml
@@ -1,0 +1,50 @@
+spec_id: "contract-01-llm-routing-001"
+type: contract
+state: active
+intent:
+  summary: "LLMRouter + CostTracker 完整接口约定"
+  detail: |
+    @dataclass
+    class LLMResponse:
+        content: str                    # 原始文本
+        parsed: dict | None             # JSON 解析结果（text 格式为 None）
+        model_used: str                 # 实际使用的模型
+        task_type: TaskType
+        input_tokens: int
+        output_tokens: int
+        cost: float                     # 本次成本（美元）
+        from_fallback: bool
+        from_cache: bool
+
+    class LLMRouter:
+        def __init__(task_configs?, max_retries=2)
+        def route(task_type, prompt, system_prompt?, output_schema?) → LLMResponse
+        def get_config(task_type) → TaskConfig
+        def list_task_types() → list[dict]
+        def set_completion_fn(fn)       # 测试用 mock
+
+    class CostTracker:
+        def __init__(db_path, monthly_budget=15.0)
+        def initialize() / shutdown()
+        def record_call(task_type, model, prompt, response_content,
+                        input_tokens, output_tokens, cost, from_fallback)
+        def get_cached(task_type, prompt) → str | None
+        def is_over_budget(month?) → bool
+        def monthly_spent(month?) → float
+        def monthly_report(month?) → dict
+        def cache_size() → int
+constraints: []
+indexing:
+  type: contract
+  priority: high
+  layer: feature
+  domain: "quantitative-trading"
+  tags: ["api", "interface", "llm"]
+provenance:
+  source_type: implementation
+  confidence: 1.0
+  source_ref: "src/stockbee/llm_routing/"
+relations: []
+anchors:
+  - { file: "src/stockbee/llm_routing/router.py", type: implementation }
+  - { file: "src/stockbee/llm_routing/cost_tracker.py", type: implementation }

--- a/meta/00-project-room/03-model-system/01-llm-routing/specs/decision-01-llm-routing-001.yaml
+++ b/meta/00-project-room/03-model-system/01-llm-routing/specs/decision-01-llm-routing-001.yaml
@@ -1,0 +1,33 @@
+spec_id: "decision-01-llm-routing-001"
+type: decision
+state: active
+intent:
+  summary: "litellm 统一接口 vs 直接 OpenAI + Anthropic SDK"
+  detail: |
+    决策：使用 litellm 作为统一 LLM 调用层。
+
+    评估选项：
+    - 直接 OpenAI SDK + Anthropic SDK：两套不同的 API 格式，需要各写 adapter
+    - litellm：统一 completion() 接口，一行代码切换 100+ 模型
+
+    决策理由：
+    - 一个 model 参数（如 "openai/gpt-4.1-nano"）即可选模型
+    - completion_cost() 内置成本计算
+    - 未来换模型（如 Gemini、Mistral）零改动
+    - 降级链实现只需切换 model 字符串
+
+    代价：多一个依赖（litellm），但它本身是轻量包装层。
+constraints: []
+indexing:
+  type: decision
+  priority: high
+  layer: feature
+  domain: "quantitative-trading"
+  tags: ["litellm", "sdk", "adr"]
+provenance:
+  source_type: implementation
+  confidence: 1.0
+  source_ref: "plan-milestones 讨论 2026-04-07"
+relations: []
+anchors:
+  - { file: "src/stockbee/llm_routing/router.py", type: implementation }

--- a/meta/00-project-room/03-model-system/01-llm-routing/specs/decision-01-llm-routing-002.yaml
+++ b/meta/00-project-room/03-model-system/01-llm-routing/specs/decision-01-llm-routing-002.yaml
@@ -1,0 +1,33 @@
+spec_id: "decision-01-llm-routing-002"
+type: decision
+state: active
+intent:
+  summary: "Router task-agnostic vs 内置 G1/G2/G3 处理逻辑"
+  detail: |
+    决策：Router 只提供 route(task_type, prompt) 接口，不包含 G1/G2/G3 业务逻辑。
+
+    评估选项：
+    - Router 内置 G1/G2/G3 prompt 模板和后处理：方便但耦合严重
+    - Router task-agnostic：G1/G2/G3 的 prompt 和处理放在调用方（news-data）
+
+    决策理由：
+    - Router 是通用基础设施，不应和新闻处理逻辑耦合
+    - 其他模块（macro-analysis、sec-parse）也需要调 LLM，不涉及 G1/G2/G3
+    - 调用方只需选择 TaskType + 构建 prompt，Router 负责选模型+调API+降级
+    - 更容易测试：Router 测试不依赖新闻数据
+
+    代价：调用方需要自己管理 prompt 模板。
+constraints: []
+indexing:
+  type: decision
+  priority: high
+  layer: feature
+  domain: "quantitative-trading"
+  tags: ["agnostic", "decoupling", "adr"]
+provenance:
+  source_type: implementation
+  confidence: 1.0
+  source_ref: "plan-milestones 讨论 2026-04-07"
+relations: []
+anchors:
+  - { file: "src/stockbee/llm_routing/router.py", type: implementation }

--- a/meta/00-project-room/03-model-system/01-llm-routing/specs/intent-01-llm-routing-001.yaml
+++ b/meta/00-project-room/03-model-system/01-llm-routing/specs/intent-01-llm-routing-001.yaml
@@ -1,23 +1,49 @@
 spec_id: "intent-01-llm-routing-001"
 type: intent
-state: draft
+state: active
 intent:
-  summary: "按任务选模型，G1/G2/G3 分级路由，降级链"
+  summary: "litellm 多模型路由器 + 降级链 + 成本追踪 + 响应缓存"
   detail: |
-    G1 GPT-4.1 nano (<$1)，G2 Claude Sonnet 4 (<$2)，G3 GPT-4.1 (<$5)，SEC GPT-4.1 long (<$3)，宏观 Claude Sonnet 4 (<$4)。降级链：主模型→备选→缓存→禁用信号。
+    LLM Routing 模块提供统一的 LLM 调用接口，按任务类型选择最优模型。
 
-来源：Tech Design §3.2
-研究状态：研究完成 (research-llm-selection.md)
-constraints: []
+    1. LLMRouter（路由核心）
+       - route(task_type, prompt, system_prompt?, output_schema?) → LLMResponse
+       - 统一调用接口 via litellm（屏蔽 OpenAI/Anthropic SDK 差异）
+       - 降级链：主模型 → 备选模型 → RuntimeError（可配置重试次数）
+       - JSON 输出自动解析（含 markdown code block 处理）
+       - 简单 schema 验证（检查 required 字段）
+       - set_completion_fn() 替换底层调用（测试 mock 用）
+       - task-agnostic：不包含 G1/G2/G3 业务逻辑
+
+    2. TaskConfig（任务配置）
+       - 5 种 TaskType: G1_FILTER, G2_CLASSIFY, G3_ANALYSIS, SEC_PARSE, MACRO_ANALYSIS
+       - 每种配置：model, fallback_model, max_tokens, temperature, output_format, monthly_budget
+       - DEFAULT_TASK_CONFIGS 映射 Tech Design §3.2 的模型选择
+       - TOTAL_MONTHLY_BUDGET = $15
+
+    3. CostTracker（成本追踪 + 缓存）
+       - SQLite 两张表：llm_calls（调用历史）+ llm_cache（响应缓存）
+       - record_call：记录调用 + 自动更新缓存
+       - get_cached：SHA256 prompt hash 去重，返回上次成功响应
+       - is_over_budget / monthly_spent：月度预算检查
+       - monthly_report：按任务类型分组的成本报告
+constraints:
+  - "constraint-01-llm-routing-001"
+  - "constraint-01-llm-routing-002"
+  - "constraint-01-llm-routing-003"
 indexing:
   type: intent
   priority: high
-  layer: epic
+  layer: feature
   domain: "quantitative-trading"
-  tags: []
+  tags: ["llm", "routing", "litellm", "cost-tracking", "fallback"]
 provenance:
-  source_type: prd_extraction
-  confidence: 0.8
-  source_ref: "PRD + Feature Hierarchy + Tech Design"
-relations: []
-anchors: []
+  source_type: implementation_verified
+  confidence: 1.0
+  source_ref: "src/stockbee/llm_routing/, Tech Design §3.2"
+relations:
+  - { type: depends_on, target: "intent-07-provider-arch-001", reason: "复用 Provider 设计模式" }
+anchors:
+  - { file: "src/stockbee/llm_routing/router.py", type: implementation }
+  - { file: "src/stockbee/llm_routing/task_config.py", type: implementation }
+  - { file: "src/stockbee/llm_routing/cost_tracker.py", type: implementation }

--- a/meta/00-project-room/_tree.yaml
+++ b/meta/00-project-room/_tree.yaml
@@ -36,7 +36,7 @@ tree:
           priority: P0
           phase: "1-2"
           children:
-            - { id: "01-llm-routing", type: feature, priority: P0, phase: 1, status: "研究完成" }
+            - { id: "01-llm-routing", type: feature, priority: P0, phase: 1, status: "已完成" }
             - { id: "02-small-models", type: feature, priority: P0, phase: 1, status: "研究完成" }
             - { id: "03-rl-algorithms", type: feature, priority: P0, phase: 2, status: "待研究" }
             - { id: "04-alpha-mining", type: feature, priority: P0, phase: 1, status: "研究完成" }

--- a/meta/00-project-room/timeline.yaml
+++ b/meta/00-project-room/timeline.yaml
@@ -79,10 +79,10 @@ timeline:
           target_start: "2026-04-21"
           target_end: "2026-05-02"
           estimated_days: 9
-          status: planning
-          completion: 0.0
+          status: completed
+          completion: 1.0
           depends_on: ["02-news-data"]
-          note: "研究完成，多模型路由+降级链"
+          note: "已完成 2026-04-08, litellm + 降级链 + CostTracker"
 
         - room: "02-small-models"
           parent: "03-model-system"
@@ -471,8 +471,8 @@ timeline:
     phase_1_rooms: 26
     phase_2_rooms: 11
     phase_3_rooms: 3
-    completed: 3
+    completed: 5
     in_progress: 0
-    planning: 23
+    planning: 21
     backlog: 14
-    completion: 0.075
+    completion: 0.125

--- a/src/stockbee/llm_routing/__init__.py
+++ b/src/stockbee/llm_routing/__init__.py
@@ -5,11 +5,14 @@ Router 不管业务逻辑（G1/G2/G3），只提供 route(task_type, prompt) 接
 """
 
 from .task_config import TaskType, TaskConfig, DEFAULT_TASK_CONFIGS
-from .router import LLMRouter
+from .router import LLMRouter, LLMResponse
+from .cost_tracker import CostTracker
 
 __all__ = [
     "TaskType",
     "TaskConfig",
     "DEFAULT_TASK_CONFIGS",
     "LLMRouter",
+    "LLMResponse",
+    "CostTracker",
 ]

--- a/src/stockbee/llm_routing/__init__.py
+++ b/src/stockbee/llm_routing/__init__.py
@@ -1,0 +1,15 @@
+"""LLM Routing 模块 — 多模型路由 + 降级链 + 成本追踪。
+
+按任务类型选模型，统一 OpenAI/Anthropic 调用接口（via litellm）。
+Router 不管业务逻辑（G1/G2/G3），只提供 route(task_type, prompt) 接口。
+"""
+
+from .task_config import TaskType, TaskConfig, DEFAULT_TASK_CONFIGS
+from .router import LLMRouter
+
+__all__ = [
+    "TaskType",
+    "TaskConfig",
+    "DEFAULT_TASK_CONFIGS",
+    "LLMRouter",
+]

--- a/src/stockbee/llm_routing/cost_tracker.py
+++ b/src/stockbee/llm_routing/cost_tracker.py
@@ -1,0 +1,220 @@
+"""CostTracker — LLM 调用成本追踪 + 响应缓存。
+
+按任务类型累计 token 用量和成本。月度预算检查（$15 上限）。
+响应缓存：同一 prompt hash 复用上次成功结果。
+SQLite 存储历史调用记录。
+
+来源：Tech Design §3.2
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .task_config import TaskType, TOTAL_MONTHLY_BUDGET
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS llm_calls (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_type       TEXT NOT NULL,
+    model           TEXT NOT NULL,
+    prompt_hash     TEXT NOT NULL,
+    input_tokens    INTEGER DEFAULT 0,
+    output_tokens   INTEGER DEFAULT 0,
+    cost            REAL DEFAULT 0.0,
+    from_fallback   INTEGER DEFAULT 0,
+    created_at      TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_llm_calls_month
+    ON llm_calls(created_at);
+
+CREATE INDEX IF NOT EXISTS idx_llm_calls_task
+    ON llm_calls(task_type);
+
+CREATE TABLE IF NOT EXISTS llm_cache (
+    prompt_hash     TEXT PRIMARY KEY,
+    task_type       TEXT NOT NULL,
+    response_json   TEXT NOT NULL,
+    created_at      TEXT NOT NULL
+);
+"""
+
+
+class CostTracker:
+    """LLM 成本追踪 + 响应缓存。
+
+    使用方式：
+        tracker = CostTracker(db_path="data/llm_costs.db")
+        tracker.initialize()
+
+        # 检查预算
+        if tracker.is_over_budget():
+            # 降级到缓存
+
+        # 记录调用
+        tracker.record_call(response)
+
+        # 查缓存
+        cached = tracker.get_cached(task_type, prompt)
+
+        # 月度报告
+        report = tracker.monthly_report()
+    """
+
+    def __init__(
+        self,
+        db_path: str | Path = "data/llm_costs.db",
+        monthly_budget: float = TOTAL_MONTHLY_BUDGET,
+    ) -> None:
+        self._db_path = Path(db_path)
+        self._monthly_budget = monthly_budget
+        self._conn: sqlite3.Connection | None = None
+
+    def initialize(self) -> None:
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self._db_path))
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.executescript(_SCHEMA_SQL)
+        self._conn.commit()
+        logger.info("CostTracker ready: %s (budget=$%.0f/mo)", self._db_path, self._monthly_budget)
+
+    def shutdown(self) -> None:
+        if self._conn:
+            self._conn.close()
+            self._conn = None
+
+    def record_call(
+        self,
+        task_type: TaskType,
+        model: str,
+        prompt: str,
+        response_content: str,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cost: float = 0.0,
+        from_fallback: bool = False,
+    ) -> None:
+        """记录一次 LLM 调用。同时更新缓存。"""
+        if not self._conn:
+            return
+
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        prompt_hash = self._hash_prompt(task_type, prompt)
+
+        self._conn.execute(
+            """INSERT INTO llm_calls
+               (task_type, model, prompt_hash, input_tokens, output_tokens,
+                cost, from_fallback, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (task_type.value, model, prompt_hash, input_tokens, output_tokens,
+             cost, int(from_fallback), now),
+        )
+
+        # 更新缓存
+        self._conn.execute(
+            """INSERT OR REPLACE INTO llm_cache
+               (prompt_hash, task_type, response_json, created_at)
+               VALUES (?, ?, ?, ?)""",
+            (prompt_hash, task_type.value, json.dumps({"content": response_content}), now),
+        )
+        self._conn.commit()
+
+    def get_cached(self, task_type: TaskType, prompt: str) -> str | None:
+        """查询缓存，返回上次成功响应内容，无缓存返回 None。"""
+        if not self._conn:
+            return None
+
+        prompt_hash = self._hash_prompt(task_type, prompt)
+        cur = self._conn.execute(
+            "SELECT response_json FROM llm_cache WHERE prompt_hash = ?",
+            (prompt_hash,),
+        )
+        row = cur.fetchone()
+        if row:
+            try:
+                return json.loads(row[0])["content"]
+            except (json.JSONDecodeError, KeyError):
+                return None
+        return None
+
+    def is_over_budget(self, month: str | None = None) -> bool:
+        """检查当月是否超预算。"""
+        spent = self.monthly_spent(month)
+        return spent >= self._monthly_budget
+
+    def monthly_spent(self, month: str | None = None) -> float:
+        """获取当月累计花费。"""
+        if not self._conn:
+            return 0.0
+
+        month = month or date.today().strftime("%Y-%m")
+        cur = self._conn.execute(
+            "SELECT COALESCE(SUM(cost), 0) FROM llm_calls WHERE created_at LIKE ?",
+            (f"{month}%",),
+        )
+        return cur.fetchone()[0]
+
+    def monthly_report(self, month: str | None = None) -> dict[str, Any]:
+        """月度成本报告，按任务类型分组。"""
+        if not self._conn:
+            return {}
+
+        month = month or date.today().strftime("%Y-%m")
+        cur = self._conn.execute(
+            """SELECT task_type,
+                      COUNT(*) as calls,
+                      SUM(input_tokens) as total_input,
+                      SUM(output_tokens) as total_output,
+                      SUM(cost) as total_cost
+               FROM llm_calls
+               WHERE created_at LIKE ?
+               GROUP BY task_type""",
+            (f"{month}%",),
+        )
+
+        breakdown: dict[str, Any] = {}
+        total_cost = 0.0
+        total_calls = 0
+
+        for row in cur.fetchall():
+            task_type, calls, inp, out, cost = row
+            breakdown[task_type] = {
+                "calls": calls,
+                "input_tokens": inp or 0,
+                "output_tokens": out or 0,
+                "cost": cost or 0.0,
+            }
+            total_cost += cost or 0.0
+            total_calls += calls
+
+        return {
+            "month": month,
+            "total_cost": round(total_cost, 4),
+            "total_calls": total_calls,
+            "budget": self._monthly_budget,
+            "remaining": round(self._monthly_budget - total_cost, 4),
+            "over_budget": total_cost >= self._monthly_budget,
+            "breakdown": breakdown,
+        }
+
+    def cache_size(self) -> int:
+        """返回缓存条目数。"""
+        if not self._conn:
+            return 0
+        cur = self._conn.execute("SELECT COUNT(*) FROM llm_cache")
+        return cur.fetchone()[0]
+
+    @staticmethod
+    def _hash_prompt(task_type: TaskType, prompt: str) -> str:
+        """生成 prompt 的确定性 hash。"""
+        key = f"{task_type.value}:{prompt}"
+        return hashlib.sha256(key.encode()).hexdigest()[:16]

--- a/src/stockbee/llm_routing/router.py
+++ b/src/stockbee/llm_routing/router.py
@@ -1,0 +1,247 @@
+"""LLMRouter — 多模型路由器 + 降级链。
+
+统一调用接口（via litellm），按 TaskType 选模型。
+Router 是 task-agnostic 的 — 不管 G1/G2/G3 业务逻辑，
+只提供 route(task_type, prompt) → response 接口。
+
+依赖：pip install litellm（可选依赖）
+
+来源：Tech Design §3.2
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from .task_config import DEFAULT_TASK_CONFIGS, TaskConfig, TaskType
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LLMResponse:
+    """LLM 调用的统一响应。"""
+    content: str                        # 原始文本响应
+    parsed: dict[str, Any] | None       # JSON 解析后的结果（output_format=json 时）
+    model_used: str                     # 实际使用的模型
+    task_type: TaskType
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cost: float = 0.0                   # 本次调用成本（美元）
+    from_fallback: bool = False         # 是否使用了降级模型
+    from_cache: bool = False            # 是否来自缓存
+
+
+class LLMRouter:
+    """多模型路由器。
+
+    使用方式：
+        router = LLMRouter()
+        response = router.route(
+            TaskType.G1_FILTER,
+            "Is this news relevant to AAPL? Headline: ...",
+        )
+        print(response.parsed)  # {"relevant": true}
+    """
+
+    def __init__(
+        self,
+        task_configs: dict[TaskType, TaskConfig] | None = None,
+        max_retries: int = 2,
+    ) -> None:
+        self._configs = task_configs or DEFAULT_TASK_CONFIGS
+        self._max_retries = max_retries
+        self._completion_fn = self._default_completion
+
+    def set_completion_fn(self, fn: Any) -> None:
+        """替换底层调用函数（用于测试 mock）。"""
+        self._completion_fn = fn
+
+    def route(
+        self,
+        task_type: TaskType,
+        prompt: str,
+        system_prompt: str | None = None,
+        output_schema: dict[str, Any] | None = None,
+    ) -> LLMResponse:
+        """路由 LLM 调用。
+
+        Args:
+            task_type: 任务类型，决定使用哪个模型
+            prompt: 用户 prompt
+            system_prompt: 可选的 system prompt
+            output_schema: 可选的 JSON schema（用于验证输出）
+
+        Returns:
+            LLMResponse
+        """
+        config = self._configs.get(task_type)
+        if config is None:
+            raise ValueError(f"Unknown task type: {task_type}")
+
+        # 尝试主模型
+        response = self._try_model(config.model, config, prompt, system_prompt)
+        if response is not None:
+            return self._finalize(response, config, output_schema, from_fallback=False)
+
+        # 降级到备选模型
+        if config.fallback_model:
+            logger.warning(
+                "Primary model %s failed for %s, falling back to %s",
+                config.model, task_type.value, config.fallback_model,
+            )
+            response = self._try_model(config.fallback_model, config, prompt, system_prompt)
+            if response is not None:
+                return self._finalize(response, config, output_schema, from_fallback=True)
+
+        # 全部失败
+        logger.error("All models failed for task %s", task_type.value)
+        raise RuntimeError(
+            f"LLM routing failed for {task_type.value}: "
+            f"primary={config.model}, fallback={config.fallback_model}"
+        )
+
+    def get_config(self, task_type: TaskType) -> TaskConfig:
+        """获取某任务类型的配置。"""
+        config = self._configs.get(task_type)
+        if config is None:
+            raise ValueError(f"Unknown task type: {task_type}")
+        return config
+
+    def list_task_types(self) -> list[dict[str, str]]:
+        """列出所有注册的任务类型及其模型。"""
+        return [
+            {
+                "task_type": config.task_type.value,
+                "model": config.model,
+                "fallback": config.fallback_model or "none",
+                "description": config.description,
+            }
+            for config in self._configs.values()
+        ]
+
+    # ------ Internal ------
+
+    def _try_model(
+        self,
+        model: str,
+        config: TaskConfig,
+        prompt: str,
+        system_prompt: str | None,
+    ) -> dict[str, Any] | None:
+        """尝试调用指定模型，失败返回 None。"""
+        messages = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": prompt})
+
+        for attempt in range(1, self._max_retries + 1):
+            try:
+                result = self._completion_fn(
+                    model=model,
+                    messages=messages,
+                    max_tokens=config.max_tokens,
+                    temperature=config.temperature,
+                )
+                return {
+                    "content": result["content"],
+                    "model": model,
+                    "input_tokens": result.get("input_tokens", 0),
+                    "output_tokens": result.get("output_tokens", 0),
+                    "cost": result.get("cost", 0.0),
+                }
+            except Exception:
+                logger.warning(
+                    "Model %s attempt %d/%d failed for %s",
+                    model, attempt, self._max_retries, config.task_type.value,
+                    exc_info=attempt == self._max_retries,
+                )
+        return None
+
+    def _finalize(
+        self,
+        raw: dict[str, Any],
+        config: TaskConfig,
+        output_schema: dict[str, Any] | None,
+        from_fallback: bool,
+    ) -> LLMResponse:
+        """构建 LLMResponse，尝试 JSON 解析。"""
+        content = raw["content"]
+        parsed = None
+
+        if config.output_format == "json":
+            parsed = self._try_parse_json(content)
+            if parsed is None:
+                logger.warning("Failed to parse JSON output for %s", config.task_type.value)
+
+            if parsed and output_schema:
+                if not self._validate_schema(parsed, output_schema):
+                    logger.warning(
+                        "Output schema validation failed for %s",
+                        config.task_type.value,
+                    )
+
+        return LLMResponse(
+            content=content,
+            parsed=parsed,
+            model_used=raw["model"],
+            task_type=config.task_type,
+            input_tokens=raw.get("input_tokens", 0),
+            output_tokens=raw.get("output_tokens", 0),
+            cost=raw.get("cost", 0.0),
+            from_fallback=from_fallback,
+        )
+
+    def _try_parse_json(self, content: str) -> dict[str, Any] | None:
+        """尝试从 LLM 输出中解析 JSON。"""
+        content = content.strip()
+        # 处理 markdown code block
+        if content.startswith("```"):
+            lines = content.split("\n")
+            content = "\n".join(lines[1:-1]) if len(lines) > 2 else content
+
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError:
+            return None
+
+    def _validate_schema(self, data: dict, schema: dict) -> bool:
+        """简单的 schema 验证（检查必需字段是否存在）。"""
+        required = schema.get("required", [])
+        return all(k in data for k in required)
+
+    @staticmethod
+    def _default_completion(
+        model: str,
+        messages: list[dict],
+        max_tokens: int,
+        temperature: float,
+    ) -> dict[str, Any]:
+        """默认调用函数 — 使用 litellm。"""
+        try:
+            import litellm
+        except ImportError:
+            raise ImportError(
+                "litellm is required for LLMRouter. "
+                "Install with: pip install litellm"
+            )
+
+        response = litellm.completion(
+            model=model,
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+
+        choice = response.choices[0]
+        usage = response.usage
+
+        return {
+            "content": choice.message.content or "",
+            "input_tokens": usage.prompt_tokens if usage else 0,
+            "output_tokens": usage.completion_tokens if usage else 0,
+            "cost": litellm.completion_cost(completion_response=response),
+        }

--- a/src/stockbee/llm_routing/task_config.py
+++ b/src/stockbee/llm_routing/task_config.py
@@ -1,0 +1,92 @@
+"""TaskConfig — 任务类型定义 + 模型映射配置。
+
+5 种任务类型，每种指定主模型、备选模型、token 限制、输出格式。
+成本估算基于 Tech Design §3.2。
+
+来源：Tech Design §3.2, research-llm-selection.md
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class TaskType(str, Enum):
+    """LLM 任务类型。"""
+    G1_FILTER = "g1_filter"              # 新闻快速过滤（相关/无关）
+    G2_CLASSIFY = "g2_classify"          # 新闻分类（情绪/主题/紧急度）
+    G3_ANALYSIS = "g3_analysis"          # 深度基本面分析
+    SEC_PARSE = "sec_parse"              # SEC 10-K/10-Q 解析
+    MACRO_ANALYSIS = "macro_analysis"    # 宏观环境分析（周度）
+
+
+@dataclass(frozen=True)
+class TaskConfig:
+    """单个任务类型的模型配置。"""
+    task_type: TaskType
+    model: str                     # litellm 模型 ID（如 "openai/gpt-4.1-nano"）
+    fallback_model: str | None     # 备选模型
+    max_tokens: int                # 最大输出 token
+    temperature: float = 0.0       # 默认确定性输出
+    output_format: str = "json"    # "json" | "text"
+    monthly_budget: float = 0.0    # 月度预算上限（美元）
+    description: str = ""
+
+
+# 默认配置 — Tech Design §3.2
+DEFAULT_TASK_CONFIGS: dict[TaskType, TaskConfig] = {
+    TaskType.G1_FILTER: TaskConfig(
+        task_type=TaskType.G1_FILTER,
+        model="openai/gpt-4.1-nano",
+        fallback_model="google/gemini-2.0-flash",
+        max_tokens=100,
+        temperature=0.0,
+        output_format="json",
+        monthly_budget=1.0,
+        description="新闻快速过滤：标题+摘要 → {relevant: bool}",
+    ),
+    TaskType.G2_CLASSIFY: TaskConfig(
+        task_type=TaskType.G2_CLASSIFY,
+        model="anthropic/claude-sonnet-4-20250514",
+        fallback_model="openai/gpt-4o-mini",
+        max_tokens=500,
+        temperature=0.0,
+        output_format="json",
+        monthly_budget=2.0,
+        description="新闻分类：摘要+部分正文 → {sentiment, category, urgency}",
+    ),
+    TaskType.G3_ANALYSIS: TaskConfig(
+        task_type=TaskType.G3_ANALYSIS,
+        model="openai/gpt-4.1",
+        fallback_model="anthropic/claude-opus-4-20250514",
+        max_tokens=2000,
+        temperature=0.3,
+        output_format="text",
+        monthly_budget=5.0,
+        description="深度基本面分析：完整新闻+持仓情景 → 影响评估",
+    ),
+    TaskType.SEC_PARSE: TaskConfig(
+        task_type=TaskType.SEC_PARSE,
+        model="openai/gpt-4.1",
+        fallback_model="anthropic/claude-sonnet-4-20250514",
+        max_tokens=3000,
+        temperature=0.0,
+        output_format="json",
+        monthly_budget=3.0,
+        description="SEC 10-K/10-Q 解析 → 关键财务指标 JSON",
+    ),
+    TaskType.MACRO_ANALYSIS: TaskConfig(
+        task_type=TaskType.MACRO_ANALYSIS,
+        model="anthropic/claude-sonnet-4-20250514",
+        fallback_model="openai/gpt-4.1",
+        max_tokens=1500,
+        temperature=0.2,
+        output_format="text",
+        monthly_budget=4.0,
+        description="周度宏观环境分析：FRED 指标 → 经济周期判断",
+    ),
+}
+
+TOTAL_MONTHLY_BUDGET = sum(c.monthly_budget for c in DEFAULT_TASK_CONFIGS.values())
+# Should be $15

--- a/tests/test_llm_routing.py
+++ b/tests/test_llm_routing.py
@@ -1,0 +1,296 @@
+# tests/test_llm_routing.py
+"""LLM Routing 模块测试。
+# PYTHONPATH=src .venv/bin/python -m pytest tests/test_llm_routing.py -v
+
+测试对象：LLMRouter（路由 + 降级链 + JSON 解析）、CostTracker（成本 + 缓存）。
+全部使用 mock completion function，不调真实 LLM API。
+"""
+
+import json
+
+import pytest
+
+from stockbee.llm_routing.router import LLMRouter, LLMResponse
+from stockbee.llm_routing.task_config import (
+    TaskType, TaskConfig, DEFAULT_TASK_CONFIGS, TOTAL_MONTHLY_BUDGET,
+)
+from stockbee.llm_routing.cost_tracker import CostTracker
+
+
+# =========================================================================
+# Helpers
+# =========================================================================
+
+def make_mock_fn(content: str = '{"relevant": true}', cost: float = 0.001):
+    """创建一个固定返回值的 mock completion function。"""
+    def fn(model, messages, max_tokens, temperature):
+        return {
+            "content": content,
+            "input_tokens": 50,
+            "output_tokens": 10,
+            "cost": cost,
+        }
+    return fn
+
+
+def make_failing_fn(fail_models: set[str], fallback_content: str = '{"ok": true}'):
+    """创建一个对指定模型失败的 mock。"""
+    def fn(model, messages, max_tokens, temperature):
+        if any(fm in model for fm in fail_models):
+            raise ConnectionError(f"{model} unavailable")
+        return {
+            "content": fallback_content,
+            "input_tokens": 30,
+            "output_tokens": 5,
+            "cost": 0.0005,
+        }
+    return fn
+
+
+# =========================================================================
+# TaskConfig Tests
+# =========================================================================
+
+class TestTaskConfig:
+
+    def test_5_task_types(self):
+        assert len(TaskType) == 5
+        assert len(DEFAULT_TASK_CONFIGS) == 5
+
+    def test_total_budget_15(self):
+        assert TOTAL_MONTHLY_BUDGET == 15.0
+
+    def test_all_configs_have_model(self):
+        for tt, cfg in DEFAULT_TASK_CONFIGS.items():
+            assert cfg.model, f"{tt} missing model"
+            assert cfg.max_tokens > 0
+
+    def test_g1_uses_nano(self):
+        cfg = DEFAULT_TASK_CONFIGS[TaskType.G1_FILTER]
+        assert "nano" in cfg.model
+        assert cfg.output_format == "json"
+
+    def test_macro_uses_sonnet(self):
+        cfg = DEFAULT_TASK_CONFIGS[TaskType.MACRO_ANALYSIS]
+        assert "sonnet" in cfg.model
+        assert cfg.output_format == "text"
+
+
+# =========================================================================
+# LLMRouter Tests
+# =========================================================================
+
+class TestLLMRouter:
+
+    def test_basic_route(self):
+        router = LLMRouter()
+        router.set_completion_fn(make_mock_fn('{"relevant": true}'))
+
+        resp = router.route(TaskType.G1_FILTER, "test prompt")
+        assert resp.parsed == {"relevant": True}
+        assert resp.model_used == "openai/gpt-4.1-nano"
+        assert resp.from_fallback is False
+        assert resp.cost == 0.001
+
+    def test_fallback_on_primary_failure(self):
+        router = LLMRouter(max_retries=1)
+        router.set_completion_fn(make_failing_fn({"nano"}, '{"relevant": false}'))
+
+        resp = router.route(TaskType.G1_FILTER, "test")
+        assert resp.from_fallback is True
+        assert resp.model_used == "google/gemini-2.0-flash"
+        assert resp.parsed == {"relevant": False}
+
+    def test_all_models_fail_raises(self):
+        router = LLMRouter(max_retries=1)
+        router.set_completion_fn(make_failing_fn({"nano", "gemini", "flash"}))
+
+        with pytest.raises(RuntimeError, match="LLM routing failed"):
+            router.route(TaskType.G1_FILTER, "test")
+
+    def test_text_output_format(self):
+        router = LLMRouter()
+        router.set_completion_fn(make_mock_fn("The economy is expanding."))
+
+        resp = router.route(TaskType.MACRO_ANALYSIS, "Analyze macro")
+        assert resp.content == "The economy is expanding."
+        assert resp.parsed is None  # text format, no JSON parsing
+
+    def test_json_with_code_block(self):
+        router = LLMRouter()
+        content = '```json\n{"sentiment": "positive", "urgency": 0.8}\n```'
+        router.set_completion_fn(make_mock_fn(content))
+
+        resp = router.route(TaskType.G2_CLASSIFY, "classify this")
+        assert resp.parsed == {"sentiment": "positive", "urgency": 0.8}
+
+    def test_invalid_json_returns_none_parsed(self):
+        router = LLMRouter()
+        router.set_completion_fn(make_mock_fn("not valid json at all"))
+
+        resp = router.route(TaskType.G1_FILTER, "test")
+        assert resp.parsed is None
+        assert resp.content == "not valid json at all"
+
+    def test_schema_validation_pass(self):
+        router = LLMRouter()
+        router.set_completion_fn(make_mock_fn('{"relevant": true}'))
+
+        schema = {"required": ["relevant"]}
+        resp = router.route(TaskType.G1_FILTER, "test", output_schema=schema)
+        assert resp.parsed == {"relevant": True}
+
+    def test_schema_validation_fail_still_returns(self):
+        router = LLMRouter()
+        router.set_completion_fn(make_mock_fn('{"foo": "bar"}'))
+
+        schema = {"required": ["relevant"]}
+        resp = router.route(TaskType.G1_FILTER, "test", output_schema=schema)
+        # Still returns, just logs warning
+        assert resp.parsed == {"foo": "bar"}
+
+    def test_unknown_task_type_raises(self):
+        router = LLMRouter(task_configs={TaskType.G2_CLASSIFY: DEFAULT_TASK_CONFIGS[TaskType.G2_CLASSIFY]})
+        router.set_completion_fn(make_mock_fn())
+        with pytest.raises(ValueError, match="Unknown task type"):
+            router.route(TaskType.G1_FILTER, "test")  # G1 not in configs
+
+    def test_system_prompt_passed(self):
+        received = {}
+
+        def capture_fn(model, messages, max_tokens, temperature):
+            received["messages"] = messages
+            return {"content": '{"ok": true}', "input_tokens": 10, "output_tokens": 5, "cost": 0}
+
+        router = LLMRouter()
+        router.set_completion_fn(capture_fn)
+        router.route(TaskType.G1_FILTER, "user msg", system_prompt="be brief")
+
+        assert len(received["messages"]) == 2
+        assert received["messages"][0] == {"role": "system", "content": "be brief"}
+        assert received["messages"][1] == {"role": "user", "content": "user msg"}
+
+    def test_retry_count(self):
+        call_count = 0
+
+        def counting_fn(model, messages, max_tokens, temperature):
+            nonlocal call_count
+            call_count += 1
+            raise Exception("fail")
+
+        router = LLMRouter(max_retries=3, task_configs={
+            TaskType.G1_FILTER: TaskConfig(
+                task_type=TaskType.G1_FILTER,
+                model="test-model",
+                fallback_model=None,
+                max_tokens=100,
+            )
+        })
+        router.set_completion_fn(counting_fn)
+
+        with pytest.raises(RuntimeError):
+            router.route(TaskType.G1_FILTER, "test")
+
+        assert call_count == 3  # 3 retries on primary, no fallback
+
+    def test_list_task_types(self):
+        router = LLMRouter()
+        types = router.list_task_types()
+        assert len(types) == 5
+        assert all("task_type" in t for t in types)
+
+    def test_get_config(self):
+        router = LLMRouter()
+        cfg = router.get_config(TaskType.G3_ANALYSIS)
+        assert "gpt-4.1" in cfg.model
+        assert cfg.max_tokens == 2000
+
+
+# =========================================================================
+# CostTracker Tests
+# =========================================================================
+
+class TestCostTracker:
+
+    @pytest.fixture
+    def tracker(self, tmp_path) -> CostTracker:
+        t = CostTracker(db_path=str(tmp_path / "costs.db"), monthly_budget=15.0)
+        t.initialize()
+        return t
+
+    def test_record_and_report(self, tracker):
+        tracker.record_call(TaskType.G1_FILTER, "nano", "prompt1", '{"r":true}', 50, 10, 0.001)
+        tracker.record_call(TaskType.G2_CLASSIFY, "sonnet", "prompt2", '{"s":"pos"}', 200, 50, 0.01)
+
+        report = tracker.monthly_report()
+        assert report["total_calls"] == 2
+        assert report["total_cost"] == 0.011
+        assert report["over_budget"] is False
+        assert "g1_filter" in report["breakdown"]
+        assert "g2_classify" in report["breakdown"]
+
+    def test_cache_hit(self, tracker):
+        tracker.record_call(TaskType.G1_FILTER, "nano", "same prompt", "cached response", 50, 10, 0.001)
+
+        cached = tracker.get_cached(TaskType.G1_FILTER, "same prompt")
+        assert cached == "cached response"
+
+    def test_cache_miss(self, tracker):
+        cached = tracker.get_cached(TaskType.G1_FILTER, "never seen")
+        assert cached is None
+
+    def test_cache_different_task_type(self, tracker):
+        tracker.record_call(TaskType.G1_FILTER, "nano", "prompt", "response", 50, 10, 0.001)
+
+        # Same prompt, different task type → cache miss
+        cached = tracker.get_cached(TaskType.G2_CLASSIFY, "prompt")
+        assert cached is None
+
+    def test_over_budget(self, tracker):
+        assert not tracker.is_over_budget()
+
+        # Record expensive calls
+        for i in range(20):
+            tracker.record_call(TaskType.G3_ANALYSIS, "gpt4", f"prompt{i}", "resp", 1000, 500, 1.0)
+
+        assert tracker.is_over_budget()
+        assert tracker.monthly_spent() == 20.0
+
+    def test_monthly_spent_filters_by_month(self, tracker):
+        tracker.record_call(TaskType.G1_FILTER, "nano", "p", "r", 50, 10, 5.0)
+
+        # Current month should show the cost
+        assert tracker.monthly_spent() == 5.0
+
+        # A different month should be 0
+        assert tracker.monthly_spent("2025-01") == 0.0
+
+    def test_cache_size(self, tracker):
+        assert tracker.cache_size() == 0
+
+        tracker.record_call(TaskType.G1_FILTER, "nano", "p1", "r1", 50, 10, 0.001)
+        tracker.record_call(TaskType.G2_CLASSIFY, "sonnet", "p2", "r2", 100, 20, 0.005)
+
+        assert tracker.cache_size() == 2
+
+    def test_cache_update_on_same_prompt(self, tracker):
+        tracker.record_call(TaskType.G1_FILTER, "nano", "same", "old response", 50, 10, 0.001)
+        tracker.record_call(TaskType.G1_FILTER, "nano", "same", "new response", 50, 10, 0.001)
+
+        cached = tracker.get_cached(TaskType.G1_FILTER, "same")
+        assert cached == "new response"
+        assert tracker.cache_size() == 1  # same hash, replaced
+
+    def test_shutdown_and_reinit(self, tracker):
+        tracker.record_call(TaskType.G1_FILTER, "nano", "p", "r", 50, 10, 0.5)
+        tracker.shutdown()
+
+        tracker.initialize()
+        assert tracker.monthly_spent() == 0.5
+        assert tracker.get_cached(TaskType.G1_FILTER, "p") == "r"
+
+    def test_empty_report(self, tracker):
+        report = tracker.monthly_report()
+        assert report["total_calls"] == 0
+        assert report["total_cost"] == 0
+        assert report["remaining"] == 15.0


### PR DESCRIPTION
## Summary

- **LLMRouter**: `route(task_type, prompt)` → `LLMResponse`, unified API via litellm, configurable fallback chain (primary → fallback → raise), JSON parsing with markdown code block handling, simple schema validation
- **TaskConfig**: 5 task types (G1_FILTER, G2_CLASSIFY, G3_ANALYSIS, SEC_PARSE, MACRO_ANALYSIS) with model mapping, $15/mo total budget
- **CostTracker**: SQLite call history + response cache (SHA256 prompt hash), monthly budget check, per-task-type cost breakdown
- 28 tests (all mock, no real API calls)
- 8 active specs (intent, 3 constraints, 2 decisions, contract, change)

### Key decisions
- litellm over raw OpenAI+Anthropic SDKs (one-line model switching)
- Router is task-agnostic (no G1/G2/G3 business logic — callers build prompts)

## Test plan
- [x] 28 tests pass (`pytest tests/test_llm_routing.py`)
- [x] 169 total tests pass
- [x] Routing + fallback + JSON parsing verified via mock
- [x] CostTracker: budget check, cache hit/miss, monthly report verified


🤖 Generated with [Claude Code](https://claude.com/claude-code)