### PR TITLE
feat(04-factor-storage): factor engine + Alpha158 + IC eval + integration tests (8 milestones)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 .claude/
 data/
+.DS_Store

--- a/claude-skills/dev/SKILL.md
+++ b/claude-skills/dev/SKILL.md
@@ -8,8 +8,6 @@ description: >
 
 # Dev — Milestone 级开发（context pull → 实现 → commit-sync）
 
-一个 prompt 完成一个 milestone 的完整开发周期。用户不需要手动调 prompt-gen 和 commit-sync。
-
 ## 触发词
 
 - "做 {room} m{N}"、"开发 {room} 的 {milestone 名}"
@@ -24,195 +22,187 @@ description: >
 
 ## 执行步骤
 
+### Phase 0: Repo 状态预检查
+
+1. 运行 `git status`。如果有**非本 milestone 相关**的未提交改动（上次遗留 debug、别 room 修改等），
+   问用户三选一：(a) 先 commit-sync 掉 / (b) git stash / (c) ignore（commit 时只 stage 本 milestone 文件）。
+   改动就是本 milestone 续做则直接进 Phase 1。
+
 ### Phase 1: 定位 Milestone
 
-1. 从用户输入解析 Room + Milestone：
-   - 显式指定："做 news-data m1" → room=02-news-data, milestone=m1
-   - "下一个" → 读当前 Room 的 progress.yaml，找下一个 `status: pending` 的 milestone
+2. 解析 Room + Milestone：
+   - 显式："做 news-data m1" → room=02-news-data, milestone=m1
+   - "下一个" → 读当前 Room progress.yaml 找下一个 `status: pending`
    - 语义推断："实现 Z-score 计算" → 匹配 milestone name
 
-2. 读取 Room 的 progress.yaml，确认该 milestone 状态为 `pending` 或 `in_progress`
-   - 如果 `completed` → 提示用户 "m1 已完成，要重做还是跳到下一个？"
+3. 读 Room progress.yaml，确认 milestone 为 `pending` / `in_progress`。
+   `completed` → 提示用户 "已完成，重做还是跳下一个？"
 
-3. 检查前置 milestone 是否已完成：
-   - 如果 m3 依赖 m1/m2 的产出，但 m1/m2 未完成 → 警告用户
+4. 检查前置 milestone 已完成；未完成则警告。
 
 ### Phase 2: Context Pull（内置 prompt-gen 逻辑）
 
-4. 拉取**该 milestone 需要的**上下文（不是整个 Room 的全量上下文）：
+5. 按下表拉 milestone-scoped 上下文：
 
-   **必拉**：
-   - Room 的 intent spec（理解整体目标）
-   - 该 milestone 相关的 constraint / contract specs
-   - 已完成 milestone 的产出摘要（作为前置条件）
-   - 父 Room + 全局继承的 constraints
+| 类别 | 内容 |
+|------|------|
+| 必拉 | Room intent spec、milestone 相关 constraint/contract、已完成 milestone 产出摘要、父 Room + 全局 constraints |
+| 选拉 | Tech Design 相关段、兄弟 Room contract specs（跨 Room 依赖）、已有代码接口签名（本 milestone 实现 interface 时） |
+| 不拉 | 未来 milestone 详细设计、不相关 Room specs |
 
-   **选拉**（根据 milestone 内容智能判断）：
-   - Tech Design 中相关段落
-   - 兄弟 Room 的 contract specs（如果有跨 Room 依赖）
-   - 已有代码的接口签名（如果本 milestone 要实现某个 interface）
-
-   **不拉**：
-   - 未来 milestone 的详细设计
-   - 不相关 Room 的 specs
-
-5. 组装 milestone-scoped prompt（内部使用，不展示给用户）
+6. 组装 milestone-scoped prompt（内部用，不展示）。
 
 ### Phase 2.5: 多方案规划 + 双重 Review（编码前必经）
 
-**不直接写代码。** 先生成方案，review 通过后再动手。
+7. **生成实施方案**：
 
-6. **生成实施方案**：
-
-   **简单 milestone 走快速路径（主会话直接生成，不启动 sub-agent）**：
-   当 milestone 同时满足以下条件时，主会话直接生成**单方案**，跳过多方案对比和 sub-agent：
+   **快速路径**（主会话直接生成 1 个方案，不启 sub-agent）——同时满足：
+   - 有可参考的同类已完成 milestone（模式明确）← 主导条件
    - 无 `complexity_flags`
-   - `estimated_lines ≤ 120`
-   - 有可参考的同类已完成 milestone（模式明确）
 
-   快速路径产出：
+   `estimated_lines` 不再是硬门槛——模式明确即使 280 行也走快速路径。
+
+   **完整路径**（启 planning sub-agent，产出 Plan A + Plan B）——有 `complexity_flags`、无先例模式、或开发者显式要求。
+
+   **Plan 模板（两路径共用）**：
    ```
-   Plan: {名称}
-     步骤: {numbered sub-tasks}
-     每步: 内容 / 预估行数 / 测试点
-     Corner cases: {简要列出}
-     总计: ~{N} 行 code + ~{N} 行 test
-   ```
-   → 直接进入 step 8 展示给开发者确认。
-
-   **复杂 milestone 走完整路径（启动 planning sub-agent）**：
-   当 milestone 有 `complexity_flags`、`estimated_lines > 120`、或无先例模式时，
-   启动 planning sub-agent（不写代码），产出两套方案：
-
-   ```
-   Plan A: {名称} (如 Bottom-Up)
-     思路: {1-2 句}
-     步骤: {numbered sub-tasks with dependencies}
-     每步: 内容 / 预估行数 / 测试点
-     Corner cases 识别:
-       - {edge case 1}: 如何处理
-       - {edge case 2}: 如何处理
-     总计: ~{N} 行 code + ~{N} 行 test
-     优点: ...
-     缺点: ...
-
-   Plan B: {名称} (如 Top-Down Vertical Slice)
-     ...
+   Plan {名称}:
+     思路: {1-2 句}（完整路径必填，快速路径可省）
+     步骤: numbered sub-tasks，每步含内容 / 预估行数 / 测试点
+     Corner cases（必覆盖以下类别，缺项要说明为什么不适用）:
+       - 空输入: tickers=[], factor_names=[], empty DataFrame
+       - 类型边界: datetime.date vs Timestamp, scalar vs Series
+       - 资源缺失: setter 未注入, 文件不存在, 字段不存在
+       - 名字冲突 / 重复 / shadow
+       - 错误传播: 下游 raise 时的处理方式
+     优缺点: {至少各 1 条}
    ```
 
-   方案必须覆盖：
-   - **正常路径**: 功能实现步骤
-   - **Corner cases**: 空输入、异常数据、超时、并发、边界值
-   - **Error handling**: 哪些错误需要 retry、fallback、还是直接失败
-   - **测试策略**: 每个 sub-task 测什么、怎么 mock
+   有 `complexity_flags` 时，在方案里重点分析该类复杂度。
+   有 `open_questions` 时，必须在方案里列出并标记需开发者决定。
 
-   如果 milestone 有 `complexity_flags`（来自 plan-milestones），重点分析该类复杂度。
-   如果有 `open_questions`，必须在方案中列出并标记需要开发者决定。
+8. **AI 自身 Review**（仅完整路径）：对 Plan A/B 做对比 review，给出推荐并说明：
+   - 哪个更适合当前代码量/复杂度
+   - corner cases 两套方案处理差异
+   - 需锁定的不可逆设计决策
+   - 是否合并/调整步骤
 
-7. **AI 自身 Review**（仅完整路径，快速路径跳过此步）：
-
-   对两套方案做对比 review，给出推荐并说明理由：
-   - 哪个方案更适合当前代码量/复杂度
-   - 哪些 corner cases 两套方案处理方式不同
-   - 是否有需要锁定的设计决策（不可轻松逆转的）
-   - 是否建议合并/调整步骤
-
-8. **展示方案 + Review 结果，等待开发者确认**：
+9. **展示方案 + Review + 等待确认**：
 
    ```
    📋 Milestone 实施方案: {room} {milestone}
-   ────────────────────────────────
+   Plan A: {名称} [步骤 + corner cases + 优缺点]
+   Plan B: {名称} [同上]  # 仅完整路径
 
-   Plan A: {名称}
-     [步骤列表 + corner cases]
-
-   Plan B: {名称}
-     [步骤列表 + corner cases]
-
-   🔍 AI Review:
-     推荐 Plan {X}，理由: ...
-     ⚠️ 需要你决定:
-       - Q1: {设计问题}
-       - Q2: {设计问题}
-
-   选择方案？(A/B/调整后再看)
+   🔍 AI Review: 推荐 Plan {X}，理由: ...
+   ⚠️ Open Questions:
+     - Q1: {问题}
+     - Q2: {问题}
+   选择方案？(A/B/调整/回答问题)
    ```
 
-   开发者可以：
-   - 选 A 或 B
-   - 要求调整（"A 的步骤但用 B 的 error handling 策略"）
-   - 回答设计问题
-   - 要求 sub-agent 深入分析某个问题
+   开发者可：选 A/B、要求调整、回答 OQ、要 sub-agent 深入分析、
+   或对 OQ 说"你给建议" → AI 给 tradeoff 但**不替开发者拍板**。
 
-   **循环直到开发者确认方案。确认前不写任何代码。**
+   **Open Questions 全部锁定、方案确认后才进 Phase 3。未锁定不许"先写着看"**。
 
-### Phase 3: 实现（按确认的方案执行）
+### Phase 3: 实现
 
-9. 按开发者选定的方案逐步实现：
-   - 严格按方案的 sub-task 顺序执行
-   - 遵循已有的代码模式（如 stock_data 的 Provider 模式）
-   - 只做该 milestone 范围内的事
-   - 写方案中列出的测试（包括 corner case 测试）
+10. **Smoke-test real interfaces**（写详细测试前必做）——用 2 秒脚本验证假设：
 
-10. 运行测试验证：
-   - 新测试必须全部通过
-   - 已有测试不能 break
+    ```bash
+    python -c "
+    from stockbee.factor_data import Alpha158
+    a = Alpha158()
+    print(a.list_factor_names()[:20])
+    print('KMID' in a, a.max_lookback('MA5'))
+    "
+    ```
+    确认：导入路径、公开 API 实际返回类型/形状/名字、依赖对象能构造。
+
+11. 按选定方案逐步实现：严格按 sub-task 顺序、遵循已有代码模式、只做本 milestone 范围、写方案中列出的测试（含 corner case）。
+
+12. 运行测试：新测试全过 + 已有测试不 break。
+
+### Phase 3.5: Post-Implementation Code Review（非 trivial milestone 必经）
+
+13. **跳过条件**（任一满足即可跳过）：
+    - milestone < 50 行纯 glue 代码
+    - 纯重命名 / 搬运，无新逻辑
+    - 开发者显式说 "跳过 review，赶时间"
+
+14. 否则并行启动两个 reviewer：
+    - **Reviewer A: Codex CLI**（codex:rescue 或 codex review）——独立视角、查真实 API、找类型不匹配 / 签名错用 / 契约违反
+    - **Reviewer B: Plan sub-agent**——纯代码角度、无 plan bias、找 edge case / 空输入 / 并发 / 资源生命周期
+
+    每个 reviewer 的 prompt 必含：
+    - 新增/修改文件的绝对路径
+    - 依赖模块的接口签名
+    - 关键决策背景
+    - 要求按 severity（CRITICAL/HIGH/MEDIUM/LOW）分级 + 具体行号 + 修复建议
+
+15. **汇总 findings → 过滤 → 修复**：
+    - CRITICAL + HIGH：必修，补测试验证
+    - MEDIUM：默认修，除非开发者明说 defer
+    - LOW：展示给开发者逐条决定 take/defer
+
+    ```
+    🔍 Code Review 汇总
+      Codex: 2 CRITICAL / 1 HIGH / 3 MEDIUM
+      Subagent: 0 CRITICAL / 2 HIGH / 4 MEDIUM / 3 LOW
+      必修: ✴️ [C1] date vs Timestamp 类型 mismatch (line 145) → normalize helper
+            ✴️ [C2] 空 ohlcv 未短路 crash Evaluator (line 148) → empty guard
+            ⚠️ [H1] IC 前向收益截尾 (line 264) → 多取 shift 天
+      LOW（要 defer？）: · [L1] list_factors schema 不统一 → TypedDict / ...
+    修复并重跑测试？(y/n/选择性)
+    ```
+
+16. 修复后重跑全量测试，必须全绿才进 Phase 4。
 
 ### Phase 4: Commit-Sync（内置 commit-sync 逻辑）
 
-11. 分析本次变更，生成 commit：
-    - commit message 格式：`[room-id] type: milestone 描述`
-    - git add 只 stage 本 milestone 相关的文件
-    - git commit + git push
+17. 生成 commit：格式 `[room-id] type: milestone 描述`；只 stage 本 milestone 相关文件（Phase 0 发现的无关改动不 stage）；commit + push。
 
-12. 更新 Room 元数据（**只更新该 milestone 的部分**）：
-    - progress.yaml: 该 milestone → `completed`，追加 commit hash
+18. 更新 Room 元数据（**只更新该 milestone 部分**）：
+    - progress.yaml: milestone → `completed`、追加 commit hash
     - spec.md: 增量更新（不重写整个文件）
     - 如果是最后一个 milestone → 更新 room.yaml lifecycle、_tree.yaml status
 
-13. **不做**整个 Room 的 spec 大重写（那是全部完成后的事）
+19. **禁止**整个 Room 的 spec 大重写（那是全部完成后的事）。
 
 ### Phase 5: 暂停等待
 
-14. 展示完成摘要：
-```
-✅ [03-macro-data] m1-Parquet时间序列 completed
-   commit: abc1234
-   files: 2 added, 0 modified
-   tests: 8 new, 141 total (all pass)
-   progress: 03-macro-data 20% (1/5 milestones)
+20. 展示完成摘要：
+    ```
+    ✅ [03-macro-data] m1-Parquet时间序列 completed
+       commit: abc1234  files: 2 added, 0 modified  tests: 8 new / 141 all pass
+       review: 2 CRITICAL + 1 HIGH fixed, 3 LOW deferred
+       progress: 03-macro-data 20% (1/5)
+    下一个 milestone: m2-FRED指标采集
+    说 "下一个" 继续，或给其他指令。
+    ```
 
-下一个 milestone: m2-FRED指标采集
-说 "下一个" 继续，或给其他指令。
-```
-
-15. **等待用户决定**，不自动继续下一个 milestone
+21. **等用户决定，不自动续做**。
 
 ## 特殊情况
 
 ### "下一个" 逻辑
 
-- 在同一个 Room 内：找下一个 `pending` milestone
+- 同一 Room 内：找下一个 `pending` milestone
 - 当前 Room 全部完成：提示 "Room X 已全部完成，要做哪个 Room？"
 - 无上下文（新对话）：提示 "要做哪个 Room 的哪个 milestone？"
 
 ### 一个 milestone 太大
 
-如果 Phase 2.5 的方案预估 >200 行代码，可以：
-- 在方案中拆成多个 sub-task（每个 sub-task 可以独立 commit）
-- milestone 状态只在全部 sub-task 完成后才标记 completed
-- 方案的 sub-task 粒度应该在 Phase 2.5 就和开发者确认好
-
-### milestone 之间有代码依赖
-
-- m2 的代码 import 了 m1 的产出 → Phase 2 context pull 会自动包含 m1 的代码
-- 不需要用户手动说明依赖关系
+方案预估 >200 行时：拆成多个 sub-task（每个可独立 commit）。
+milestone 状态**只在全部 sub-task 完成后**才标记 `completed`。
+sub-task 粒度在 Phase 2.5 就和开发者确认好。
 
 ## 和其他 skill 的关系
 
-| Skill | 何时用 | 和 dev 的关系 |
-|-------|-------|--------------|
-| prompt-gen | 想看完整 Room prompt 但不开发 | dev 内置了 milestone 级的 prompt-gen |
-| commit-sync | 手动修改代码后想提交 | dev 内置了 commit-sync |
-| room-status | 看项目全局进度 | dev 完成后可以调 room-status 查看 |
+| Skill | 何时用 | 关系 |
+|-------|-------|------|
+| prompt-gen | 想看完整 Room prompt 但不开发 | dev 内置 milestone 级 prompt-gen |
+| commit-sync | 手动修改代码后想提交 | dev 内置 commit-sync |
+| room-status | 看项目全局进度 | dev 完成后可调 room-status 查看 |
 | room | 创建/修改 Room 结构 | dev 之前先用 room 创建好 Room 和 milestones |

--- a/claude-skills/plan-milestones/SKILL.md
+++ b/claude-skills/plan-milestones/SKILL.md
@@ -131,7 +131,8 @@ Feature Room 的 milestones 最初由 room-init 从 PRD 机械生成，粒度不
 
 ### Phase 2.5: 多方案对比（关键 milestone）
 
-对于带有 `complexity_flags` 的 milestone，必须生成 **至少 2 个实施方案** 供开发者选择。
+对于带有 `complexity_flags` 的 milestone，必须生成 **至少 2 个实施方案** 供开发者选择并 **思考是否应该拆成更多milestone**。
+
 
 方案对比维度：
 

--- a/claude-skills/plan-milestones/SKILL.md
+++ b/claude-skills/plan-milestones/SKILL.md
@@ -267,7 +267,7 @@ Tech Design: §2.3 新闻数据处理管道
 | **发现 Tech Design 和 PRD 不一致** | "Tech Design 说 19 个指标，但 FRED 只能映射 17 个，怎么处理？" |
 | **字段/功能有消费者吗** | "impact_pct 现在没有下游模块消费，先加还是 defer？" |
 | **实施方案有多种路径** | 必须展示 ≥2 个方案 + 推荐理由，开发者最终选择 |
-| **设计决策的可逆性不同** | 用 sub-agent 分析：现在做 vs 后续改的工作量/风险，哪些必须锁定 |
+| **设计决策的可逆性不同** | 用 sub-agent 分析：现在做 vs 后续改的工作量/风险，哪些必须锁定，**哪些优化可以 defer 到 phase 2**。defer 的条目先记入 spec.md 的 Deferred 章节（planning loop 内部，无外部副作用）；Phase 4 用户最终确认后，再由开发者决定是否人工提 github issue——**禁止在 Phase 3 草稿阶段直接 `gh issue create`**，避免每次迭代产生重复/失效 ticket |
 
 **不问的情况**：
 - 文件命名、目录结构 → 参考已完成 Room 的模式

--- a/config/factors-alpha158.yaml
+++ b/config/factors-alpha158.yaml
@@ -1,0 +1,57 @@
+# Alpha158 因子定义 — qlib 标准 158 因子集
+# 来源：qlib/contrib/data/handler.py Alpha158
+# 引擎对接：src/stockbee/factor_data/alpha158.py
+#
+# 分布：9 KBAR + 4 price + 29 rolling operators × 5 windows = 158
+# windows: [5, 10, 20, 30, 60]
+
+groups:
+  kbar:
+    - { name: KMID,  expr: "($close-$open)/$open" }
+    - { name: KLEN,  expr: "($high-$low)/$open" }
+    - { name: KMID2, expr: "($close-$open)/($high-$low+1e-12)" }
+    - { name: KUP,   expr: "($high-MAX($open,$close))/$open" }
+    - { name: KUP2,  expr: "($high-MAX($open,$close))/($high-$low+1e-12)" }
+    - { name: KLOW,  expr: "(MIN($open,$close)-$low)/$open" }
+    - { name: KLOW2, expr: "(MIN($open,$close)-$low)/($high-$low+1e-12)" }
+    - { name: KSFT,  expr: "(2*$close-$high-$low)/$open" }
+    - { name: KSFT2, expr: "(2*$close-$high-$low)/($high-$low+1e-12)" }
+
+  price:
+    - { name: OPEN0, expr: "$open/$close" }
+    - { name: HIGH0, expr: "$high/$close" }
+    - { name: LOW0,  expr: "$low/$close" }
+    - { name: VWAP0, expr: "$vwap/$close" }
+
+  rolling:
+    windows: [5, 10, 20, 30, 60]
+    operators:
+      - { name_template: "ROC{w}",  expr_template: "REF($close,{w})/$close" }
+      - { name_template: "MA{w}",   expr_template: "MEAN($close,{w})/$close" }
+      - { name_template: "STD{w}",  expr_template: "STD($close,{w})/$close" }
+      - { name_template: "BETA{w}", expr_template: "SLOPE($close,{w})/$close" }
+      - { name_template: "RSQR{w}", expr_template: "RSQUARE($close,{w})" }
+      - { name_template: "RESI{w}", expr_template: "RESI($close,{w})/$close" }
+      - { name_template: "MAX{w}",  expr_template: "MAX($high,{w})/$close" }
+      - { name_template: "MIN{w}",  expr_template: "MIN($low,{w})/$close" }
+      - { name_template: "QTLU{w}", expr_template: "TS_QUANTILE($close,{w},0.8)/$close" }
+      - { name_template: "QTLD{w}", expr_template: "TS_QUANTILE($close,{w},0.2)/$close" }
+      - { name_template: "RANK{w}", expr_template: "TS_RANK($close,{w})" }
+      - { name_template: "RSV{w}",  expr_template: "($close-MIN($low,{w}))/(MAX($high,{w})-MIN($low,{w})+1e-12)" }
+      - { name_template: "IMAX{w}", expr_template: "IDXMAX($high,{w})/{w}" }
+      - { name_template: "IMIN{w}", expr_template: "IDXMIN($low,{w})/{w}" }
+      - { name_template: "IMXD{w}", expr_template: "(IDXMAX($high,{w})-IDXMIN($low,{w}))/{w}" }
+      - { name_template: "CORR{w}", expr_template: "CORR($close,LOG($volume+1),{w})" }
+      - { name_template: "CORD{w}", expr_template: "CORR($close/REF($close,1),LOG($volume/REF($volume,1)+1),{w})" }
+      - { name_template: "CNTP{w}", expr_template: "MEAN($close>REF($close,1),{w})" }
+      - { name_template: "CNTN{w}", expr_template: "MEAN($close<REF($close,1),{w})" }
+      - { name_template: "CNTD{w}", expr_template: "MEAN($close>REF($close,1),{w})-MEAN($close<REF($close,1),{w})" }
+      - { name_template: "SUMP{w}", expr_template: "SUM(MAX($close-REF($close,1),0),{w})/(SUM(ABS($close-REF($close,1)),{w})+1e-12)" }
+      - { name_template: "SUMN{w}", expr_template: "SUM(MAX(REF($close,1)-$close,0),{w})/(SUM(ABS($close-REF($close,1)),{w})+1e-12)" }
+      - { name_template: "SUMD{w}", expr_template: "(SUM(MAX($close-REF($close,1),0),{w})-SUM(MAX(REF($close,1)-$close,0),{w}))/(SUM(ABS($close-REF($close,1)),{w})+1e-12)" }
+      - { name_template: "VMA{w}",  expr_template: "MEAN($volume,{w})/($volume+1e-12)" }
+      - { name_template: "VSTD{w}", expr_template: "STD($volume,{w})/($volume+1e-12)" }
+      - { name_template: "WVMA{w}", expr_template: "STD(ABS($close/REF($close,1)-1)*$volume,{w})/(MEAN(ABS($close/REF($close,1)-1)*$volume,{w})+1e-12)" }
+      - { name_template: "VSUMP{w}", expr_template: "SUM(MAX($volume-REF($volume,1),0),{w})/(SUM(ABS($volume-REF($volume,1)),{w})+1e-12)" }
+      - { name_template: "VSUMN{w}", expr_template: "SUM(MAX(REF($volume,1)-$volume,0),{w})/(SUM(ABS($volume-REF($volume,1)),{w})+1e-12)" }
+      - { name_template: "VSUMD{w}", expr_template: "(SUM(MAX($volume-REF($volume,1),0),{w})-SUM(MAX(REF($volume,1)-$volume,0),{w}))/(SUM(ABS($volume-REF($volume,1)),{w})+1e-12)" }

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
@@ -1,20 +1,77 @@
 progress:
   completion: 0.0
   milestones:
-    - id: "m1-表达式引擎"
-      name: "表达式引擎"
+    - id: "m1-expression-engine-core"
+      name: "表达式引擎核心"
       status: pending
       completed_at: null
-    - id: "m2-预计算-Parquet-存储"
-      name: "预计算 Parquet 存储"
+      estimated_files: ["src/stockbee/factor_data/expression_engine.py"]
+      estimated_lines: 220
+      depends_on: []
+      complexity_flags: [first_of_kind]
+      description: |
+        Tokenizer (regex) → Parser (递归下降) → Evaluator (MultiIndex DF)。
+        变量映射: CLOSE→adj_close, OPEN→open, HIGH→high, LOW→low, VOLUME→volume, VWAP→典型价。
+        基础函数 (16): REF/DELAY, MA/MEAN, STD, SUM, MAX, MIN, DELTA, ABS, LOG, SIGN。
+        MAX/MIN 重载: 整数≥2 → rolling, 否则 → element-wise。
+
+    - id: "m2-advanced-functions"
+      name: "高级表达式函数"
       status: pending
       completed_at: null
-    - id: "m3-因子读取-API"
-      name: "因子读取 API"
+      estimated_files: ["src/stockbee/factor_data/expression_engine.py"]
+      estimated_lines: 200
+      depends_on: [m1-expression-engine-core]
+      complexity_flags: [first_of_kind]
+      description: |
+        追加 10 个函数: EMA, SLOPE, RSQUARE, RESI, CORR, RANK, IF, QUANTILE, IDXMAX, IDXMIN。
+        SLOPE/RSQUARE/RESI 共享 rolling OLS 计算。
+
+    - id: "m3-alpha158-full"
+      name: "Alpha158 全量因子定义"
       status: pending
       completed_at: null
-    - id: "m4-测试"
-      name: "测试"
+      estimated_files: ["src/stockbee/factor_data/alpha158.py", "config/factors-alpha158.yaml"]
+      estimated_lines: 350
+      depends_on: [m1-expression-engine-core, m2-advanced-functions]
+      complexity_flags: []
+      description: |
+        alpha158.py: YAML 加载, factor registry, max_lookback()。
+        factors-alpha158.yaml: 全部 158 因子 (9 KBAR + 27组×5窗口)。
+
+    - id: "m4-parquet-factor-store"
+      name: "预计算因子 Parquet 存储"
       status: pending
       completed_at: null
+      estimated_files: ["src/stockbee/factor_data/parquet_factor.py"]
+      estimated_lines: 150
+      depends_on: []
+      complexity_flags: []
+      description: |
+        参照 parquet_macro.py。存储: data/factors/{group}.parquet。
+        接口: read_factors, write_factors (merge-write), list_precomputed_factors。
+
+    - id: "m5-local-provider"
+      name: "LocalFactorProvider + IC 评估"
+      status: pending
+      completed_at: null
+      estimated_files: ["src/stockbee/factor_data/local_provider.py", "src/stockbee/factor_data/ic_evaluator.py"]
+      estimated_lines: 200
+      depends_on: [m1-expression-engine-core, m2-advanced-functions, m3-alpha158-full, m4-parquet-factor-store]
+      complexity_flags: []
+      description: |
+        实现 FactorProvider 接口。MarketDataProvider setter 注入。
+        get_factors 路由 expression/precomputed。IC/ICIR 仅离线评估。
+
+    - id: "m6-tests"
+      name: "测试 + 模块导出"
+      status: pending
+      completed_at: null
+      estimated_files: ["tests/test_factor_data.py", "src/stockbee/factor_data/__init__.py"]
+      estimated_lines: 350
+      depends_on: [m1-expression-engine-core, m2-advanced-functions, m3-alpha158-full, m4-parquet-factor-store, m5-local-provider]
+      complexity_flags: []
+      description: |
+        5 个 TestClass (~30 tests): ExpressionEngine, Alpha158Config,
+        ParquetFactorStore, LocalFactorProvider, ICEvaluator。__init__.py 导出。
   commits: []

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
@@ -1,5 +1,5 @@
 progress:
-  completion: 0.625   # 5/8 milestones done
+  completion: 0.75   # 6/8 milestones done
   milestones:
     - id: "m1a-tokenizer-parser"
       name: "Tokenizer + Parser + AST"
@@ -116,18 +116,25 @@ progress:
 
     - id: "m5-ic-evaluator"
       name: "IC / ICIR 离线评估"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-12"
+      actual_files:
+        - "src/stockbee/factor_data/ic_evaluator.py"
+        - "src/stockbee/factor_data/__init__.py"
+        - "tests/test_factor_data.py"
+      actual_lines: 248   # ic_evaluator ~125 + __init__ +3 + tests ~120 (19 cases)
       estimated_files: ["src/stockbee/factor_data/ic_evaluator.py", "tests/test_factor_data.py"]
       estimated_lines: 200
       depends_on: []
       complexity_flags: []
       description: |
         纯数值模块，无 provider 依赖，可与 m1-m4 并行开发。
-        接口：compute(factor_df, prices_df, shift=1) → ic_mean, ic_std, icir。
-        shift=1 在本层做（factor at t vs return at t+1），禁止让 caller shift。
-        rolling IC（默认 window=252），IC 序列 NaN 处理：少于 20 个有效值时返回 NaN。
-        测试：合成 golden data（factor = true_return * 0.8 + noise），断言 |ic_mean - 0.8| < 0.05。
+        接口：compute(factor_df, prices_df, shift=1, window=252) → dict(ic_mean, ic_std, icir)。
+        shift 在本层做（factor at t vs return at t+shift），禁止让 caller shift。
+        逐日截面 Spearman rank IC，纯 pandas rank().corr()（零 scipy 依赖）。
+        NaN gate：有效 IC < 20 → 全 NaN。ICIR = mean/std(ddof=1)，std=0 → NaN。
+        输入校验：shift>=1, window>=1, duplicate index, 单列 factor, adj_close 存在。
+        19 个测试 case（含 golden ±1.0、noisy、边界 19/20、corner case），203 全量 pass。
 
     - id: "m6-local-provider"
       name: "LocalFactorProvider + 模块导出"
@@ -180,3 +187,12 @@ progress:
         - "change-2026-04-12-m4-parquet-store (created)"
       milestones_affected:
         - "m4-parquet-factor-store (→ completed)"
+    - hash: "461ebfc"
+      date: "2026-04-12"
+      message: "[04-factor-storage] feat: m5 IC/ICIR evaluator — 纯数值离线评估 + 19 tests"
+      files_changed: 3
+      specs_affected:
+        - "intent-04-factor-storage-001 (anchor updated)"
+        - "change-2026-04-12-m5-ic-evaluator (created)"
+      milestones_affected:
+        - "m5-ic-evaluator (→ completed)"

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
@@ -70,15 +70,18 @@ progress:
       name: "Alpha158 全量因子定义"
       status: pending
       completed_at: null
-      estimated_files: ["src/stockbee/factor_data/alpha158.py", "config/factors-alpha158.yaml", "tests/test_factor_data.py"]
-      estimated_lines: 350
+      estimated_files: ["src/stockbee/factor_data/alpha158.py", "src/stockbee/factor_data/expression_engine.py", "config/factors-alpha158.yaml", "tests/test_factor_data.py"]
+      estimated_lines: 940
       depends_on: [m1a-tokenizer-parser, m2-advanced-functions]
       complexity_flags: []
       description: |
-        alpha158.py：YAML 加载，factor registry，max_lookback()。
-        max_lookback()：调用 AST.walk() 沿嵌套链相加（MA(REF(c,5),20) → 25 非 20）。
-        config/factors-alpha158.yaml：全部 158 因子（9 KBAR + 27组×5窗口）。
-        测试：最小 YAML 片段测 loader；嵌套表达式验证 max_lookback 相加语义。
+        expression_engine.py：新增 TS_RANK/TS_QUANTILE 时序滚动函数（与横截面 RANK/QUANTILE 共存）。
+        alpha158.py：YAML 加载，factor registry，AST cache，max_lookback()。
+        max_lookback()：直接调用 AST.lookback()（嵌套相加，MA(REF(c,5),20) → 25）。
+        config/factors-alpha158.yaml：全部 158 因子（9 KBAR + 4 price + 5 VMA + 28算子×5窗口）。
+        全量 YAML 定义（含长表达式），不混合 Python factory。
+        测试：全部 158 parse + lookback 参数化断言 + 全量 evaluate smoke + 数值金标。
+        新增 decisions：NaN 比较语义（保持 pandas 默认=qlib 兼容）、TS ties/interpolation、因子别名表。
 
     - id: "m4-parquet-factor-store"
       name: "预计算因子 Parquet 存储"

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
@@ -1,5 +1,5 @@
 progress:
-  completion: 0.25   # 2/8 milestones done
+  completion: 0.375   # 3/8 milestones done
   milestones:
     - id: "m1a-tokenizer-parser"
       name: "Tokenizer + Parser + AST"
@@ -43,17 +43,28 @@ progress:
 
     - id: "m2-advanced-functions"
       name: "高级表达式函数"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-11"
+      actual_files:
+        - "src/stockbee/factor_data/expression_engine.py"
+        - "tests/test_factor_data.py"
+        - "meta/00-project-room/02-data-architecture/04-factor-storage/spec.md"
+      actual_lines: 687   # engine +244 / tests +443
       estimated_files: ["src/stockbee/factor_data/expression_engine.py", "tests/test_factor_data.py"]
       estimated_lines: 300
       depends_on: [m1b-evaluator-basic-funcs]
       complexity_flags: [first_of_kind]
       description: |
         追加 10 个函数：EMA, SLOPE, RSQUARE, RESI, CORR, RANK, IF, QUANTILE, IDXMAX, IDXMIN。
-        SLOPE/RSQUARE/RESI 共享 rolling OLS（用 rolling sum 代数展开，非 apply(lstsq)）。
-        RANK/QUANTILE 默认横截面（cross-section at each date），非时序。
-        测试：≥2 tickers 验证横截面 RANK；rolling OLS 用 numpy 线性数据验证斜率精度。
+        SLOPE/RSQUARE/RESI 共享 _rolling_ols kernel：per-ticker cumcount() 做全局行号 k，
+        Σxy = Σ(k·y) − (k_t−n+1)·Σy 代数展开，避免 rolling.apply(lstsq) 慢路径。
+        RSQUARE 闭式 r² = slope²·SSxx/SStot。RESI = last-point residual（qlib 约定）。
+        RANK/QUANTILE 横截面（groupby level='date'），QUANTILE 广播回 (date,ticker)。
+        IF 支持 6 种 (cond, a, b) 标量/Series 组合。CORR via concat + apply + droplevel。
+        FunctionSpec 加 min_window 字段，EMA/SLOPE/RSQUARE/RESI/CORR 设为 2（n=1 数学退化）。
+        EMA 决策：pandas ewm(adjust=False) IIR 递推，与 qlib FIR 在前 ~2n 行有差异（见 spec.md）。
+        Evaluator dispatch 零改动——m1a 预留的 cross_section/rolling_arg_index 元数据完全够用。
+        43 个 m2 test case，全量 122 pass。5 commit 按函数分组落盘。
 
     - id: "m3-alpha158-full"
       name: "Alpha158 全量因子定义"

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
@@ -138,8 +138,9 @@ progress:
 
     - id: "m6-local-provider"
       name: "LocalFactorProvider + 模块导出"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-12"
+      actual_lines: 470  # local_provider ~230 + __init__ +3 + tests ~237 (20 cases)
       estimated_files: ["src/stockbee/factor_data/local_provider.py", "src/stockbee/factor_data/__init__.py", "tests/test_factor_data.py"]
       estimated_lines: 280
       depends_on: [m1b-evaluator-basic-funcs, m2-advanced-functions, m3-alpha158-full, m4-parquet-factor-store, m5-ic-evaluator]
@@ -196,3 +197,12 @@ progress:
         - "change-2026-04-12-m5-ic-evaluator (created)"
       milestones_affected:
         - "m5-ic-evaluator (→ completed)"
+    - hash: "15af978"
+      date: "2026-04-12"
+      message: "[04-factor-storage] feat: m6 LocalFactorProvider — 因子路由 + IC 报告 + 20 tests"
+      files_changed: 6
+      specs_affected:
+        - "intent-04-factor-storage-001 (anchor updated)"
+        - "change-2026-04-12-m6-local-provider (created)"
+      milestones_affected:
+        - "m6-local-provider (→ completed)"

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
@@ -1,5 +1,5 @@
 progress:
-  completion: 0.375   # 3/8 milestones done
+  completion: 0.500   # 4/8 milestones done
   milestones:
     - id: "m1a-tokenizer-parser"
       name: "Tokenizer + Parser + AST"
@@ -68,8 +68,16 @@ progress:
 
     - id: "m3-alpha158-full"
       name: "Alpha158 全量因子定义"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-11"
+      actual_files:
+        - "src/stockbee/factor_data/expression_engine.py"
+        - "src/stockbee/factor_data/alpha158.py"
+        - "src/stockbee/factor_data/__init__.py"
+        - "config/factors-alpha158.yaml"
+        - "tests/test_factor_data.py"
+        - "meta/00-project-room/02-data-architecture/04-factor-storage/spec.md"
+      actual_lines: 516   # engine +51 / alpha158 85 / yaml 57 / __init__ +3 / tests +320
       estimated_files: ["src/stockbee/factor_data/alpha158.py", "src/stockbee/factor_data/expression_engine.py", "config/factors-alpha158.yaml", "tests/test_factor_data.py"]
       estimated_lines: 940
       depends_on: [m1a-tokenizer-parser, m2-advanced-functions]

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
@@ -1,5 +1,5 @@
 progress:
-  completion: 0.500   # 4/8 milestones done
+  completion: 0.625   # 5/8 milestones done
   milestones:
     - id: "m1a-tokenizer-parser"
       name: "Tokenizer + Parser + AST"
@@ -93,8 +93,13 @@ progress:
 
     - id: "m4-parquet-factor-store"
       name: "预计算因子 Parquet 存储"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-11"
+      actual_files:
+        - "src/stockbee/factor_data/parquet_factor.py"
+        - "src/stockbee/factor_data/__init__.py"
+        - "tests/test_factor_data.py"
+      actual_lines: 315   # parquet_factor ~150 + __init__ +3 + tests +130 (13 cases)
       estimated_files: ["src/stockbee/factor_data/parquet_factor.py", "tests/test_factor_data.py"]
       estimated_lines: 250
       depends_on: []
@@ -104,7 +109,10 @@ progress:
         group 粒度：按数据来源分组（e.g. fundamental, sentiment, ml_score），每组一文件。
         接口：read_factors(group, tickers, start, end)，write_factors(group, df)（merge-write
         按 (date, ticker) 主键去重），list_precomputed_factors() → list[str]。
-        测试：tmp Parquet 路径，写入后读取对比，merge 去重验证。
+        merge-write 用 combine_first+update（非 concat+duplicated），保留旧列值。
+        新增输入校验：MultiIndex (date, ticker) 验证 + group 名路径穿越防护。
+        tickers=None/[] 均返回全部 tickers；start/end=None 不过滤。
+        测试：13 个 case，180 全量 pass。
 
     - id: "m5-ic-evaluator"
       name: "IC / ICIR 离线评估"
@@ -162,4 +170,13 @@ progress:
         10. test_column_order_preserved：factor_names=["B","A"] 返回 [B,A] 列顺序
         11. test_open_zero_div_nan：$open=0 → inf → 因子值 NaN 不崩
         12. test_empty_date_range：无数据日期 → 返回空 MultiIndex DataFrame，不 crash
-  commits: []
+  commits:
+    - hash: "46c5636"
+      date: "2026-04-12"
+      message: "[04-factor-storage] feat: m4 ParquetFactorStore — 预计算因子存储 + 17 tests"
+      files_changed: 5
+      specs_affected:
+        - "intent-04-factor-storage-001 (draft → active)"
+        - "change-2026-04-12-m4-parquet-store (created)"
+      milestones_affected:
+        - "m4-parquet-factor-store (→ completed)"

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
@@ -1,5 +1,5 @@
 progress:
-  completion: 0.75   # 6/8 milestones done
+  completion: 1.0   # 8/8 milestones done (m1a, m1b, m2, m3, m4, m5, m6, m7)
   milestones:
     - id: "m1a-tokenizer-parser"
       name: "Tokenizer + Parser + AST"
@@ -157,27 +157,31 @@ progress:
 
     - id: "m7-integration-tests"
       name: "集成层 edge case 测试"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-13"
+      actual_files:
+        - "tests/test_factor_integration.py"
+      actual_lines: 512   # helpers + 18 cases 分 7 组
       estimated_files: ["tests/test_factor_integration.py"]
       estimated_lines: 250
       depends_on: [m6-local-provider]
       complexity_flags: []
       description: |
-        专用集成测试文件，覆盖单元测试无法发现的跨模块 edge case。
-        每个 case 显式命名，场景清单：
-        1. test_nested_ref_lookback：MA(REF(c,5),20) lookback=25，trim 后 start 正确
-        2. test_lookback_calendar_vs_trading：lookback 用交易日延伸，trim 回 user start
-        3. test_multiindex_groupby_isolation：2 tickers 不同起止日，rolling 不跨 ticker 串数据
-        4. test_cross_section_rank_multi_ticker：RANK 按日做 cross-section，单 ticker 退化边界
-        5. test_precomputed_expression_index_merge：Parquet (ticker,date) 与 (date,ticker) 对齐
-        6. test_adjusted_price_split_boundary：split 日前后 adj_close ratio 正确，volume 不复权
-        7. test_ic_forward_shift_no_lookahead：shift=1 无前瞻，手工算参考值断言
-        8. test_setter_not_injected_raises：无 MarketData 调 expression 因子 → RuntimeError
-        9. test_unknown_factor_raises：未知 factor name → 明确异常
-        10. test_column_order_preserved：factor_names=["B","A"] 返回 [B,A] 列顺序
-        11. test_open_zero_div_nan：$open=0 → inf → 因子值 NaN 不崩
-        12. test_empty_date_range：无数据日期 → 返回空 MultiIndex DataFrame，不 crash
+        18 个集成测试分 7 组，与 m6 单元测试无重复。Review 后删除与 m6 重复的
+        setter/unknown_factor/single-source column_order case，新增 7 个 corner case。
+        新增回归全量 665 pass。
+        A. Lookback & date (4): 嵌套 lookback / 日历乘数 mock 断言 / trim overshoot /
+           多因子 max_lookback 聚合
+        B. Ticker & index isolation (3): groupby ticker 隔离 / market_data 返回 ticker
+           子集 / datetime.date 级别规范化端到端
+        D. Precomputed merge & routing (3): 索引对齐 / 跨 group 合并 / precomputed
+           与 expression 日期范围不对齐时的 outer-join
+        E. Variable mapping (2): $close→adj_close 端到端 / $volume 不复权
+        F. IC report integration (3): oracle 因子 IC≈1 无 lookahead / 缺 adj_close
+           抛错透传 / ic_universe 超出数据 NaN 报告
+        G. 列序与异常 (3): 交错 precomputed+expression 列序 / $open=0 inf/NaN / 空 date range
+        原计划 case 6 (split) 因 Evaluator 只见 adj_close 改为 $close 映射端到端。
+        原 case 7 (no-lookahead) 强化为 oracle 因子法（factor = fwd_ret → IC ≈ 1）。
   commits:
     - hash: "46c5636"
       date: "2026-04-12"

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
@@ -1,5 +1,5 @@
 progress:
-  completion: 0.125   # 1/8 milestones done
+  completion: 0.25   # 2/8 milestones done
   milestones:
     - id: "m1a-tokenizer-parser"
       name: "Tokenizer + Parser + AST"
@@ -21,9 +21,14 @@ progress:
         注：m3 的 max_lookback() 依赖此处暴露的 walk() 接口，需在本 milestone 锁定。
 
     - id: "m1b-evaluator-basic-funcs"
-      name: "Evaluator + 16 基础函数"
-      status: pending
-      completed_at: null
+      name: "Evaluator + 12 基础函数"
+      status: completed
+      completed_at: "2026-04-11"
+      actual_files:
+        - "src/stockbee/factor_data/expression_engine.py"
+        - "src/stockbee/factor_data/__init__.py"
+        - "tests/test_factor_data.py"
+      actual_lines: 866  # expression_engine +281 / tests +504 / __init__ +4
       estimated_files: ["src/stockbee/factor_data/expression_engine.py", "tests/test_factor_data.py"]
       estimated_lines: 250
       depends_on: [m1a-tokenizer-parser]
@@ -31,9 +36,10 @@ progress:
       description: |
         Evaluator：遍历 AST，变量映射 CLOSE→adj_close/OPEN/HIGH/LOW/VOLUME/VWAP，
         在 MultiIndex DataFrame (date, ticker) 上执行，rolling 必须 groupby(ticker)。
-        16 基础函数：REF/DELAY, MA/MEAN, STD, SUM, MAX, MIN, DELTA, ABS, LOG, SIGN。
-        MAX/MIN 重载：第二参数整数≥2 → rolling，否则 → element-wise。
-        测试：造假 OHLCV（内存 DataFrame，2 tickers）验证各函数数值。
+        12 基础函数（10 impl）：REF/DELAY, MA/MEAN, STD, SUM, MAX, MIN, DELTA, ABS, LOG, SIGN。
+        MAX/MIN 重载：第二参数整数≥2 → rolling，否则 → element-wise（Evaluator 内 hardcode 分支，不走 register_impl）。
+        min_periods=window（Alpha158 约定）。
+        测试：造假 OHLCV（2 tickers × 10 天），33 个 m1b case，含 ticker 隔离 + adj_close 映射验证。
 
     - id: "m2-advanced-functions"
       name: "高级表达式函数"

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml
@@ -1,77 +1,137 @@
 progress:
-  completion: 0.0
+  completion: 0.125   # 1/8 milestones done
   milestones:
-    - id: "m1-expression-engine-core"
-      name: "表达式引擎核心"
-      status: pending
-      completed_at: null
-      estimated_files: ["src/stockbee/factor_data/expression_engine.py"]
-      estimated_lines: 220
+    - id: "m1a-tokenizer-parser"
+      name: "Tokenizer + Parser + AST"
+      status: completed
+      completed_at: "2026-04-11"
+      actual_files:
+        - "src/stockbee/factor_data/__init__.py"
+        - "src/stockbee/factor_data/expression_engine.py"
+        - "tests/test_factor_data.py"
+      actual_lines: 740   # expression_engine ~500 + tests ~240
+      estimated_files: ["src/stockbee/factor_data/expression_engine.py", "tests/test_factor_data.py"]
+      estimated_lines: 200
       depends_on: []
       complexity_flags: [first_of_kind]
       description: |
-        Tokenizer (regex) → Parser (递归下降) → Evaluator (MultiIndex DF)。
-        变量映射: CLOSE→adj_close, OPEN→open, HIGH→high, LOW→low, VOLUME→volume, VWAP→典型价。
-        基础函数 (16): REF/DELAY, MA/MEAN, STD, SUM, MAX, MIN, DELTA, ABS, LOG, SIGN。
-        MAX/MIN 重载: 整数≥2 → rolling, 否则 → element-wise。
+        Tokenizer (regex) → 递归下降 Parser → AST 节点。
+        AST 必须暴露 walk() / lookback() 方法，供 max_lookback 和集成测试使用。
+        测试：只验证 AST 形状，不跑 OHLCV 数据（纯 parser 单元测试）。
+        注：m3 的 max_lookback() 依赖此处暴露的 walk() 接口，需在本 milestone 锁定。
+
+    - id: "m1b-evaluator-basic-funcs"
+      name: "Evaluator + 16 基础函数"
+      status: pending
+      completed_at: null
+      estimated_files: ["src/stockbee/factor_data/expression_engine.py", "tests/test_factor_data.py"]
+      estimated_lines: 250
+      depends_on: [m1a-tokenizer-parser]
+      complexity_flags: [first_of_kind]
+      description: |
+        Evaluator：遍历 AST，变量映射 CLOSE→adj_close/OPEN/HIGH/LOW/VOLUME/VWAP，
+        在 MultiIndex DataFrame (date, ticker) 上执行，rolling 必须 groupby(ticker)。
+        16 基础函数：REF/DELAY, MA/MEAN, STD, SUM, MAX, MIN, DELTA, ABS, LOG, SIGN。
+        MAX/MIN 重载：第二参数整数≥2 → rolling，否则 → element-wise。
+        测试：造假 OHLCV（内存 DataFrame，2 tickers）验证各函数数值。
 
     - id: "m2-advanced-functions"
       name: "高级表达式函数"
       status: pending
       completed_at: null
-      estimated_files: ["src/stockbee/factor_data/expression_engine.py"]
-      estimated_lines: 200
-      depends_on: [m1-expression-engine-core]
+      estimated_files: ["src/stockbee/factor_data/expression_engine.py", "tests/test_factor_data.py"]
+      estimated_lines: 300
+      depends_on: [m1b-evaluator-basic-funcs]
       complexity_flags: [first_of_kind]
       description: |
-        追加 10 个函数: EMA, SLOPE, RSQUARE, RESI, CORR, RANK, IF, QUANTILE, IDXMAX, IDXMIN。
-        SLOPE/RSQUARE/RESI 共享 rolling OLS 计算。
+        追加 10 个函数：EMA, SLOPE, RSQUARE, RESI, CORR, RANK, IF, QUANTILE, IDXMAX, IDXMIN。
+        SLOPE/RSQUARE/RESI 共享 rolling OLS（用 rolling sum 代数展开，非 apply(lstsq)）。
+        RANK/QUANTILE 默认横截面（cross-section at each date），非时序。
+        测试：≥2 tickers 验证横截面 RANK；rolling OLS 用 numpy 线性数据验证斜率精度。
 
     - id: "m3-alpha158-full"
       name: "Alpha158 全量因子定义"
       status: pending
       completed_at: null
-      estimated_files: ["src/stockbee/factor_data/alpha158.py", "config/factors-alpha158.yaml"]
+      estimated_files: ["src/stockbee/factor_data/alpha158.py", "config/factors-alpha158.yaml", "tests/test_factor_data.py"]
       estimated_lines: 350
-      depends_on: [m1-expression-engine-core, m2-advanced-functions]
+      depends_on: [m1a-tokenizer-parser, m2-advanced-functions]
       complexity_flags: []
       description: |
-        alpha158.py: YAML 加载, factor registry, max_lookback()。
-        factors-alpha158.yaml: 全部 158 因子 (9 KBAR + 27组×5窗口)。
+        alpha158.py：YAML 加载，factor registry，max_lookback()。
+        max_lookback()：调用 AST.walk() 沿嵌套链相加（MA(REF(c,5),20) → 25 非 20）。
+        config/factors-alpha158.yaml：全部 158 因子（9 KBAR + 27组×5窗口）。
+        测试：最小 YAML 片段测 loader；嵌套表达式验证 max_lookback 相加语义。
 
     - id: "m4-parquet-factor-store"
       name: "预计算因子 Parquet 存储"
       status: pending
       completed_at: null
-      estimated_files: ["src/stockbee/factor_data/parquet_factor.py"]
-      estimated_lines: 150
+      estimated_files: ["src/stockbee/factor_data/parquet_factor.py", "tests/test_factor_data.py"]
+      estimated_lines: 250
       depends_on: []
       complexity_flags: []
       description: |
-        参照 parquet_macro.py。存储: data/factors/{group}.parquet。
-        接口: read_factors, write_factors (merge-write), list_precomputed_factors。
+        参照 parquet_macro.py（234行）。存储路径：data/factors/{group}.parquet。
+        group 粒度：按数据来源分组（e.g. fundamental, sentiment, ml_score），每组一文件。
+        接口：read_factors(group, tickers, start, end)，write_factors(group, df)（merge-write
+        按 (date, ticker) 主键去重），list_precomputed_factors() → list[str]。
+        测试：tmp Parquet 路径，写入后读取对比，merge 去重验证。
 
-    - id: "m5-local-provider"
-      name: "LocalFactorProvider + IC 评估"
+    - id: "m5-ic-evaluator"
+      name: "IC / ICIR 离线评估"
       status: pending
       completed_at: null
-      estimated_files: ["src/stockbee/factor_data/local_provider.py", "src/stockbee/factor_data/ic_evaluator.py"]
+      estimated_files: ["src/stockbee/factor_data/ic_evaluator.py", "tests/test_factor_data.py"]
       estimated_lines: 200
-      depends_on: [m1-expression-engine-core, m2-advanced-functions, m3-alpha158-full, m4-parquet-factor-store]
+      depends_on: []
       complexity_flags: []
       description: |
-        实现 FactorProvider 接口。MarketDataProvider setter 注入。
-        get_factors 路由 expression/precomputed。IC/ICIR 仅离线评估。
+        纯数值模块，无 provider 依赖，可与 m1-m4 并行开发。
+        接口：compute(factor_df, prices_df, shift=1) → ic_mean, ic_std, icir。
+        shift=1 在本层做（factor at t vs return at t+1），禁止让 caller shift。
+        rolling IC（默认 window=252），IC 序列 NaN 处理：少于 20 个有效值时返回 NaN。
+        测试：合成 golden data（factor = true_return * 0.8 + noise），断言 |ic_mean - 0.8| < 0.05。
 
-    - id: "m6-tests"
-      name: "测试 + 模块导出"
+    - id: "m6-local-provider"
+      name: "LocalFactorProvider + 模块导出"
       status: pending
       completed_at: null
-      estimated_files: ["tests/test_factor_data.py", "src/stockbee/factor_data/__init__.py"]
-      estimated_lines: 350
-      depends_on: [m1-expression-engine-core, m2-advanced-functions, m3-alpha158-full, m4-parquet-factor-store, m5-local-provider]
+      estimated_files: ["src/stockbee/factor_data/local_provider.py", "src/stockbee/factor_data/__init__.py", "tests/test_factor_data.py"]
+      estimated_lines: 280
+      depends_on: [m1b-evaluator-basic-funcs, m2-advanced-functions, m3-alpha158-full, m4-parquet-factor-store, m5-ic-evaluator]
       complexity_flags: []
       description: |
-        5 个 TestClass (~30 tests): ExpressionEngine, Alpha158Config,
-        ParquetFactorStore, LocalFactorProvider, ICEvaluator。__init__.py 导出。
+        实现 FactorProvider 接口。MarketDataProvider setter 注入（未注入时 expression 请求
+        raise RuntimeError，错误信息明确）。
+        get_factors 路由：expression → Alpha158.get_expression → Evaluator（+ lookback trim）；
+        precomputed → ParquetFactorStore。merge 时统一 (date, ticker) 索引顺序，
+        保持调用方请求的列顺序，unknown factor name 直接 raise。
+        get_ic_report() wire 到 ic_evaluator.compute()。
+        __init__.py 增量导出本模块全部公共类。
+        集成测试（happy path）：2 tickers，2 expression + 1 precomputed，验证输出 shape 和列顺序。
+
+    - id: "m7-integration-tests"
+      name: "集成层 edge case 测试"
+      status: pending
+      completed_at: null
+      estimated_files: ["tests/test_factor_integration.py"]
+      estimated_lines: 250
+      depends_on: [m6-local-provider]
+      complexity_flags: []
+      description: |
+        专用集成测试文件，覆盖单元测试无法发现的跨模块 edge case。
+        每个 case 显式命名，场景清单：
+        1. test_nested_ref_lookback：MA(REF(c,5),20) lookback=25，trim 后 start 正确
+        2. test_lookback_calendar_vs_trading：lookback 用交易日延伸，trim 回 user start
+        3. test_multiindex_groupby_isolation：2 tickers 不同起止日，rolling 不跨 ticker 串数据
+        4. test_cross_section_rank_multi_ticker：RANK 按日做 cross-section，单 ticker 退化边界
+        5. test_precomputed_expression_index_merge：Parquet (ticker,date) 与 (date,ticker) 对齐
+        6. test_adjusted_price_split_boundary：split 日前后 adj_close ratio 正确，volume 不复权
+        7. test_ic_forward_shift_no_lookahead：shift=1 无前瞻，手工算参考值断言
+        8. test_setter_not_injected_raises：无 MarketData 调 expression 因子 → RuntimeError
+        9. test_unknown_factor_raises：未知 factor name → 明确异常
+        10. test_column_order_preserved：factor_names=["B","A"] 返回 [B,A] 列顺序
+        11. test_open_zero_div_nan：$open=0 → inf → 因子值 NaN 不崩
+        12. test_empty_date_range：无数据日期 → 返回空 MultiIndex DataFrame，不 crash
   commits: []

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/room.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/room.yaml
@@ -3,11 +3,11 @@ room:
   name: "因子存储"
   parent: "02-data-architecture"
   type: feature
-  lifecycle: implementing
+  lifecycle: completed
   priority: P0
   phase: "1"
   created_at: "2026-03-24"
-  updated_at: "2026-04-12"
+  updated_at: "2026-04-13"
   prompt_test:
     passable: false
     last_tested: null

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/room.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/room.yaml
@@ -7,7 +7,7 @@ room:
   priority: P0
   phase: "1"
   created_at: "2026-03-24"
-  updated_at: "2026-03-24"
+  updated_at: "2026-04-12"
   prompt_test:
     passable: false
     last_tested: null

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/room.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/room.yaml
@@ -3,7 +3,7 @@ room:
   name: "因子存储"
   parent: "02-data-architecture"
   type: feature
-  lifecycle: planning
+  lifecycle: implementing
   priority: P0
   phase: "1"
   created_at: "2026-03-24"

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
@@ -29,6 +29,8 @@ Alpha158 全部 158 个技术因子用表达式引擎动态计算（27 组 × 5 
 | NaN 比较语义 | 保持 pandas 默认（NaN 比较→False），与 qlib 行为一致，不改为 NaN 传播 | 2026-04-11 |
 | max_lookback 实现 | 直接用 AST.lookback()（嵌套相加），不需要 walk() | 2026-04-11 |
 | 因子定义源 | 全量 YAML（config/factors-alpha158.yaml），长表达式也写全，不混合 Python factory | 2026-04-11 |
+| 混合价格 schema | CLOSE→adj_close + raw OHLV 是已知约束（数据源仅提供 adj_close）；m6 LocalFactorProvider 可用 adj_close/close ratio 推导 adj OHLV 解决 | 2026-04-11 |
+| VWAP0 可选依赖 | VWAP0 属于 Alpha158 标准但 vwap 列在当前数据源中不保证存在；无 vwap 时该因子 raise，其余 157 因子正常 | 2026-04-11 |
 
 ## Contracts
 

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
@@ -16,32 +16,52 @@ Alpha158 全部 158 个技术因子用表达式引擎动态计算（27 组 × 5 
 | CLOSE 映射 | adj_close（复权价）| 2026-04-09 |
 | MarketDataProvider 注入 | setter 注入（和 cache 模式一致）| 2026-04-09 |
 | Alpha158 范围 | 全部 158 因子 | 2026-04-09 |
-| Milestone 方案 | Plan A: 6 milestones 精细拆分 | 2026-04-09 |
+| Milestone 方案 | Plan B: 8 milestones（m1 拆 tokenizer/evaluator，m5/m6 并行，m7 集成测试）| 2026-04-11 |
 | MAX/MIN 重载 | 第二参数整数≥2 → rolling, 否则 → element-wise | 2026-04-09 |
+| RANK/QUANTILE 语义 | 横截面（cross-section at each date），非时序 | 2026-04-11 |
+| IC shift 归属 | ic_evaluator.compute(shift=1) 层做，禁止 caller 自行 shift | 2026-04-11 |
+| max_lookback 算法 | AST.walk() 沿嵌套链相加（MA(REF(c,5),20)→25），非取 max | 2026-04-11 |
+| Parquet group 粒度 | 按数据来源（fundamental/sentiment/ml_score），每组一文件 | 2026-04-11 |
+| 未知 factor 处理 | get_factors 收到未知 factor name → raise，不静默跳过 | 2026-04-11 |
 
 ## Contracts
 
 **FactorProvider 接口** (`providers/interfaces.py:129-161`):
 - `get_factors(tickers, factor_names, start, end) → MultiIndex DataFrame (date, ticker) x factors`
+  - 列顺序与 factor_names 一致
+  - unknown name → raise
+  - 无 MarketDataProvider 时请求 expression 因子 → RuntimeError
 - `list_factors() → list[dict]` (含 type: expression / precomputed)
 - `get_ic_report(factor_name, window=252) → dict` (ic_mean, ic_std, icir)
 
 **表达式引擎函数** (26 个):
-- 基础 (m1): REF/DELAY, MA/MEAN, STD, SUM, MAX, MIN, DELTA, ABS, LOG, SIGN
+- 基础 (m1b): REF/DELAY, MA/MEAN, STD, SUM, MAX, MIN, DELTA, ABS, LOG, SIGN
 - 高级 (m2): EMA, SLOPE, RSQUARE, RESI, CORR, RANK, IF, QUANTILE, IDXMAX, IDXMIN
+
+**AST 接口** (m1a 锁定):
+- `AST.walk() → Iterator[Node]` — 遍历全树，供 max_lookback 和集成测试
+- `AST.lookback() → int` — 沿嵌套链相加，返回该子树所需的最大 lookback 窗口
+
+**IC Evaluator 接口**:
+- `compute(factor_df, prices_df, shift=1) → dict(ic_mean, ic_std, icir)`
+- shift 在内部做（factor at t vs return at t+1），禁止 caller 侧 shift
 
 ## 当前进度
 
-6 milestones, ~1470 行, 7 files — 全部 pending
+8 milestones, ~2080 行, 9 files — 全部 pending
 
-1. **m1-expression-engine-core** — 表达式引擎核心 (~220行)
-2. **m2-advanced-functions** — 高级表达式函数 (~200行)
-3. **m3-alpha158-full** — Alpha158 全量 158 因子定义 (~350行)
-4. **m4-parquet-factor-store** — 预计算因子 Parquet 存储 (~150行)
-5. **m5-local-provider** — LocalFactorProvider + IC 评估 (~200行)
-6. **m6-tests** — 测试 + 模块导出 (~350行)
+1. **m1a-tokenizer-parser** — Tokenizer + Parser + AST（含 walk/lookback 接口）(~200行)
+2. **m1b-evaluator-basic-funcs** — Evaluator + 16 基础函数 + MAX/MIN 重载 (~250行)
+3. **m2-advanced-functions** — 10 高级函数（rolling OLS / cross-section RANK 等）(~300行)
+4. **m3-alpha158-full** — Alpha158 全量 158 因子定义 + max_lookback (~350行)
+5. **m4-parquet-factor-store** — 预计算因子 Parquet 存储（可与 m1-m3 并行）(~250行)
+6. **m5-ic-evaluator** — IC/ICIR 纯数值计算（可与 m1-m4 并行）(~200行)
+7. **m6-local-provider** — LocalFactorProvider 路由 + 模块导出 (~280行)
+8. **m7-integration-tests** — 集成层 edge case 测试（12 个场景）(~250行)
+
+**并行路径**：m1a / m4 / m5 三条链第一天可同时开工。
 
 ---
 _spec 状态: intent (draft), change (active)_
-_spec.md 最后更新: 2026-04-10 (milestone 规划 + pytest 配置)_
+_spec.md 最后更新: 2026-04-11 (8-milestone 重规划 + contract 扩充)_
 _specs 目录: 1 intent + 1 change = 2 个 spec 文件_

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
@@ -24,6 +24,11 @@ Alpha158 全部 158 个技术因子用表达式引擎动态计算（27 组 × 5 
 | Parquet group 粒度 | 按数据来源（fundamental/sentiment/ml_score），每组一文件 | 2026-04-11 |
 | 未知 factor 处理 | get_factors 收到未知 factor name → raise，不静默跳过 | 2026-04-11 |
 | EMA 实现 | pandas ewm(adjust=False, α=2/(n+1))，IIR 递推；与 qlib FIR 截断加权在前 ~2n 行有差异 | 2026-04-11 |
+| Alpha158 因子分布 | 9 KBAR + 4 price + 5 VMA + 28算子×5窗口 = 158（修正 PRD "27组×5"） | 2026-04-11 |
+| TS_RANK/TS_QUANTILE | 新增时序滚动函数（与横截面 RANK/QUANTILE 共存），TS_RANK ties=average，TS_QUANTILE interpolation=linear | 2026-04-11 |
+| NaN 比较语义 | 保持 pandas 默认（NaN 比较→False），与 qlib 行为一致，不改为 NaN 传播 | 2026-04-11 |
+| max_lookback 实现 | 直接用 AST.lookback()（嵌套相加），不需要 walk() | 2026-04-11 |
+| 因子定义源 | 全量 YAML（config/factors-alpha158.yaml），长表达式也写全，不混合 Python factory | 2026-04-11 |
 
 ## Contracts
 
@@ -35,13 +40,43 @@ Alpha158 全部 158 个技术因子用表达式引擎动态计算（27 组 × 5 
 - `list_factors() → list[dict]` (含 type: expression / precomputed)
 - `get_ic_report(factor_name, window=252) → dict` (ic_mean, ic_std, icir)
 
-**表达式引擎函数** (26 个):
+**表达式引擎函数** (28 个):
 - 基础 (m1b): REF/DELAY, MA/MEAN, STD, SUM, MAX, MIN, DELTA, ABS, LOG, SIGN
 - 高级 (m2): EMA, SLOPE, RSQUARE, RESI, CORR, RANK, IF, QUANTILE, IDXMAX, IDXMIN
+- 时序滚动 (m3): TS_RANK, TS_QUANTILE
+
+**Alpha158 因子名→表达式函数 Alias**:
+| Factor 前缀 | 表达式函数 | 参数 |
+|-------------|-----------|------|
+| ROC | REF | `REF($close,w)/$close` |
+| MA | MEAN | `MEAN($close,w)/$close` |
+| STD | STD | `STD($close,w)/$close` |
+| BETA | SLOPE | `SLOPE($close,w)/$close` |
+| RSQR | RSQUARE | `RSQUARE($close,w)` |
+| RESI | RESI | `RESI($close,w)/$close` |
+| MAX | MAX(rolling) | `MAX($high,w)/$close` |
+| MIN | MIN(rolling) | `MIN($low,w)/$close` |
+| QTLU | TS_QUANTILE | q=0.8 `TS_QUANTILE($close,w,0.8)/$close` |
+| QTLD | TS_QUANTILE | q=0.2 `TS_QUANTILE($close,w,0.2)/$close` |
+| RANK | TS_RANK | `TS_RANK($close,w)` |
+| RSV | MAX/MIN | `($close-MIN($low,w))/(MAX($high,w)-MIN($low,w)+1e-12)` |
+| IMAX | IDXMAX | `IDXMAX($high,w)/w` |
+| IMIN | IDXMIN | `IDXMIN($low,w)/w` |
+| IMXD | IDXMAX-IDXMIN | `(IDXMAX($high,w)-IDXMIN($low,w))/w` |
+| CORR | CORR | `CORR($close,LOG($volume+1),w)` |
+| CORD | CORR(returns) | `CORR($close/REF($close,1),LOG($volume/REF($volume,1)+1),w)` |
+| CNTP | MEAN(bool) | `MEAN($close>REF($close,1),w)` |
+| CNTN | MEAN(bool) | `MEAN($close<REF($close,1),w)` |
+| CNTD | CNTP-CNTN | 差值 |
+| SUMP/SUMN/SUMD | SUM+MAX | 比率 |
+| VMA | MEAN(volume) | `MEAN($volume,w)/($volume+1e-12)` |
+| VSTD | STD(volume) | `STD($volume,w)/($volume+1e-12)` |
+| WVMA | STD/MEAN | 嵌套加权波动率 |
+| VSUMP/VSUMN/VSUMD | SUM+MAX(volume) | 同 SUMP 但用 $volume |
 
 **AST 接口** (m1a 锁定):
-- `AST.walk() → Iterator[Node]` — 遍历全树，供 max_lookback 和集成测试
-- `AST.lookback() → int` — 沿嵌套链相加，返回该子树所需的最大 lookback 窗口
+- `AST.walk() → Iterator[Node]` — 遍历全树，供集成测试
+- `AST.lookback() → int` — 沿嵌套链相加，返回该子树所需的最大 lookback 窗口（m3 max_lookback 直接调用此接口）
 
 **IC Evaluator 接口**:
 - `compute(factor_df, prices_df, shift=1) → dict(ic_mean, ic_std, icir)`
@@ -54,7 +89,7 @@ Alpha158 全部 158 个技术因子用表达式引擎动态计算（27 组 × 5 
 1. **m1a-tokenizer-parser** — Tokenizer + Parser + AST（含 walk/lookback 接口）(~200行)
 2. **m1b-evaluator-basic-funcs** — Evaluator + 16 基础函数 + MAX/MIN 重载 (~250行)
 3. **m2-advanced-functions** — 10 高级函数（rolling OLS / cross-section RANK 等）(~300行)
-4. **m3-alpha158-full** — Alpha158 全量 158 因子定义 + max_lookback (~350行)
+4. **m3-alpha158-full** — Alpha158 全量 158 因子定义 (9 KBAR + 4 price + 5 VMA + 28算子×5窗口) + TS_RANK/TS_QUANTILE + max_lookback (~940行)
 5. **m4-parquet-factor-store** — 预计算因子 Parquet 存储（可与 m1-m3 并行）(~250行)
 6. **m5-ic-evaluator** — IC/ICIR 纯数值计算（可与 m1-m4 并行）(~200行)
 7. **m6-local-provider** — LocalFactorProvider 路由 + 模块导出 (~280行)

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
@@ -86,13 +86,13 @@ Alpha158 全部 158 个技术因子用表达式引擎动态计算（27 组 × 5 
 
 ## 当前进度
 
-8 milestones — 4/8 完成 (m1a, m1b, m2, m3)
+8 milestones — 5/8 完成 (m1a, m1b, m2, m3, m4)
 
 1. **m1a-tokenizer-parser** — ✅ Tokenizer + Parser + AST（740行）
 2. **m1b-evaluator-basic-funcs** — ✅ Evaluator + 12 基础函数（866行）
 3. **m2-advanced-functions** — ✅ 10 高级函数（687行）
 4. **m3-alpha158-full** — ✅ Alpha158 全量 158 因子 + TS_RANK/TS_QUANTILE（516行, 167 tests）
-5. **m4-parquet-factor-store** — 预计算因子 Parquet 存储（可与 m1-m3 并行）(~250行)
+5. **m4-parquet-factor-store** — ✅ 预计算因子 Parquet 存储（315行, 13 tests, 180 全量 pass）
 6. **m5-ic-evaluator** — IC/ICIR 纯数值计算（可与 m1-m4 并行）(~200行)
 7. **m6-local-provider** — LocalFactorProvider 路由 + 模块导出 (~280行)
 8. **m7-integration-tests** — 集成层 edge case 测试（12 个场景）(~250行)

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
@@ -86,20 +86,20 @@ Alpha158 全部 158 个技术因子用表达式引擎动态计算（27 组 × 5 
 
 ## 当前进度
 
-8 milestones — 5/8 完成 (m1a, m1b, m2, m3, m4)
+8 milestones — 6/8 完成 (m1a, m1b, m2, m3, m4, m5)
 
 1. **m1a-tokenizer-parser** — ✅ Tokenizer + Parser + AST（740行）
 2. **m1b-evaluator-basic-funcs** — ✅ Evaluator + 12 基础函数（866行）
 3. **m2-advanced-functions** — ✅ 10 高级函数（687行）
 4. **m3-alpha158-full** — ✅ Alpha158 全量 158 因子 + TS_RANK/TS_QUANTILE（516行, 167 tests）
-5. **m4-parquet-factor-store** — ✅ 预计算因子 Parquet 存储（315行, 13 tests, 180 全量 pass）
-6. **m5-ic-evaluator** — IC/ICIR 纯数值计算（可与 m1-m4 并行）(~200行)
+5. **m4-parquet-factor-store** — ✅ 预计算因子 Parquet 存储（315行, 17 tests, 184 全量 pass）
+6. **m5-ic-evaluator** — ✅ IC/ICIR 纯数值离线评估（248行, 19 tests, 203 全量 pass）
 7. **m6-local-provider** — LocalFactorProvider 路由 + 模块导出 (~280行)
 8. **m7-integration-tests** — 集成层 edge case 测试（12 个场景）(~250行)
 
 **并行路径**：m1a / m4 / m5 三条链第一天可同时开工。
 
 ---
-_spec 状态: intent (draft), change (active)_
-_spec.md 最后更新: 2026-04-11 (m3 完成 + codex review findings)_
-_specs 目录: 1 intent + 3 change = 4 个 spec 文件_
+_spec 状态: intent (active), change (active)_
+_spec.md 最后更新: 2026-04-12 (m5 完成)_
+_specs 目录: 1 intent + 4 change = 5 个 spec 文件_

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
@@ -86,7 +86,7 @@ Alpha158 全部 158 个技术因子用表达式引擎动态计算（27 组 × 5 
 
 ## 当前进度
 
-8 milestones — 6/8 完成 (m1a, m1b, m2, m3, m4, m5)
+8 milestones — 7/8 完成 (m1a, m1b, m2, m3, m4, m5, m6)
 
 1. **m1a-tokenizer-parser** — ✅ Tokenizer + Parser + AST（740行）
 2. **m1b-evaluator-basic-funcs** — ✅ Evaluator + 12 基础函数（866行）
@@ -94,12 +94,12 @@ Alpha158 全部 158 个技术因子用表达式引擎动态计算（27 组 × 5 
 4. **m3-alpha158-full** — ✅ Alpha158 全量 158 因子 + TS_RANK/TS_QUANTILE（516行, 167 tests）
 5. **m4-parquet-factor-store** — ✅ 预计算因子 Parquet 存储（315行, 17 tests, 184 全量 pass）
 6. **m5-ic-evaluator** — ✅ IC/ICIR 纯数值离线评估（248行, 19 tests, 203 全量 pass）
-7. **m6-local-provider** — LocalFactorProvider 路由 + 模块导出 (~280行)
+7. **m6-local-provider** — ✅ LocalFactorProvider 路由 + 模块导出 + ICUniverse（~470行, 20 tests, 224 全量 pass）
 8. **m7-integration-tests** — 集成层 edge case 测试（12 个场景）(~250行)
 
 **并行路径**：m1a / m4 / m5 三条链第一天可同时开工。
 
 ---
 _spec 状态: intent (active), change (active)_
-_spec.md 最后更新: 2026-04-12 (m5 完成)_
-_specs 目录: 1 intent + 4 change = 5 个 spec 文件_
+_spec.md 最后更新: 2026-04-12 (m6 完成)_
+_specs 目录: 1 intent + 5 change = 6 个 spec 文件_

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
@@ -86,12 +86,12 @@ Alpha158 全部 158 个技术因子用表达式引擎动态计算（27 组 × 5 
 
 ## 当前进度
 
-8 milestones, ~2080 行, 9 files — 全部 pending
+8 milestones — 4/8 完成 (m1a, m1b, m2, m3)
 
-1. **m1a-tokenizer-parser** — Tokenizer + Parser + AST（含 walk/lookback 接口）(~200行)
-2. **m1b-evaluator-basic-funcs** — Evaluator + 16 基础函数 + MAX/MIN 重载 (~250行)
-3. **m2-advanced-functions** — 10 高级函数（rolling OLS / cross-section RANK 等）(~300行)
-4. **m3-alpha158-full** — Alpha158 全量 158 因子定义 (9 KBAR + 4 price + 5 VMA + 28算子×5窗口) + TS_RANK/TS_QUANTILE + max_lookback (~940行)
+1. **m1a-tokenizer-parser** — ✅ Tokenizer + Parser + AST（740行）
+2. **m1b-evaluator-basic-funcs** — ✅ Evaluator + 12 基础函数（866行）
+3. **m2-advanced-functions** — ✅ 10 高级函数（687行）
+4. **m3-alpha158-full** — ✅ Alpha158 全量 158 因子 + TS_RANK/TS_QUANTILE（516行, 167 tests）
 5. **m4-parquet-factor-store** — 预计算因子 Parquet 存储（可与 m1-m3 并行）(~250行)
 6. **m5-ic-evaluator** — IC/ICIR 纯数值计算（可与 m1-m4 并行）(~200行)
 7. **m6-local-provider** — LocalFactorProvider 路由 + 模块导出 (~280行)
@@ -101,5 +101,5 @@ Alpha158 全部 158 个技术因子用表达式引擎动态计算（27 组 × 5 
 
 ---
 _spec 状态: intent (draft), change (active)_
-_spec.md 最后更新: 2026-04-11 (8-milestone 重规划 + contract 扩充)_
-_specs 目录: 1 intent + 1 change = 2 个 spec 文件_
+_spec.md 最后更新: 2026-04-11 (m3 完成 + codex review findings)_
+_specs 目录: 1 intent + 3 change = 4 个 spec 文件_

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
@@ -23,6 +23,7 @@ Alpha158 全部 158 个技术因子用表达式引擎动态计算（27 组 × 5 
 | max_lookback 算法 | AST.walk() 沿嵌套链相加（MA(REF(c,5),20)→25），非取 max | 2026-04-11 |
 | Parquet group 粒度 | 按数据来源（fundamental/sentiment/ml_score），每组一文件 | 2026-04-11 |
 | 未知 factor 处理 | get_factors 收到未知 factor name → raise，不静默跳过 | 2026-04-11 |
+| EMA 实现 | pandas ewm(adjust=False, α=2/(n+1))，IIR 递推；与 qlib FIR 截断加权在前 ~2n 行有差异 | 2026-04-11 |
 
 ## Contracts
 

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
@@ -4,19 +4,44 @@
 
 **表达式引擎（技术因子）+ Parquet 预计算（融合因子）**
 
-Alpha158 技术因子用表达式引擎动态计算，灵活度高。基本面/情绪/ML 因子预计算存 Parquet。
+Alpha158 全部 158 个技术因子用表达式引擎动态计算（27 组 × 5 窗口 + 9 KBAR），灵活度高。基本面/情绪/ML 因子预计算存 Parquet。
 
 来源：Tech Design §2.5
 研究状态：研究完成 (research-factor-storage.md)
 
 ## Decisions
 
-_暂无决策记录_
+| 决策 | 结论 | 日期 |
+|------|------|------|
+| CLOSE 映射 | adj_close（复权价）| 2026-04-09 |
+| MarketDataProvider 注入 | setter 注入（和 cache 模式一致）| 2026-04-09 |
+| Alpha158 范围 | 全部 158 因子 | 2026-04-09 |
+| Milestone 方案 | Plan A: 6 milestones 精细拆分 | 2026-04-09 |
+| MAX/MIN 重载 | 第二参数整数≥2 → rolling, 否则 → element-wise | 2026-04-09 |
 
 ## Contracts
 
-_暂无接口约定_
+**FactorProvider 接口** (`providers/interfaces.py:129-161`):
+- `get_factors(tickers, factor_names, start, end) → MultiIndex DataFrame (date, ticker) x factors`
+- `list_factors() → list[dict]` (含 type: expression / precomputed)
+- `get_ic_report(factor_name, window=252) → dict` (ic_mean, ic_std, icir)
+
+**表达式引擎函数** (26 个):
+- 基础 (m1): REF/DELAY, MA/MEAN, STD, SUM, MAX, MIN, DELTA, ABS, LOG, SIGN
+- 高级 (m2): EMA, SLOPE, RSQUARE, RESI, CORR, RANK, IF, QUANTILE, IDXMAX, IDXMIN
+
+## 当前进度
+
+6 milestones, ~1470 行, 7 files — 全部 pending
+
+1. **m1-expression-engine-core** — 表达式引擎核心 (~220行)
+2. **m2-advanced-functions** — 高级表达式函数 (~200行)
+3. **m3-alpha158-full** — Alpha158 全量 158 因子定义 (~350行)
+4. **m4-parquet-factor-store** — 预计算因子 Parquet 存储 (~150行)
+5. **m5-local-provider** — LocalFactorProvider + IC 评估 (~200行)
+6. **m6-tests** — 测试 + 模块导出 (~350行)
 
 ---
-_所有 spec 状态: draft（需要 review 后升为 active）_
-_spec.md 由 room-init 自动生成，specs/*.yaml 为源数据_
+_spec 状态: intent (draft), change (active)_
+_spec.md 最后更新: 2026-04-10 (milestone 规划 + pytest 配置)_
+_specs 目录: 1 intent + 1 change = 2 个 spec 文件_

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/spec.md
@@ -86,7 +86,7 @@ Alpha158 全部 158 个技术因子用表达式引擎动态计算（27 组 × 5 
 
 ## 当前进度
 
-8 milestones — 7/8 完成 (m1a, m1b, m2, m3, m4, m5, m6)
+8 milestones — 8/8 完成 (m1a, m1b, m2, m3, m4, m5, m6, m7) ✅
 
 1. **m1a-tokenizer-parser** — ✅ Tokenizer + Parser + AST（740行）
 2. **m1b-evaluator-basic-funcs** — ✅ Evaluator + 12 基础函数（866行）
@@ -95,11 +95,11 @@ Alpha158 全部 158 个技术因子用表达式引擎动态计算（27 组 × 5 
 5. **m4-parquet-factor-store** — ✅ 预计算因子 Parquet 存储（315行, 17 tests, 184 全量 pass）
 6. **m5-ic-evaluator** — ✅ IC/ICIR 纯数值离线评估（248行, 19 tests, 203 全量 pass）
 7. **m6-local-provider** — ✅ LocalFactorProvider 路由 + 模块导出 + ICUniverse（~470行, 20 tests, 224 全量 pass）
-8. **m7-integration-tests** — 集成层 edge case 测试（12 个场景）(~250行)
+8. **m7-integration-tests** — ✅ 集成层 edge case 测试（18 个场景，7 组，512行, 18 tests, 665 全量 pass）
 
 **并行路径**：m1a / m4 / m5 三条链第一天可同时开工。
 
 ---
 _spec 状态: intent (active), change (active)_
-_spec.md 最后更新: 2026-04-12 (m6 完成)_
+_spec.md 最后更新: 2026-04-13 (m7 完成，Room 全部完成)_
 _specs 目录: 1 intent + 5 change = 6 个 spec 文件_

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/specs/change-2026-04-10-factor-storage-plan.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/specs/change-2026-04-10-factor-storage-plan.yaml
@@ -1,6 +1,6 @@
 spec_id: "change-2026-04-10-factor-storage-plan"
 type: change
-state: active
+state: superseded
 intent:
   summary: "04-factor-storage 里程碑重规划 + pytest 根目录配置"
   detail: |

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/specs/change-2026-04-10-factor-storage-plan.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/specs/change-2026-04-10-factor-storage-plan.yaml
@@ -1,0 +1,42 @@
+spec_id: "change-2026-04-10-factor-storage-plan"
+type: change
+state: active
+intent:
+  summary: "04-factor-storage 里程碑重规划 + pytest 根目录配置"
+  detail: |
+    为 04-factor-storage Room 重新拆分了 6 个可开发的 milestones：
+    - m1-expression-engine-core: Tokenizer / Parser / Evaluator + 16 个基础函数
+    - m2-advanced-functions: EMA / rolling OLS / rank / quantile / idxmax/min 等高级函数
+    - m3-alpha158-full: YAML 加载 + 全量 158 因子定义
+    - m4-parquet-factor-store: 预计算因子 Parquet 读写与枚举
+    - m5-local-provider: expression / precomputed 双路由 + IC/ICIR 离线评估
+    - m6-tests: 模块导出 + 约 30 个测试
+
+    同步更新了 spec.md 的 Decisions / Contracts / 当前进度段落，使人类可读视图和
+    progress.yaml 中的新 milestone 结构一致。
+
+    同时新增根目录 pyproject.toml：
+    - [tool.pytest.ini_options]
+    - pythonpath = ["src"]
+
+    这样从仓库根目录运行 pytest 时可以直接导入 stockbee 包，不需要手动设置 PYTHONPATH。
+    .gitignore 也补充了 .DS_Store，避免本地 Finder 元数据持续污染工作区。
+constraints: []
+indexing:
+  type: change
+  priority: high
+  layer: feature
+  domain: "quantitative-trading"
+  tags: ["planning", "factor-storage", "pytest", "repo-config"]
+provenance:
+  source_type: commit
+  confidence: 1.0
+  source_ref: "feature/factor-storage planning sync, 2026-04-10"
+relations:
+  - { type: refines, target: "intent-04-factor-storage-001", reason: "将 Room 目标拆分为可执行 milestones，并补充测试运行约定" }
+anchors:
+  - { file: "meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml", type: planning }
+  - { file: "meta/00-project-room/02-data-architecture/04-factor-storage/spec.md", type: docs }
+  - { file: "meta/00-project-room/02-data-architecture/04-factor-storage/specs/change-2026-04-10-factor-storage-plan.yaml", type: spec }
+  - { file: "pyproject.toml", type: test_config }
+  - { file: ".gitignore", type: config }

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/specs/change-2026-04-11-m3-alpha158.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/specs/change-2026-04-11-m3-alpha158.yaml
@@ -1,0 +1,62 @@
+spec_id: "change-2026-04-11-m3-alpha158"
+type: change
+state: active
+intent:
+  summary: "m3-alpha158-full 实现：158 因子注册表 + TS_RANK/TS_QUANTILE + 全量测试"
+  detail: |
+    实现 Alpha158 全量 158 因子定义（m3-alpha158-full milestone）。
+
+    主要交付：
+    1. expression_engine.py 新增 TS_RANK/TS_QUANTILE 时序滚动函数
+       - 与横截面 RANK/QUANTILE 共存（不破坏 m2 已有语义）
+       - TS_QUANTILE parse 阶段 q∈[0,1] 校验
+       - TS_RANK ties=average, TS_QUANTILE interpolation=linear（pandas 默认）
+    2. config/factors-alpha158.yaml 全量 158 因子 YAML 定义
+       - 9 KBAR + 4 price + 29 算子×5 窗口 = 158
+       - 长表达式（WVMA/CORD/SUMD 等）也全写 YAML，无 Python factory 混合
+    3. alpha158.py 因子注册表
+       - YAML 加载 + 笛卡尔展开 + AST 延迟解析缓存
+       - max_lookback() = AST.lookback()（嵌套相加）
+       - list_factor_names() 固定顺序（contract）
+    4. 全量测试覆盖（167 pass，m3 新增 45 case）
+       - 全部 158 parse 成功
+       - 全部 158 lookback 参数化断言（按家族：KBAR=0, simple=w, nested=w+1）
+       - 全量 158 evaluate smoke（Series + index 对齐）
+       - 无 vwap 157 因子 smoke（真实数据源兼容性）
+       - VWAP0 无 vwap 时 raise 验证
+       - 数值金标：KMID, OPEN0, MA5, RANK5, CNTP5 NaN 行为
+
+    新增 spec decisions（8 条）：
+    - 因子分布 158 = 9+4+5+140（修正 PRD "27组×5"）
+    - TS_RANK/TS_QUANTILE 命名 + ties/interpolation
+    - NaN 比较语义（保持 pandas 默认 = qlib 兼容）
+    - 混合价格 schema（known constraint, m6 解决）
+    - VWAP0 可选依赖
+    - max_lookback 用 lookback() 非 walk()
+    - 因子定义源 = 全 YAML
+
+    Codex review findings 已处理：
+    - Finding 1 (混合 adj_close + raw OHLV): m1b 决策，非 m3 bug，记为 known constraint
+    - Finding 2 (VWAP0 smoke 假阳性): 已修复，加 157 无 vwap smoke + raise 验证
+
+constraints: []
+indexing:
+  type: change
+  priority: high
+  layer: feature
+  domain: "quantitative-trading"
+  tags: ["factor-storage", "alpha158", "expression-engine", "ts-rank", "ts-quantile"]
+provenance:
+  source_type: implementation
+  confidence: 1.0
+  source_ref: "m3-alpha158-full implementation, 7 commits ecef8db..24605e6"
+relations:
+  - { type: implements, target: "intent-04-factor-storage-001", reason: "实现 Alpha158 因子注册表" }
+  - { type: extends, target: "change-2026-04-11-milestone-replan", reason: "完成 m3 milestone" }
+anchors:
+  - { file: "src/stockbee/factor_data/expression_engine.py", type: implementation }
+  - { file: "src/stockbee/factor_data/alpha158.py", type: implementation }
+  - { file: "config/factors-alpha158.yaml", type: config }
+  - { file: "tests/test_factor_data.py", type: test }
+  - { file: "meta/00-project-room/02-data-architecture/04-factor-storage/spec.md", type: docs }
+  - { file: "meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml", type: planning }

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/specs/change-2026-04-11-milestone-replan.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/specs/change-2026-04-11-milestone-replan.yaml
@@ -1,0 +1,46 @@
+spec_id: "change-2026-04-11-milestone-replan"
+type: change
+state: active
+intent:
+  summary: "04-factor-storage milestone 重规划：6→8，补集成测试，锁定跨模块 contract"
+  detail: |
+    基于 design review 发现的问题，将 6 个 milestone 重拆为 8 个：
+
+    主要变动：
+    1. m1 拆为 m1a(tokenizer/parser/AST) + m1b(evaluator/基础函数)
+       - AST 在 m1a 锁定 walk()/lookback() 接口，供 m3 max_lookback 和 m7 集成测试使用
+    2. 删除旧 m6-tests（测试堆在最后破坏独立可测性）
+       - 每个 milestone 自带本模块单元测试
+    3. m5 拆出为独立的 m5-ic-evaluator（纯数值，无 provider 依赖，可与 m1-m4 并行）
+    4. m6-local-provider 专注路由/胶水层，带 happy-path 集成测试
+    5. 新增 m7-integration-tests：12 个跨模块 edge case（lookback trim, groupby,
+       index merge, split boundary, IC forward-shift, 异常路径, 空数据等）
+
+    锁定 4 个之前 spec 未决的 contract：
+    - RANK/QUANTILE 默认横截面（非时序）
+    - IC shift=1 在 ic_evaluator 层做
+    - max_lookback 用嵌套相加（MA(REF(c,5),20)→25）
+    - Parquet group 按数据来源分组
+
+    估算修正：
+    - 原 1470 行 → 新 2080 行（反映 2-2.5x PRD 偏差修正）
+    - m4 从 150→250（参考 parquet_macro.py 234行基线）
+    - m2 从 200→300（rolling OLS + cross-section 实现量）
+
+constraints: []
+indexing:
+  type: change
+  priority: high
+  layer: feature
+  domain: "quantitative-trading"
+  tags: ["planning", "factor-storage", "milestone-replan", "integration-tests", "contracts"]
+provenance:
+  source_type: design_review
+  confidence: 1.0
+  source_ref: "design review 2026-04-11: integration edge cases + testability analysis"
+relations:
+  - { type: supersedes, target: "change-2026-04-10-factor-storage-plan", reason: "8-milestone 方案替换旧 6-milestone 方案" }
+  - { type: refines, target: "intent-04-factor-storage-001", reason: "补充跨模块 contract 和集成测试策略" }
+anchors:
+  - { file: "meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml", type: planning }
+  - { file: "meta/00-project-room/02-data-architecture/04-factor-storage/spec.md", type: docs }

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/specs/change-2026-04-12-m4-parquet-store.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/specs/change-2026-04-12-m4-parquet-store.yaml
@@ -1,0 +1,43 @@
+spec_id: "change-2026-04-12-m4-parquet-store"
+type: change
+state: active
+intent:
+  summary: "m4 完成：ParquetFactorStore 预计算因子 Parquet 存储"
+  detail: |
+    实现 ParquetFactorStore 类，为预计算因子（fundamental/sentiment/ml_score）
+    提供按 group 分文件的 Parquet 持久化层。
+
+    实现内容：
+    - read_factors(group, tickers, start, end) → MultiIndex (date, ticker) DataFrame
+    - write_factors(group, df) — reindex + .loc 赋值（NaN 也覆盖，新数据无条件胜出）
+    - list_precomputed_factors() → sorted list[str]
+    - 输入校验：MultiIndex 验证 + group 名路径穿越防护
+    - 原子写入：write-then-rename 防止 crash 导致文件损坏
+    - date 级别归一化：pyarrow round-trip 后 object dtype → datetime64
+
+    经 2 轮 review（Codex + subagent 独立 review）修正的关键问题：
+    1. combine_first+update → reindex+.loc（修复 NaN 不传播 bug）
+    2. date 级别 dtype 归一化（修复 datetime.date object 比较 TypeError）
+    3. 空 DataFrame 写入跳过（避免空 parquet 文件污染）
+    4. 反斜杠路径穿越防护
+
+    17 个测试 case，184 全量 pass。
+
+constraints: []
+indexing:
+  type: change
+  priority: high
+  layer: feature
+  domain: "quantitative-trading"
+  tags: ["factor-storage", "parquet", "m4", "precomputed-factors"]
+provenance:
+  source_type: implementation
+  confidence: 1.0
+  source_ref: "m4-parquet-factor-store milestone implementation"
+relations:
+  - { type: implements, target: "intent-04-factor-storage-001", reason: "实现预计算因子 Parquet 存储部分" }
+  - { type: refines, target: "change-2026-04-11-milestone-replan", reason: "完成 m4 milestone" }
+anchors:
+  - { file: "src/stockbee/factor_data/parquet_factor.py", type: source }
+  - { file: "src/stockbee/factor_data/__init__.py", type: source }
+  - { file: "tests/test_factor_data.py", type: test }

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/specs/change-2026-04-12-m5-ic-evaluator.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/specs/change-2026-04-12-m5-ic-evaluator.yaml
@@ -1,0 +1,42 @@
+spec_id: "change-2026-04-12-m5-ic-evaluator"
+type: change
+state: active
+intent:
+  summary: "m5 完成：IC/ICIR 离线评估纯数值模块"
+  detail: |
+    实现 ic_evaluator.py，计算因子值与前向收益的 Spearman rank IC / ICIR。
+
+    实现内容：
+    - compute(factor_df, prices_df, shift=1, window=252) → dict(ic_mean, ic_std, icir)
+    - 前向收益内部计算：groupby(ticker).shift(-shift) / price - 1
+    - 逐日截面 IC：groupby(date).apply(rank().corr())，纯 pandas 无 scipy
+    - NaN gate：有效 IC < 20 → 三项全 NaN
+    - ICIR = ic_mean / ic_std(ddof=1)，std=0 → NaN
+    - 输入校验：MultiIndex (date, ticker)、单列 factor、adj_close 存在、shift >= 1、window >= 1、无 duplicate index
+
+    经 Codex + sub-agent 双重 plan review 修正的关键问题：
+    1. golden test 修正：Spearman IC 用 perfect corr (≈1.0/-1.0) 替代错误的 0.8 目标
+    2. 删除 price_col/min_valid 公开参数（内部常量化）
+    3. 纯 pandas rank().corr() 替代 scipy spearmanr（零新依赖）
+    4. 补全 corner case：shift/window 校验、duplicate index、partial overlap、flat prices
+
+    19 个测试 case，203 全量 pass。
+
+constraints: []
+indexing:
+  type: change
+  priority: high
+  layer: feature
+  domain: "quantitative-trading"
+  tags: ["factor-storage", "ic-evaluator", "m5", "spearman-ic"]
+provenance:
+  source_type: implementation
+  confidence: 1.0
+  source_ref: "m5-ic-evaluator milestone implementation"
+relations:
+  - { type: implements, target: "intent-04-factor-storage-001", reason: "实现 IC/ICIR 离线评估部分" }
+  - { type: refines, target: "change-2026-04-12-m4-parquet-store", reason: "完成 m5 milestone" }
+anchors:
+  - { file: "src/stockbee/factor_data/ic_evaluator.py", type: source }
+  - { file: "src/stockbee/factor_data/__init__.py", type: source }
+  - { file: "tests/test_factor_data.py", type: test }

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/specs/change-2026-04-12-m6-local-provider.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/specs/change-2026-04-12-m6-local-provider.yaml
@@ -1,0 +1,42 @@
+id: change-2026-04-12-m6-local-provider
+type: change
+state: active
+room: 04-factor-storage
+date: "2026-04-12"
+summary: "m6 LocalFactorProvider — ���子路由 + 合并 + IC 报告 + 20 tests"
+
+description: |
+  实现 LocalFactorProvider，整合 Alpha158 表达式引擎和 ParquetFactorStore。
+
+  核心功能：
+  - get_factors(): expression/precomputed 路由，batched Evaluator 复用，
+    outer join 合并，列顺序保持，未知 factor raise
+  - list_factors(): expression + precomputed 合并列表，同名 expression 优先
+  - get_ic_report(): wire 到 ic_evaluator.compute()，需要 ICUniverse 配置
+  - MarketDataProvider setter 注入
+  - ICUniverse dataclass（ticker universe + 日期范围）
+  - Precomputed reverse index：pyarrow schema 元数据读取，lazy build
+  - 日期��一化：_normalize_date_index 防止 date vs Timestamp TypeError
+
+  Review 驱动的改进：
+  - 空 OHLCV 短路（不构造 Evaluator）
+  - IC 价格数据多取 shift 天（前向收益不截断）
+  - 跨 group 同名 precomputed 列 warning
+  - Scalar broadcast guard（constant-only expression���
+
+  测试：20 个 case 覆盖 happy path���错误处理、空输入、
+  列顺序、名字冲突、IC 报告、lazy index、日期归一化。
+
+files_changed:
+  - src/stockbee/factor_data/local_provider.py (created, ~230 lines)
+  - src/stockbee/factor_data/__init__.py (updated, +3 lines)
+  - tests/test_factor_data.py (updated, +237 lines, 20 new tests)
+
+anchors:
+  file:
+    - src/stockbee/factor_data/local_provider.py
+    - src/stockbee/factor_data/__init__.py
+  symbols:
+    - LocalFactorProvider
+    - ICUniverse
+    - _normalize_date_index

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/specs/change-2026-04-13-m7-integration-tests.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/specs/change-2026-04-13-m7-integration-tests.yaml
@@ -1,0 +1,96 @@
+id: change-2026-04-13-m7-integration-tests
+type: change
+state: active
+room: 04-factor-storage
+date: "2026-04-13"
+summary: "m7 集成测试 + adversarial review fix — 18 edge cases + 3 个修复，Room 全部完成"
+
+description: |
+  完成 Room 04-factor-storage 最后一个 milestone。18 个集成测试覆盖跨模块
+  edge case；adversarial review 发现 3 个生产层问题，全部修复。
+
+  测试分 7 组 18 cases（单元层无法抓到的跨模块问题）：
+    A. Lookback & date arithmetic (4):
+       - 嵌套 lookback 通过 provider 正确传递
+       - extended_start 用日历乘数 × max_lookback 计算（mock 断言）
+       - trim 移除 lookback overshoot
+       - 多因子时 extended_start 用 max(lookback)
+    B. Ticker & index isolation (3):
+       - groupby ticker rolling 隔离
+       - market_data 返回 ticker 子集不崩
+       - datetime.date level 端到端正规化
+    D. Precomputed merge & routing (3):
+       - 索引完整对齐 (date,ticker)
+       - 跨 Parquet group 合并
+       - precomputed 与 expression 日期范围不对齐 → outer-join NaN
+    E. Variable mapping (2):
+       - $close → adj_close 端到端 (adj_close=2*close 验证)
+       - $volume 不复权
+    F. IC report integration (3):
+       - Oracle 因子 (factor=fwd_ret) IC ≈ 1.0，证明 provider 无二次 shift
+       - prices 缺 adj_close → ValueError 透传
+       - ic_universe 超出数据 → NaN 报告不崩
+    G. 列序 / 异常 / 空输入 (3):
+       - [precomp, expr, precomp, expr] 交错列序保持
+       - $open=0 → inf/NaN，其他行正常
+       - 请求范围在数据外 → 空 MultiIndex DataFrame
+
+  Plan review 驱动的改动（原计划 12 → 最终 18 cases）:
+    删除与 m6 重复的 3 个 case:
+      - test_setter_not_injected_raises
+      - test_unknown_factor_raises
+      - test_column_order_preserved (原 single-source 版)
+    重构：
+      - 原 split boundary case → $close 映射端到端 (Evaluator 只见 adj_close)
+      - 原 no-lookahead case → oracle 因子法 (IC≈1)
+    新增 7 个 corner case:
+      - max_lookback 聚合
+      - ticker subset
+      - datetime.date 规范化
+      - cross-group merge
+      - date range divergence
+      - missing adj_close
+      - ic_universe out-of-data
+
+  Adversarial review 修复:
+    1. _normalize_date_index 按位置假设 date 在 level[0]，改为 name-based 定位
+       (若 MultiIndex names=['ticker','date'] 会把 ticker 字符串送 pd.to_datetime)
+    2. ParquetFactorStore._atomic_write tmp 文件带 uuid 后缀，多进程同时写同 group
+       不再互相覆盖 tmp；加 try/unlink 清理
+    3. LocalFactorProvider.refresh_precomputed_index() 公开方法：lazy build 之后
+       写入新 group 时需要显式 refresh 才能发现（否则 "Unknown factor"）
+
+files_changed:
+  - tests/test_factor_integration.py (created, 560+ lines, 21 cases)
+  - src/stockbee/factor_data/local_provider.py (modified: _normalize_date_index
+    name-based + refresh_precomputed_index 公开方法)
+  - src/stockbee/factor_data/parquet_factor.py (modified: _atomic_write uuid tmp + cleanup)
+  - meta/00-project-room/02-data-architecture/04-factor-storage/progress.yaml (m7 completed, 1.0)
+  - meta/00-project-room/02-data-architecture/04-factor-storage/spec.md (8/8 完成)
+  - meta/00-project-room/02-data-architecture/04-factor-storage/room.yaml (lifecycle: completed)
+  - meta/00-project-room/_tree.yaml (04-factor-storage 已完成)
+
+decisions_locked:
+  - Oracle 因子法是 IC no-lookahead 的黄金测试（vs 手算参考值）
+  - _CALENDAR_MULTIPLIER=2 对当前 Alpha158 所有 lookback 够用（WVMA60 = 61 最大）
+  - 空 date range 返回空 MultiIndex DataFrame 带正确列名（不抛异常）
+  - provider.refresh_precomputed_index() 是 lazy index 失效的逃生舱
+
+anchors:
+  file:
+    - tests/test_factor_integration.py
+    - src/stockbee/factor_data/local_provider.py
+    - src/stockbee/factor_data/parquet_factor.py
+  symbols:
+    - LocalFactorProvider.refresh_precomputed_index
+    - _normalize_date_index
+    - ParquetFactorStore._atomic_write
+
+followups:
+  - "Parquet write 跨进程 read-modify-write 原子性（当前 tmp 名已唯一，但两进程并发
+     write_factors 同 group 仍可能丢失更新）"
+  - "EMA IIR burn-in：EMA60 实际 ~85 交易日 buffer 下残留初始偏差 5.8%"
+  - "IDXMAX/IDXMIN 使用 rolling.apply 慢路径（~100x 可提速）"
+  - "Factor 计算无 cache，IC 报告会重复算同一因子"
+  - "$vwap 缺列 raise，建议提供 strict=False 模式跳过"
+  - "conftest.py 提取 _make_ohlcv helper（跨 test_factor_data / test_factor_integration）"

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/specs/intent-04-factor-storage-001.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/specs/intent-04-factor-storage-001.yaml
@@ -24,5 +24,6 @@ anchors:
   - { file: "src/stockbee/factor_data/expression_engine.py", type: source }
   - { file: "src/stockbee/factor_data/alpha158.py", type: source }
   - { file: "src/stockbee/factor_data/parquet_factor.py", type: source }
+  - { file: "src/stockbee/factor_data/ic_evaluator.py", type: source }
   - { file: "config/factors-alpha158.yaml", type: config }
   - { file: "tests/test_factor_data.py", type: test }

--- a/meta/00-project-room/02-data-architecture/04-factor-storage/specs/intent-04-factor-storage-001.yaml
+++ b/meta/00-project-room/02-data-architecture/04-factor-storage/specs/intent-04-factor-storage-001.yaml
@@ -1,6 +1,6 @@
 spec_id: "intent-04-factor-storage-001"
 type: intent
-state: draft
+state: active
 intent:
   summary: "表达式引擎（技术因子）+ Parquet 预计算（融合因子）"
   detail: |
@@ -20,4 +20,9 @@ provenance:
   confidence: 0.8
   source_ref: "PRD + Feature Hierarchy + Tech Design"
 relations: []
-anchors: []
+anchors:
+  - { file: "src/stockbee/factor_data/expression_engine.py", type: source }
+  - { file: "src/stockbee/factor_data/alpha158.py", type: source }
+  - { file: "src/stockbee/factor_data/parquet_factor.py", type: source }
+  - { file: "config/factors-alpha158.yaml", type: config }
+  - { file: "tests/test_factor_data.py", type: test }

--- a/meta/00-project-room/02-data-architecture/progress.yaml
+++ b/meta/00-project-room/02-data-architecture/progress.yaml
@@ -1,5 +1,5 @@
 progress:
-  completion: 0.57
+  completion: 0.65
   milestones:
     - id: "m1-Provider-架构"
       name: "Provider 架构"
@@ -11,7 +11,7 @@ progress:
       completed_at: null
     - id: "m3-因子存储"
       name: "因子存储"
-      status: pending
+      status: in_progress
       completed_at: null
     - id: "m4-知识图谱"
       name: "知识图谱"

--- a/meta/00-project-room/_tree.yaml
+++ b/meta/00-project-room/_tree.yaml
@@ -26,7 +26,7 @@ tree:
             - { id: "01-stock-data", type: feature, priority: P0, phase: 1, status: "已完成" }
             - { id: "02-news-data", type: feature, priority: P0, phase: 1, status: "研究完成" }
             - { id: "03-macro-data", type: feature, priority: P0, phase: 1, status: "已完成" }
-            - { id: "04-factor-storage", type: feature, priority: P0, phase: 1, status: "研究完成" }
+            - { id: "04-factor-storage", type: feature, priority: P0, phase: 1, status: "已完成" }
             - { id: "05-experience-buffer", type: feature, priority: P0, phase: 2, status: "研究完成" }
             - { id: "06-knowledge-graph", type: feature, priority: P0, phase: "1-2", status: "研究完成" }
             - { id: "07-provider-arch", type: feature, priority: P0, phase: 1, status: "已完成" }

--- a/meta/00-project-room/timeline.yaml
+++ b/meta/00-project-room/timeline.yaml
@@ -68,9 +68,9 @@ timeline:
           target_end: "2026-04-25"
           estimated_days: 9
           status: implementing
-          completion: 0.625
+          completion: 0.75
           depends_on: ["01-stock-data", "07-provider-arch"]
-          note: "5/8 milestones done (m1a,m1b,m2,m3,m4). 剩余: m5-ic, m6-provider, m7-integration"
+          note: "6/8 milestones done (m1a,m1b,m2,m3,m4,m5). 剩余: m6-provider, m7-integration"
 
         # --- Sprint 2: 模型层 + 宏观 (Week 3-6) ---
         - room: "01-llm-routing"

--- a/meta/00-project-room/timeline.yaml
+++ b/meta/00-project-room/timeline.yaml
@@ -67,10 +67,10 @@ timeline:
           target_start: "2026-04-14"
           target_end: "2026-04-25"
           estimated_days: 9
-          status: planning
-          completion: 0.0
+          status: implementing
+          completion: 0.625
           depends_on: ["01-stock-data", "07-provider-arch"]
-          note: "研究完成，表达式引擎+预计算"
+          note: "5/8 milestones done (m1a,m1b,m2,m3,m4). 剩余: m5-ic, m6-provider, m7-integration"
 
         # --- Sprint 2: 模型层 + 宏观 (Week 3-6) ---
         - room: "01-llm-routing"
@@ -472,7 +472,7 @@ timeline:
     phase_2_rooms: 11
     phase_3_rooms: 3
     completed: 3
-    in_progress: 0
-    planning: 23
+    in_progress: 1
+    planning: 22
     backlog: 14
     completion: 0.075

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pytest.ini_options]
+pythonpath = ["src"]

--- a/src/stockbee/factor_data/__init__.py
+++ b/src/stockbee/factor_data/__init__.py
@@ -18,12 +18,15 @@ from .expression_engine import (
     tokenize,
 )
 from .ic_evaluator import compute as compute_ic
+from .local_provider import ICUniverse, LocalFactorProvider
 from .parquet_factor import ParquetFactorStore
 
 __all__ = [
     "Alpha158",
     "Evaluator",
     "ExpressionError",
+    "ICUniverse",
+    "LocalFactorProvider",
     "Node",
     "ParquetFactorStore",
     "compute_ic",

--- a/src/stockbee/factor_data/__init__.py
+++ b/src/stockbee/factor_data/__init__.py
@@ -5,6 +5,7 @@
                      + Evaluator + 基础/高级/TS 函数（m1b/m2/m3）
 - alpha158: Alpha158 因子注册表 + max_lookback（m3）
 - parquet_factor: 预计算因子 Parquet 存储（m4）
+- ic_evaluator: IC / ICIR 离线评估（m5）
 """
 
 from .alpha158 import Alpha158
@@ -16,6 +17,7 @@ from .expression_engine import (
     parse,
     tokenize,
 )
+from .ic_evaluator import compute as compute_ic
 from .parquet_factor import ParquetFactorStore
 
 __all__ = [
@@ -24,6 +26,7 @@ __all__ = [
     "ExpressionError",
     "Node",
     "ParquetFactorStore",
+    "compute_ic",
     "evaluate",
     "parse",
     "tokenize",

--- a/src/stockbee/factor_data/__init__.py
+++ b/src/stockbee/factor_data/__init__.py
@@ -1,10 +1,12 @@
 """因子数据模块（factor_data）。
 
-当前包含：
+包含：
 - expression_engine: 表达式 DSL 的 Tokenizer / Parser / AST（m1a）
-                     + Evaluator + 12 基础函数（m1b）
+                     + Evaluator + 基础/高级/TS 函数（m1b/m2/m3）
+- alpha158: Alpha158 因子注册表 + max_lookback（m3）
 """
 
+from .alpha158 import Alpha158
 from .expression_engine import (
     Evaluator,
     ExpressionError,
@@ -15,6 +17,7 @@ from .expression_engine import (
 )
 
 __all__ = [
+    "Alpha158",
     "Evaluator",
     "ExpressionError",
     "Node",

--- a/src/stockbee/factor_data/__init__.py
+++ b/src/stockbee/factor_data/__init__.py
@@ -2,18 +2,23 @@
 
 当前包含：
 - expression_engine: 表达式 DSL 的 Tokenizer / Parser / AST（m1a）
+                     + Evaluator + 12 基础函数（m1b）
 """
 
 from .expression_engine import (
+    Evaluator,
     ExpressionError,
     Node,
+    evaluate,
     parse,
     tokenize,
 )
 
 __all__ = [
+    "Evaluator",
     "ExpressionError",
     "Node",
+    "evaluate",
     "parse",
     "tokenize",
 ]

--- a/src/stockbee/factor_data/__init__.py
+++ b/src/stockbee/factor_data/__init__.py
@@ -4,6 +4,7 @@
 - expression_engine: 表达式 DSL 的 Tokenizer / Parser / AST（m1a）
                      + Evaluator + 基础/高级/TS 函数（m1b/m2/m3）
 - alpha158: Alpha158 因子注册表 + max_lookback（m3）
+- parquet_factor: 预计算因子 Parquet 存储（m4）
 """
 
 from .alpha158 import Alpha158
@@ -15,12 +16,14 @@ from .expression_engine import (
     parse,
     tokenize,
 )
+from .parquet_factor import ParquetFactorStore
 
 __all__ = [
     "Alpha158",
     "Evaluator",
     "ExpressionError",
     "Node",
+    "ParquetFactorStore",
     "evaluate",
     "parse",
     "tokenize",

--- a/src/stockbee/factor_data/__init__.py
+++ b/src/stockbee/factor_data/__init__.py
@@ -1,0 +1,19 @@
+"""因子数据模块（factor_data）。
+
+当前包含：
+- expression_engine: 表达式 DSL 的 Tokenizer / Parser / AST（m1a）
+"""
+
+from .expression_engine import (
+    ExpressionError,
+    Node,
+    parse,
+    tokenize,
+)
+
+__all__ = [
+    "ExpressionError",
+    "Node",
+    "parse",
+    "tokenize",
+]

--- a/src/stockbee/factor_data/alpha158.py
+++ b/src/stockbee/factor_data/alpha158.py
@@ -1,0 +1,85 @@
+"""Alpha158 因子注册表 — YAML 加载 + AST cache + max_lookback。
+
+加载 config/factors-alpha158.yaml，展开 rolling 模板的笛卡尔积，
+构建 name → expression 映射。不负责求值（m6 LocalFactorProvider 的工作）。
+
+公开 API：
+    Alpha158(yaml_path=None)
+    .get_expression(name) -> Node      # 解析并缓存 AST
+    .get_expression_str(name) -> str   # 原始表达式字符串
+    .max_lookback(name) -> int         # AST.lookback()
+    .list_factor_names() -> list[str]  # 158 个名字，固定顺序
+    len(alpha158) -> int               # 158
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from pathlib import Path
+
+import yaml
+
+from .expression_engine import Node, parse
+
+
+_DEFAULT_YAML = Path(__file__).resolve().parent.parent.parent.parent / "config" / "factors-alpha158.yaml"
+
+
+class Alpha158:
+    """Alpha158 因子注册表。
+
+    延迟解析：get_expression() 首次调用时 parse + cache，
+    避免初始化时一次性解析全部 158 个表达式。
+    """
+
+    def __init__(self, yaml_path: Path | None = None) -> None:
+        path = yaml_path or _DEFAULT_YAML
+        with open(path) as f:
+            cfg = yaml.safe_load(f)
+
+        self._factors: OrderedDict[str, str] = OrderedDict()
+        self._ast_cache: dict[str, Node] = {}
+
+        groups = cfg["groups"]
+
+        for entry in groups.get("kbar", []):
+            self._factors[entry["name"]] = entry["expr"]
+
+        for entry in groups.get("price", []):
+            self._factors[entry["name"]] = entry["expr"]
+
+        rolling = groups.get("rolling", {})
+        windows = rolling.get("windows", [])
+        for op in rolling.get("operators", []):
+            for w in windows:
+                name = op["name_template"].replace("{w}", str(w))
+                expr = op["expr_template"].replace("{w}", str(w))
+                self._factors[name] = expr
+
+    def get_expression(self, name: str) -> Node:
+        """返回 name 对应的 AST（缓存）。未知 name → KeyError。"""
+        if name not in self._factors:
+            raise KeyError(f"未知因子 {name!r}，共 {len(self._factors)} 个因子可用")
+        if name not in self._ast_cache:
+            self._ast_cache[name] = parse(self._factors[name])
+        return self._ast_cache[name]
+
+    def get_expression_str(self, name: str) -> str:
+        """返回 name 对应的原始表达式字符串。未知 name → KeyError。"""
+        if name not in self._factors:
+            raise KeyError(f"未知因子 {name!r}")
+        return self._factors[name]
+
+    def max_lookback(self, name: str) -> int:
+        """返回该因子所需的最大历史回溯窗口（交易日数）。"""
+        return self.get_expression(name).lookback()
+
+    def list_factor_names(self) -> list[str]:
+        """全部因子名，顺序固定（KBAR → price → rolling 按 operator × window 展开）。"""
+        return list(self._factors.keys())
+
+    def __len__(self) -> int:
+        return len(self._factors)
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._factors

--- a/src/stockbee/factor_data/expression_engine.py
+++ b/src/stockbee/factor_data/expression_engine.py
@@ -849,6 +849,40 @@ register_impl("IDXMAX", _impl_idxmax)
 register_impl("IDXMIN", _impl_idxmin)
 
 
+# ---------------------------------------------------------------------------
+# m2: CORR — per-ticker rolling 相关系数
+# ---------------------------------------------------------------------------
+#
+# 合约：CORR(x, y, n) 在每个 ticker 内部对两个 Series 做 rolling Pearson corr。
+# 当窗口内 x 或 y 恒定（方差=0）→ 除零 → NaN（传播到下游，不崩）。
+#
+# 实现细节：pandas 没有一步到位的 groupby+rolling+corr(other) 接口。
+# 手法：concat 成 DataFrame → groupby('ticker').apply → 每组内 rolling.corr。
+# groupby.apply 会残留 ticker 前缀 level（nlevels=3），用 droplevel(0) 清掉
+# 再 reindex 回 panel.index 做防御性对齐。
+# ---------------------------------------------------------------------------
+
+
+def _impl_corr(s1: pd.Series, s2: pd.Series, n: int) -> pd.Series:
+    df = pd.concat([s1.rename("a"), s2.rename("b")], axis=1)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        res = (
+            df.groupby(level="ticker", sort=False, group_keys=False)
+              .apply(
+                  lambda g: g["a"].rolling(n, min_periods=n).corr(g["b"]),
+                  include_groups=False,
+              )
+        )
+    # groupby.apply 可能残留 ticker 前缀 level（pandas 行为依版本而异），
+    # 一律 droplevel + reindex 做防御性对齐。
+    if res.index.nlevels > 2:
+        res = res.droplevel(0)
+    return res.reindex(s1.index)
+
+
+register_impl("CORR", _impl_corr)
+
+
 # --- 二元 / 一元运算 ---
 
 def _apply_binop(op: str, left: Any, right: Any) -> Any:

--- a/src/stockbee/factor_data/expression_engine.py
+++ b/src/stockbee/factor_data/expression_engine.py
@@ -292,6 +292,8 @@ class FunctionSpec:
         rolling_arg_index:  窗口参数的下标（None 表示无滚动窗口）
         overloaded_max_min: True 表示 MAX/MIN 重载（看 arg[rolling_arg_index] 类型决定）
         cross_section:      True 表示横截面语义（QUANTILE），lookback 不加窗口
+        min_window:         滚动窗口的最小合法值（parse 阶段校验）。默认 1。
+                            SLOPE/RSQUARE/RESI/CORR/EMA 需 ≥2（n=1 时数学上退化）。
         impl:               函数实现（m1b/m2 通过 register_impl 填入）
     """
     name: str
@@ -300,6 +302,7 @@ class FunctionSpec:
     rolling_arg_index: int | None = None
     overloaded_max_min: bool = False
     cross_section: bool = False
+    min_window: int = 1
     impl: Callable[..., Any] | None = field(default=None, compare=False)
 
 
@@ -314,6 +317,7 @@ def _reg(
     rolling_arg_index: int | None = None,
     overloaded_max_min: bool = False,
     cross_section: bool = False,
+    min_window: int = 1,
 ) -> None:
     _REGISTRY[name] = FunctionSpec(
         name=name,
@@ -322,16 +326,20 @@ def _reg(
         rolling_arg_index=rolling_arg_index,
         overloaded_max_min=overloaded_max_min,
         cross_section=cross_section,
+        min_window=min_window,
     )
 
 
-# --- 滚动函数：rolling_arg_index=1（arg0=data, arg1=window） ---
-for _n in ("REF", "DELAY", "MA", "MEAN", "STD", "SUM", "DELTA",
-           "EMA", "SLOPE", "RSQUARE", "RESI", "IDXMAX", "IDXMIN"):
+# --- 滚动函数（min_window=1）：窗口位置已用 ≥1 校验即可 ---
+for _n in ("REF", "DELAY", "MA", "MEAN", "STD", "SUM", "DELTA", "IDXMAX", "IDXMIN"):
     _reg(_n, min_arity=2, max_arity=2, rolling_arg_index=1)
 
-# --- CORR：arg0=data1, arg1=data2, arg2=window ---
-_reg("CORR", min_arity=3, max_arity=3, rolling_arg_index=2)
+# --- OLS/EMA 系列（min_window=2）：n=1 时数学退化或除零 ---
+for _n in ("EMA", "SLOPE", "RSQUARE", "RESI"):
+    _reg(_n, min_arity=2, max_arity=2, rolling_arg_index=1, min_window=2)
+
+# --- CORR：arg0=data1, arg1=data2, arg2=window，n=1 时样本相关系数无定义 ---
+_reg("CORR", min_arity=3, max_arity=3, rolling_arg_index=2, min_window=2)
 
 # --- element-wise 函数 ---
 _reg("ABS",  min_arity=1, max_arity=1)
@@ -375,17 +383,17 @@ def _validate_function_args(call: "FunctionCall", pos: int) -> None:
     """
     spec = _REGISTRY[call.name]
 
-    # --- 1. 严格滚动函数：窗口必须是正整数常量 ---
+    # --- 1. 严格滚动函数：窗口必须是整数常量且 ≥ spec.min_window ---
     if spec.rolling_arg_index is not None and not spec.overloaded_max_min:
         win_node = call.args[spec.rolling_arg_index]
         if not (
             isinstance(win_node, Constant)
             and isinstance(win_node.value, int)
-            and win_node.value >= 1
+            and win_node.value >= spec.min_window
         ):
             raise ParseError(
                 f"函数 {call.name} 的窗口参数（位置 {spec.rolling_arg_index}）"
-                f"必须是 ≥1 的整数常量，实际为 {win_node!r}",
+                f"必须是 ≥{spec.min_window} 的整数常量，实际为 {win_node!r}",
                 pos,
             )
 

--- a/src/stockbee/factor_data/expression_engine.py
+++ b/src/stockbee/factor_data/expression_engine.py
@@ -803,6 +803,52 @@ register_impl("RSQUARE", _impl_rsquare)
 register_impl("RESI",    _impl_resi)
 
 
+# ---------------------------------------------------------------------------
+# m2: EMA / IDXMAX / IDXMIN
+# ---------------------------------------------------------------------------
+#
+# EMA 决策（spec.md 2026-04-11）：采用 pandas ewm(adjust=False) 的 IIR 递推，
+# alpha = 2/(n+1)。与 qlib FIR 截断加权均值在前 ~2n 行存在差异，不对齐 qlib。
+#
+# IDXMAX/IDXMIN 返回窗口内位置偏移 0..n-1（0 = 最早，n-1 = 当前）。
+# rolling.apply(np.argmax, raw=True) 是慢路径（~100x vs 原生 rolling agg），
+# 后续可用 sliding_window_view 优化，m2 范围内保持可读性。
+# ---------------------------------------------------------------------------
+
+
+def _impl_ema(s: pd.Series, n: int) -> pd.Series:
+    """Per-ticker EMA via pandas ewm (IIR, adjust=False)."""
+    alpha = 2.0 / (n + 1.0)
+    return (
+        s.groupby(level="ticker", sort=False, group_keys=False)
+         .transform(lambda x: x.ewm(alpha=alpha, adjust=False, min_periods=n).mean())
+    )
+
+
+def _impl_idxmax(s: pd.Series, n: int) -> pd.Series:
+    """窗口内 argmax 位置偏移 [0, n-1]。ties: numpy argmax 返回最早出现。"""
+    return (
+        s.groupby(level="ticker", sort=False, group_keys=False)
+         .transform(
+             lambda x: x.rolling(n, min_periods=n).apply(np.argmax, raw=True)
+         )
+    )
+
+
+def _impl_idxmin(s: pd.Series, n: int) -> pd.Series:
+    return (
+        s.groupby(level="ticker", sort=False, group_keys=False)
+         .transform(
+             lambda x: x.rolling(n, min_periods=n).apply(np.argmin, raw=True)
+         )
+    )
+
+
+register_impl("EMA",    _impl_ema)
+register_impl("IDXMAX", _impl_idxmax)
+register_impl("IDXMIN", _impl_idxmin)
+
+
 # --- 二元 / 一元运算 ---
 
 def _apply_binop(op: str, left: Any, right: Any) -> Any:

--- a/src/stockbee/factor_data/expression_engine.py
+++ b/src/stockbee/factor_data/expression_engine.py
@@ -357,6 +357,12 @@ _reg("MIN", min_arity=2, max_arity=2, rolling_arg_index=1, overloaded_max_min=Tr
 # --- QUANTILE 横截面：(data, q)，q 是分位数 0~1 的浮点，非窗口 ---
 _reg("QUANTILE", min_arity=2, max_arity=2, cross_section=True)
 
+# --- m3: 时序滚动 RANK / QUANTILE（与横截面 RANK/QUANTILE 共存）---
+# TS_RANK(data, window)：per-ticker rolling rank percentile
+_reg("TS_RANK", min_arity=2, max_arity=2, rolling_arg_index=1, min_window=2)
+# TS_QUANTILE(data, window, q)：per-ticker rolling quantile，q 是第 3 参数
+_reg("TS_QUANTILE", min_arity=3, max_arity=3, rolling_arg_index=1, min_window=2)
+
 
 def _get_spec(name: str) -> FunctionSpec:
     """获取函数规格，未知函数抛 ExpressionError。"""
@@ -397,7 +403,7 @@ def _validate_function_args(call: "FunctionCall", pos: int) -> None:
                 pos,
             )
 
-    # --- 2. QUANTILE q 参数：必须是 [0,1] 范围内的数字常量 ---
+    # --- 2. QUANTILE / TS_QUANTILE q 参数：必须是 [0,1] 范围内的数字常量 ---
     if call.name == "QUANTILE":
         q_node = call.args[1]
         if not isinstance(q_node, Constant) or not isinstance(q_node.value, (int, float)):
@@ -408,6 +414,19 @@ def _validate_function_args(call: "FunctionCall", pos: int) -> None:
         if not (0 <= q_node.value <= 1):
             raise ParseError(
                 f"QUANTILE 的分位数 q 必须在 [0,1] 范围内，实际为 {q_node.value}",
+                pos,
+            )
+
+    if call.name == "TS_QUANTILE":
+        q_node = call.args[2]
+        if not isinstance(q_node, Constant) or not isinstance(q_node.value, (int, float)):
+            raise ParseError(
+                f"TS_QUANTILE 的第三参数 q 必须是数字常量，实际为 {q_node!r}",
+                pos,
+            )
+        if not (0 <= q_node.value <= 1):
+            raise ParseError(
+                f"TS_QUANTILE 的分位数 q 必须在 [0,1] 范围内，实际为 {q_node.value}",
                 pos,
             )
 
@@ -881,6 +900,38 @@ def _impl_corr(s1: pd.Series, s2: pd.Series, n: int) -> pd.Series:
 
 
 register_impl("CORR", _impl_corr)
+
+
+# ---------------------------------------------------------------------------
+# m3: 时序滚动 TS_RANK / TS_QUANTILE
+# ---------------------------------------------------------------------------
+#
+# 与横截面 RANK/QUANTILE 共存。Alpha158 的 RANK%d / QTLU%d / QTLD%d 使用时序
+# 滚动语义（qlib: Rank($close, d) = past d days rolling rank percentile）。
+#
+# TS_RANK ties 处理：pandas 默认 average（spec.md 2026-04-11 决策）。
+# TS_QUANTILE 插值：pandas 默认 linear（spec.md 2026-04-11 决策）。
+# ---------------------------------------------------------------------------
+
+
+def _impl_ts_rank(s: pd.Series, n: int) -> pd.Series:
+    """Per-ticker rolling rank percentile over window n."""
+    return (
+        s.groupby(level="ticker", sort=False, group_keys=False)
+         .transform(lambda x: x.rolling(n, min_periods=n).rank(pct=True))
+    )
+
+
+def _impl_ts_quantile(s: pd.Series, n: int, q: float) -> pd.Series:
+    """Per-ticker rolling quantile over window n."""
+    return (
+        s.groupby(level="ticker", sort=False, group_keys=False)
+         .transform(lambda x: x.rolling(n, min_periods=n).quantile(q))
+    )
+
+
+register_impl("TS_RANK", _impl_ts_rank)
+register_impl("TS_QUANTILE", _impl_ts_quantile)
 
 
 # ---------------------------------------------------------------------------

--- a/src/stockbee/factor_data/expression_engine.py
+++ b/src/stockbee/factor_data/expression_engine.py
@@ -1,0 +1,580 @@
+"""Alpha158 表达式 DSL — Tokenizer / Parser / AST。
+
+仅负责解析和结构分析（m1a）；求值逻辑在 m1b（Evaluator）中实现。
+
+公开 API：
+    parse(src: str) -> Node          -- 解析表达式，返回 AST 根节点
+    tokenize(src: str) -> list[Token]  -- 暴露给测试和调试
+    Node                             -- AST 基类
+    ExpressionError                  -- 所有解析 / 结构错误的基类
+
+支持语法（Alpha158 子集）：
+    变量    : $close $open $high $low $volume $vwap（及短别名 c o h l v，大小写不敏感）
+    数字    : 整数（Python int）/ 浮点（Python float）
+    运算符  : + - * /  以及比较 < > <= >= == !=（用于 IF 条件）
+    函数调用: MA($close, 20)、REF($close, 5)、IF($close > $open, 1, 0) …
+    括号 / 一元负
+
+不支持（m1a 显式排除）：
+    ** 幂运算、位运算 & | ^ ~ ！、逻辑 and/or/not
+"""
+
+from __future__ import annotations
+
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Any, Callable, Iterator
+
+# ---------------------------------------------------------------------------
+# 错误类
+# ---------------------------------------------------------------------------
+
+class ExpressionError(Exception):
+    """解析 / 结构错误基类。"""
+
+
+class TokenizerError(ExpressionError):
+    """Tokenizer 层错误（非法字符等）。"""
+
+    def __init__(self, msg: str, pos: int) -> None:
+        super().__init__(f"{msg} (pos {pos})")
+        self.pos = pos
+
+
+class ParseError(ExpressionError):
+    """Parser 层错误（语法 / 参数个数等）。"""
+
+    def __init__(self, msg: str, pos: int | None = None) -> None:
+        location = f" (pos {pos})" if pos is not None else ""
+        super().__init__(f"{msg}{location}")
+        self.pos = pos
+
+
+# ---------------------------------------------------------------------------
+# Token
+# ---------------------------------------------------------------------------
+
+class TokenType(Enum):
+    NUMBER   = auto()   # 123 / 4.5
+    VAR      = auto()   # $close 或短别名 c/o/h/l/v
+    IDENT    = auto()   # 函数名 MA / REF …
+    LPAREN   = auto()   # (
+    RPAREN   = auto()   # )
+    COMMA    = auto()   # ,
+    OP       = auto()   # + - * / < > <= >= == !=
+    EOF      = auto()
+
+
+@dataclass(frozen=True)
+class Token:
+    type: TokenType
+    value: Any       # str / int / float
+    pos: int         # 在源字符串中的起始字节偏移
+
+
+# ---------------------------------------------------------------------------
+# Tokenizer
+# ---------------------------------------------------------------------------
+
+# 规范变量名映射（输入不区分大小写）
+_VAR_CANON: dict[str, str] = {
+    "$close": "CLOSE",  "$open": "OPEN",  "$high": "HIGH",
+    "$low":   "LOW",    "$volume": "VOLUME", "$vwap": "VWAP",
+    "c": "CLOSE", "o": "OPEN", "h": "HIGH",
+    "l": "LOW",   "v": "VOLUME",
+}
+
+# Token 正则表（顺序重要：长 token 优先）
+_TOKEN_RE = re.compile(
+    r"""
+    (?P<SKIP>[ \t\r\n]+)              |  # 空白，跳过
+    (?P<NUMBER>[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?)  |  # 数字
+    (?P<VAR_LONG>\$[A-Za-z][A-Za-z0-9_]*)  |  # $close $open …
+    (?P<IDENT>[A-Za-z_][A-Za-z0-9_]*)      |  # 函数名或短别名
+    (?P<OP2><=|>=|==|!=)              |  # 双字符运算符（先匹配）
+    (?P<OP1>[+\-*/,()<>])                   # 单字符运算符/标点
+    """,
+    re.VERBOSE,
+)
+
+# 仅包含短别名的单字母集合（大小写不敏感）
+_SHORT_ALIAS = frozenset("cohlv")
+
+
+def tokenize(src: str) -> list[Token]:
+    """将表达式字符串切分为 Token 列表。最后追加 EOF。"""
+    tokens: list[Token] = []
+    pos = 0
+    length = len(src)
+
+    while pos < length:
+        m = _TOKEN_RE.match(src, pos)
+        if m is None:
+            raise TokenizerError(f"非法字符 {src[pos]!r}", pos)
+
+        kind = m.lastgroup
+        raw = m.group()
+        start = pos
+        pos = m.end()
+
+        if kind == "SKIP":
+            continue
+
+        if kind == "NUMBER":
+            # 保留原生类型：整数 vs 浮点
+            val: int | float = int(raw) if "." not in raw and "e" not in raw.lower() else float(raw)
+            tokens.append(Token(TokenType.NUMBER, val, start))
+
+        elif kind == "VAR_LONG":
+            canon = _VAR_CANON.get(raw.lower())
+            if canon is None:
+                raise TokenizerError(f"未知变量 {raw!r}", start)
+            tokens.append(Token(TokenType.VAR, canon, start))
+
+        elif kind == "IDENT":
+            # 先检查是否是短别名（单字母且在集合中）
+            if len(raw) == 1 and raw.lower() in _SHORT_ALIAS:
+                canon = _VAR_CANON[raw.lower()]
+                tokens.append(Token(TokenType.VAR, canon, start))
+            else:
+                # 函数名：规范化为大写
+                tokens.append(Token(TokenType.IDENT, raw.upper(), start))
+
+        elif kind in ("OP2", "OP1"):
+            if raw == "(":
+                tokens.append(Token(TokenType.LPAREN, raw, start))
+            elif raw == ")":
+                tokens.append(Token(TokenType.RPAREN, raw, start))
+            elif raw == ",":
+                tokens.append(Token(TokenType.COMMA, raw, start))
+            else:
+                tokens.append(Token(TokenType.OP, raw, start))
+
+    tokens.append(Token(TokenType.EOF, None, pos))
+    return tokens
+
+
+# ---------------------------------------------------------------------------
+# AST 节点
+# ---------------------------------------------------------------------------
+
+class Node(ABC):
+    """AST 节点基类。所有子类为 frozen dataclass，自带 __eq__/__repr__。"""
+
+    def walk(self) -> Iterator["Node"]:
+        """前序 DFS 遍历：先 yield self，再递归 children（从左到右）。"""
+        yield self
+        for child in self._children():
+            yield from child.walk()
+
+    @abstractmethod
+    def lookback(self) -> int:
+        """返回该子树所需的最大历史回溯窗口（交易日数）。"""
+        ...
+
+    def _children(self) -> list["Node"]:
+        """子节点列表，供 walk() 递归使用。子类按需重写。"""
+        return []
+
+
+@dataclass(frozen=True)
+class Constant(Node):
+    """数字常量节点。value 保留 Python 原生 int 或 float。"""
+    value: int | float
+
+    def lookback(self) -> int:
+        return 0
+
+
+@dataclass(frozen=True)
+class Variable(Node):
+    """变量节点。name 为规范大写形式（CLOSE/OPEN/HIGH/LOW/VOLUME/VWAP）。"""
+    name: str   # 例如 "CLOSE"
+
+    def lookback(self) -> int:
+        return 0
+
+
+@dataclass(frozen=True)
+class UnaryOp(Node):
+    """一元运算节点（目前只支持 -）。"""
+    op: str
+    operand: Node
+
+    def lookback(self) -> int:
+        return self.operand.lookback()
+
+    def _children(self) -> list[Node]:
+        return [self.operand]
+
+
+@dataclass(frozen=True)
+class BinaryOp(Node):
+    """二元运算节点。
+
+    lookback = max(left, right)：二元运算逐点对齐两序列，
+    所需历史为两侧的最大值，而非相加。
+    """
+    op: str
+    left: Node
+    right: Node
+
+    def lookback(self) -> int:
+        return max(self.left.lookback(), self.right.lookback())
+
+    def _children(self) -> list[Node]:
+        return [self.left, self.right]
+
+
+@dataclass(frozen=True)
+class FunctionCall(Node):
+    """函数调用节点。name 为规范大写形式。"""
+    name: str
+    args: tuple[Node, ...]   # frozen=True 要求可哈希，用 tuple
+
+    def lookback(self) -> int:
+        spec = _get_spec(self.name)   # 未知函数抛 ExpressionError
+
+        win_idx = spec.rolling_arg_index
+
+        # MAX/MIN 重载：检查 arg[win_idx] 是否为 int ≥ 2
+        if spec.overloaded_max_min:
+            win_node = self.args[win_idx] if win_idx < len(self.args) else None
+            is_rolling = (
+                isinstance(win_node, Constant)
+                and isinstance(win_node.value, int)
+                and win_node.value >= 2
+            )
+            if not is_rolling:
+                return max(arg.lookback() for arg in self.args)
+            # 走滚动分支
+            win = int(win_node.value)  # type: ignore[union-attr]
+            data_args = [a for i, a in enumerate(self.args) if i != win_idx]
+            return win + max((a.lookback() for a in data_args), default=0)
+
+        # QUANTILE 横截面：第二参数是分位数 q，不是滚动窗口
+        if spec.cross_section:
+            # lookback = 第一个数据参数的 lookback（其余参数忽略）
+            return self.args[0].lookback() if self.args else 0
+
+        # 纯 element-wise（无 rolling_arg_index）
+        if win_idx is None:
+            return max((arg.lookback() for arg in self.args), default=0)
+
+        # 严格滚动函数：窗口 parse 阶段已校验为 Constant int ≥ 1
+        win_node = self.args[win_idx]
+        assert isinstance(win_node, Constant) and isinstance(win_node.value, int)
+        win = win_node.value
+        data_args = [a for i, a in enumerate(self.args) if i != win_idx]
+        return win + max((a.lookback() for a in data_args), default=0)
+
+    def _children(self) -> list[Node]:
+        return list(self.args)
+
+
+# ---------------------------------------------------------------------------
+# FunctionSpec 注册表（m1a：仅元数据，无实现）
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FunctionSpec:
+    """函数元数据。
+
+    Attributes:
+        name:               规范大写函数名
+        min_arity:          最少参数个数
+        max_arity:          最多参数个数（None = 不限）
+        rolling_arg_index:  窗口参数的下标（None 表示无滚动窗口）
+        overloaded_max_min: True 表示 MAX/MIN 重载（看 arg[rolling_arg_index] 类型决定）
+        cross_section:      True 表示横截面语义（QUANTILE），lookback 不加窗口
+        impl:               函数实现（m1b/m2 通过 register_impl 填入）
+    """
+    name: str
+    min_arity: int
+    max_arity: int | None
+    rolling_arg_index: int | None = None
+    overloaded_max_min: bool = False
+    cross_section: bool = False
+    impl: Callable[..., Any] | None = field(default=None, compare=False)
+
+
+# 注册表本体
+_REGISTRY: dict[str, FunctionSpec] = {}
+
+
+def _reg(
+    name: str,
+    min_arity: int,
+    max_arity: int | None,
+    rolling_arg_index: int | None = None,
+    overloaded_max_min: bool = False,
+    cross_section: bool = False,
+) -> None:
+    _REGISTRY[name] = FunctionSpec(
+        name=name,
+        min_arity=min_arity,
+        max_arity=max_arity,
+        rolling_arg_index=rolling_arg_index,
+        overloaded_max_min=overloaded_max_min,
+        cross_section=cross_section,
+    )
+
+
+# --- 滚动函数：rolling_arg_index=1（arg0=data, arg1=window） ---
+for _n in ("REF", "DELAY", "MA", "MEAN", "STD", "SUM", "DELTA",
+           "EMA", "SLOPE", "RSQUARE", "RESI", "IDXMAX", "IDXMIN"):
+    _reg(_n, min_arity=2, max_arity=2, rolling_arg_index=1)
+
+# --- CORR：arg0=data1, arg1=data2, arg2=window ---
+_reg("CORR", min_arity=3, max_arity=3, rolling_arg_index=2)
+
+# --- element-wise 函数 ---
+_reg("ABS",  min_arity=1, max_arity=1)
+_reg("LOG",  min_arity=1, max_arity=1)
+_reg("SIGN", min_arity=1, max_arity=1)
+_reg("RANK", min_arity=1, max_arity=1, cross_section=True)   # 横截面，按日做 cross-section rank
+
+# --- IF：3 参数，全部是数据参数 ---
+_reg("IF", min_arity=3, max_arity=3)
+
+# --- MAX/MIN 重载 ---
+_reg("MAX", min_arity=2, max_arity=2, rolling_arg_index=1, overloaded_max_min=True)
+_reg("MIN", min_arity=2, max_arity=2, rolling_arg_index=1, overloaded_max_min=True)
+
+# --- QUANTILE 横截面：(data, q)，q 是分位数 0~1 的浮点，非窗口 ---
+_reg("QUANTILE", min_arity=2, max_arity=2, cross_section=True)
+
+
+def _get_spec(name: str) -> FunctionSpec:
+    """获取函数规格，未知函数抛 ExpressionError。"""
+    spec = _REGISTRY.get(name)
+    if spec is None:
+        raise ExpressionError(f"未知函数 {name!r}，支持的函数：{sorted(_REGISTRY)}")
+    return spec
+
+
+def register_impl(name: str, fn: Callable[..., Any]) -> None:
+    """注册函数实现（由 m1b / m2 调用）。"""
+    spec = _get_spec(name)
+    # FunctionSpec 是普通 dataclass（非 frozen），可以直接赋值
+    spec.impl = fn
+
+
+def _validate_function_args(call: "FunctionCall", pos: int) -> None:
+    """在 parse 阶段对 FunctionCall 做结构性 + 函数特化校验。
+
+    不合规的 AST 直接 raise ParseError，不允许流转到 lookback / evaluator。
+    校验项：
+      1. 严格滚动函数的窗口位必须是正整数 Constant（MAX/MIN 重载不校验）
+      2. QUANTILE 的分位数 q 必须是 [0,1] 范围内的数字 Constant
+    """
+    spec = _REGISTRY[call.name]
+
+    # --- 1. 严格滚动函数：窗口必须是正整数常量 ---
+    if spec.rolling_arg_index is not None and not spec.overloaded_max_min:
+        win_node = call.args[spec.rolling_arg_index]
+        if not (
+            isinstance(win_node, Constant)
+            and isinstance(win_node.value, int)
+            and win_node.value >= 1
+        ):
+            raise ParseError(
+                f"函数 {call.name} 的窗口参数（位置 {spec.rolling_arg_index}）"
+                f"必须是 ≥1 的整数常量，实际为 {win_node!r}",
+                pos,
+            )
+
+    # --- 2. QUANTILE q 参数：必须是 [0,1] 范围内的数字常量 ---
+    if call.name == "QUANTILE":
+        q_node = call.args[1]
+        if not isinstance(q_node, Constant) or not isinstance(q_node.value, (int, float)):
+            raise ParseError(
+                f"QUANTILE 的第二参数 q 必须是数字常量，实际为 {q_node!r}",
+                pos,
+            )
+        if not (0 <= q_node.value <= 1):
+            raise ParseError(
+                f"QUANTILE 的分位数 q 必须在 [0,1] 范围内，实际为 {q_node.value}",
+                pos,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Parser（递归下降）
+# ---------------------------------------------------------------------------
+# 优先级（从低到高）：
+#   比较：< > <= >= == !=
+#   加减：+ -
+#   乘除：* /
+#   一元负：-
+#   基础：数字 / 变量 / ( expr ) / 函数调用
+
+_COMPARE_OPS = frozenset({"<", ">", "<=", ">=", "==", "!="})
+_ADDITIVE_OPS = frozenset({"+", "-"})
+_MULTIPLICATIVE_OPS = frozenset({"*", "/"})
+
+
+class _Parser:
+    """内部 Parser 类。每次 parse() 调用创建新实例。"""
+
+    def __init__(self, tokens: list[Token]) -> None:
+        self._tokens = tokens
+        self._pos = 0
+
+    # --- 游标辅助 ---
+
+    def _peek(self) -> Token:
+        return self._tokens[self._pos]
+
+    def _advance(self) -> Token:
+        tok = self._tokens[self._pos]
+        self._pos += 1
+        return tok
+
+    def _expect(self, ttype: TokenType, value: Any = None) -> Token:
+        tok = self._peek()
+        if tok.type != ttype:
+            raise ParseError(
+                f"期望 {ttype.name}，实际得到 {tok.type.name} {tok.value!r}",
+                tok.pos,
+            )
+        if value is not None and tok.value != value:
+            raise ParseError(
+                f"期望 {value!r}，实际得到 {tok.value!r}",
+                tok.pos,
+            )
+        return self._advance()
+
+    # --- 递归下降 ---
+
+    def parse(self) -> Node:
+        node = self._comparison()
+        if self._peek().type != TokenType.EOF:
+            tok = self._peek()
+            raise ParseError(f"多余的字符 {tok.value!r}", tok.pos)
+        return node
+
+    def _comparison(self) -> Node:
+        left = self._additive()
+        if self._peek().type == TokenType.OP and self._peek().value in _COMPARE_OPS:
+            op = self._advance().value
+            right = self._additive()
+            # 显式拒绝链式比较（0 < x < 1 这种），避免静默左结合误读
+            if self._peek().type == TokenType.OP and self._peek().value in _COMPARE_OPS:
+                tok = self._peek()
+                raise ParseError(
+                    "不支持链式比较（如 a < b < c），请拆成显式的 IF/AND 组合",
+                    tok.pos,
+                )
+            left = BinaryOp(op=op, left=left, right=right)
+        return left
+
+    def _additive(self) -> Node:
+        left = self._multiplicative()
+        while self._peek().type == TokenType.OP and self._peek().value in _ADDITIVE_OPS:
+            op = self._advance().value
+            right = self._multiplicative()
+            left = BinaryOp(op=op, left=left, right=right)
+        return left
+
+    def _multiplicative(self) -> Node:
+        left = self._unary()
+        while (
+            self._peek().type == TokenType.OP
+            and self._peek().value in _MULTIPLICATIVE_OPS
+        ):
+            op = self._advance().value
+            right = self._unary()
+            left = BinaryOp(op=op, left=left, right=right)
+        return left
+
+    def _unary(self) -> Node:
+        tok = self._peek()
+        if tok.type == TokenType.OP and tok.value == "-":
+            self._advance()
+            operand = self._unary()   # 右结合
+            return UnaryOp(op="-", operand=operand)
+        return self._primary()
+
+    def _primary(self) -> Node:
+        tok = self._peek()
+
+        # 数字常量
+        if tok.type == TokenType.NUMBER:
+            self._advance()
+            return Constant(value=tok.value)
+
+        # 变量
+        if tok.type == TokenType.VAR:
+            self._advance()
+            return Variable(name=tok.value)
+
+        # 括号表达式
+        if tok.type == TokenType.LPAREN:
+            self._advance()
+            node = self._comparison()
+            self._expect(TokenType.RPAREN)
+            return node
+
+        # 函数调用（IDENT 后紧跟 LPAREN）
+        if tok.type == TokenType.IDENT:
+            name = tok.value
+            self._advance()
+
+            # 校验函数名
+            spec = _get_spec(name)   # 未知 → ParseError（ExpressionError 子类）
+
+            self._expect(TokenType.LPAREN)
+            args: list[Node] = []
+            if self._peek().type != TokenType.RPAREN:
+                args.append(self._comparison())
+                while self._peek().type == TokenType.COMMA:
+                    self._advance()
+                    args.append(self._comparison())
+            self._expect(TokenType.RPAREN)
+
+            # 检查 arity
+            n = len(args)
+            if n < spec.min_arity or (spec.max_arity is not None and n > spec.max_arity):
+                expected = (
+                    f"{spec.min_arity}"
+                    if spec.min_arity == spec.max_arity
+                    else f"{spec.min_arity}~{spec.max_arity}"
+                )
+                raise ParseError(
+                    f"函数 {name} 期望 {expected} 个参数，实际得到 {n} 个",
+                    tok.pos,
+                )
+
+            call = FunctionCall(name=name, args=tuple(args))
+            _validate_function_args(call, tok.pos)
+            return call
+
+        raise ParseError(
+            f"意外的 token {tok.type.name} {tok.value!r}",
+            tok.pos,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 公开入口
+# ---------------------------------------------------------------------------
+
+def parse(src: str) -> Node:
+    """解析 Alpha158 表达式字符串，返回 AST 根节点。
+
+    Args:
+        src: 表达式字符串，例如 "MA(REF($close,5),20)"
+
+    Returns:
+        AST 根节点（Node 子类实例）
+
+    Raises:
+        TokenizerError: 非法字符
+        ParseError:     语法错误 / 未知函数 / 参数个数错
+        ExpressionError: 其他结构错误
+    """
+    tokens = tokenize(src)
+    return _Parser(tokens).parse()

--- a/src/stockbee/factor_data/expression_engine.py
+++ b/src/stockbee/factor_data/expression_engine.py
@@ -27,6 +27,9 @@ from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import Any, Callable, Iterator
 
+import numpy as np
+import pandas as pd
+
 # ---------------------------------------------------------------------------
 # 错误类
 # ---------------------------------------------------------------------------
@@ -578,3 +581,293 @@ def parse(src: str) -> Node:
     """
     tokens = tokenize(src)
     return _Parser(tokens).parse()
+
+
+# ---------------------------------------------------------------------------
+# m1b: Evaluator（遍历 AST，在 MultiIndex (date, ticker) Panel 上求值）
+# ---------------------------------------------------------------------------
+#
+# 变量映射（硬编码，2026-04-09 决策）:
+#   CLOSE  → adj_close  (唯一被复权映射的价格)
+#   OPEN   → open       (非复权)
+#   HIGH   → high       (非复权)
+#   LOW    → low        (非复权)
+#   VOLUME → volume     (非复权)
+#   VWAP   → vwap       (可选列，缺列时引用即 raise)
+#
+# Rolling 合约:
+#   - 所有滚动函数通过 groupby(level='ticker') + transform 保证 ticker 隔离
+#   - min_periods = window（窗口不足返回 NaN，Alpha158 约定）
+#   - Evaluator 构造时 sort_index() 一次，作为 groupby 的前置不变量
+# ---------------------------------------------------------------------------
+
+_VAR_TO_COLUMN: dict[str, str] = {
+    "CLOSE":  "adj_close",
+    "OPEN":   "open",
+    "HIGH":   "high",
+    "LOW":    "low",
+    "VOLUME": "volume",
+    "VWAP":   "vwap",
+}
+
+
+def _rolling_transform(s: pd.Series, window: int, op: str) -> pd.Series:
+    """在每个 ticker 内做 rolling 聚合，保留 panel.index 对齐。
+
+    核心合约：
+      - groupby(level='ticker')：不跨 ticker 串数据
+      - min_periods=window：窗口不足返回 NaN
+      - transform：输出 shape/index 与输入一致
+    """
+    return (
+        s.groupby(level="ticker", sort=False, group_keys=False)
+         .transform(lambda x: getattr(x.rolling(window=window, min_periods=window), op)())
+    )
+
+
+# --- 基础函数实现（element-wise + rolling） ---
+
+def _impl_ref(s: pd.Series, n: int) -> pd.Series:
+    """REF/DELAY：在每个 ticker 内沿时间 shift n 个周期（正向 = 取过去）。"""
+    return s.groupby(level="ticker", sort=False, group_keys=False).shift(n)
+
+
+def _impl_ma(s: pd.Series, n: int) -> pd.Series:
+    return _rolling_transform(s, n, "mean")
+
+
+def _impl_std(s: pd.Series, n: int) -> pd.Series:
+    # pandas rolling.std 默认 ddof=1（样本标准差）
+    return _rolling_transform(s, n, "std")
+
+
+def _impl_sum(s: pd.Series, n: int) -> pd.Series:
+    return _rolling_transform(s, n, "sum")
+
+
+def _impl_delta(s: pd.Series, n: int) -> pd.Series:
+    """DELTA(x, n) = x - REF(x, n)。"""
+    return s - _impl_ref(s, n)
+
+
+def _impl_max_rolling(s: pd.Series, n: int) -> pd.Series:
+    return _rolling_transform(s, n, "max")
+
+
+def _impl_min_rolling(s: pd.Series, n: int) -> pd.Series:
+    return _rolling_transform(s, n, "min")
+
+
+def _impl_abs(x: Any) -> Any:
+    if isinstance(x, pd.Series):
+        return x.abs()
+    return abs(x)
+
+
+def _impl_log(x: Any) -> Any:
+    # numpy 默认：log(0)=-inf, log(负)=NaN + RuntimeWarning
+    # 按 decision E：不拦截，让数值向下游传播
+    with np.errstate(divide="ignore", invalid="ignore"):
+        if isinstance(x, pd.Series):
+            return pd.Series(np.log(x.to_numpy()), index=x.index)
+        return float(np.log(x))
+
+
+def _impl_sign(x: Any) -> Any:
+    if isinstance(x, pd.Series):
+        return pd.Series(np.sign(x.to_numpy()), index=x.index)
+    return float(np.sign(x))
+
+
+# 注册到 FunctionSpec（m1b 范围：12 个名字，10 个 impl）
+# REF / DELAY 共享 _impl_ref；MA / MEAN 共享 _impl_ma
+register_impl("REF",   _impl_ref)
+register_impl("DELAY", _impl_ref)
+register_impl("MA",    _impl_ma)
+register_impl("MEAN",  _impl_ma)
+register_impl("STD",   _impl_std)
+register_impl("SUM",   _impl_sum)
+register_impl("DELTA", _impl_delta)
+register_impl("ABS",   _impl_abs)
+register_impl("LOG",   _impl_log)
+register_impl("SIGN",  _impl_sign)
+# 注意：MAX/MIN 不走 register_impl。它们的 overload 分支在 Evaluator._eval_call
+# 里直接 hardcode（需要访问 AST 节点类型判断 rolling vs element-wise），避免把
+# overload 语义塞进 FunctionSpec.impl 签名。
+
+
+# --- 二元 / 一元运算 ---
+
+def _apply_binop(op: str, left: Any, right: Any) -> Any:
+    """算术 + 比较运算符分发。pandas/numpy 会自动处理 Series 与 scalar 的广播。"""
+    if op == "+":  return left + right
+    if op == "-":  return left - right
+    if op == "*":  return left * right
+    if op == "/":  return left / right
+    if op == "<":  return left < right
+    if op == ">":  return left > right
+    if op == "<=": return left <= right
+    if op == ">=": return left >= right
+    if op == "==": return left == right
+    if op == "!=": return left != right
+    raise ExpressionError(f"未知二元运算符 {op!r}")
+
+
+class Evaluator:
+    """在 MultiIndex (date, ticker) Panel 上求值 AST。
+
+    典型用法：
+        ev = Evaluator(panel)
+        series = ev.evaluate(parse("MA($close, 20)"))
+
+    构造阶段一次性：
+      - 校验 panel.index.names 含 'ticker' 一级（rolling 所需）
+      - sort_index 一次（groupby 前置不变量）
+      - 构建 self._vars: VAR_NAME → panel 列 Series 的映射
+
+    一个 Evaluator 实例绑定一个 panel。多次 evaluate 不同 AST 复用同一 panel
+    的映射和排序结果，避免重复开销（m3 Alpha158 会对同一 panel 跑数百次）。
+    """
+
+    def __init__(self, panel: pd.DataFrame) -> None:
+        if not isinstance(panel, pd.DataFrame):
+            raise ExpressionError(
+                f"Evaluator 需要 pandas DataFrame，实际得到 {type(panel).__name__}"
+            )
+
+        if not isinstance(panel.index, pd.MultiIndex):
+            raise ExpressionError(
+                "Evaluator 要求 panel 是 MultiIndex DataFrame "
+                "(levels: date, ticker)"
+            )
+
+        # 必须正好 2 级：否则 (date, exchange, ticker) 这类 panel 会被
+        # groupby(level='ticker') 放过，rolling 在 exchange 维度上串数据。
+        if panel.index.nlevels != 2:
+            raise ExpressionError(
+                f"Evaluator 要求 panel.index 正好 2 级 (date, ticker)，"
+                f"实际 {panel.index.nlevels} 级 levels={list(panel.index.names)}"
+            )
+
+        if "ticker" not in (panel.index.names or []):
+            raise ExpressionError(
+                f"Evaluator 要求 panel.index 含 'ticker' 一级，"
+                f"实际 levels={list(panel.index.names)}"
+            )
+
+        # 不在用户对象上原地 sort，拷贝索引排序后的视图
+        self._panel = panel.sort_index()
+
+        # 预构建 VAR → Series 映射。缺列的变量（如 vwap）不提前 raise，
+        # 等真正引用时才 raise —— 避免 panel 只含 OHLCV 的正常场景下被卡。
+        self._vars: dict[str, pd.Series] = {}
+        for var_name, col in _VAR_TO_COLUMN.items():
+            if col in self._panel.columns:
+                self._vars[var_name] = self._panel[col]
+
+    @property
+    def panel(self) -> pd.DataFrame:
+        """返回 sort_index 后的 panel 视图（只读语义，调用方不应修改）。"""
+        return self._panel
+
+    @property
+    def index(self) -> pd.MultiIndex:
+        return self._panel.index  # type: ignore[return-value]
+
+    def evaluate(self, root: Node) -> Any:
+        """求值 AST 根节点。
+
+        返回：
+          - pd.Series 对齐 panel.index（大多数情况）
+          - Python scalar（当 root 是 Constant 时）
+        """
+        return self._eval(root)
+
+    # --- 内部派发 ---
+
+    def _eval(self, node: Node) -> Any:
+        if isinstance(node, Constant):
+            return node.value
+
+        if isinstance(node, Variable):
+            series = self._vars.get(node.name)
+            if series is None:
+                col = _VAR_TO_COLUMN.get(node.name, "?")
+                raise ExpressionError(
+                    f"Panel 缺少变量 {node.name} 所需的列 {col!r}；"
+                    f"panel 现有列={list(self._panel.columns)}"
+                )
+            return series
+
+        if isinstance(node, UnaryOp):
+            val = self._eval(node.operand)
+            if node.op == "-":
+                return -val
+            raise ExpressionError(f"未知一元运算符 {node.op!r}")
+
+        if isinstance(node, BinaryOp):
+            left = self._eval(node.left)
+            right = self._eval(node.right)
+            return _apply_binop(node.op, left, right)
+
+        if isinstance(node, FunctionCall):
+            return self._eval_call(node)
+
+        raise ExpressionError(f"未知 AST 节点类型 {type(node).__name__}")
+
+    def _eval_call(self, node: FunctionCall) -> Any:
+        spec = _get_spec(node.name)
+
+        # --- MAX / MIN overload：arg[1] 为 int ≥ 2 → rolling，否则 element-wise ---
+        if spec.overloaded_max_min:
+            win_node = node.args[1]
+            is_rolling_syntax = (
+                isinstance(win_node, Constant)
+                and isinstance(win_node.value, int)
+                and win_node.value >= 2
+            )
+            # 先评估第一个操作数。rolling 分支只在 data 是 Series 时才合法；
+            # 若 data 退化为标量（如 MAX(1, 2) 这类纯常量表达式），
+            # 走 element-wise 路径返回标量 max/min，而不是调 rolling 崩溃。
+            a = self._eval(node.args[0])
+            if is_rolling_syntax and isinstance(a, pd.Series):
+                win = int(win_node.value)  # type: ignore[union-attr]
+                if node.name == "MAX":
+                    return _impl_max_rolling(a, win)
+                return _impl_min_rolling(a, win)
+            # element-wise 分支：两个操作数都求值后走 np.maximum/minimum
+            b = self._eval(node.args[1])
+            if isinstance(a, pd.Series) or isinstance(b, pd.Series):
+                fn = np.maximum if node.name == "MAX" else np.minimum
+                base = a if isinstance(a, pd.Series) else b
+                return pd.Series(fn(a, b), index=base.index)
+            # 纯标量：用 Python 内置 max/min 保留原生 int/float 类型
+            py_fn = max if node.name == "MAX" else min
+            return py_fn(a, b)
+
+        # --- 横截面函数 / element-wise / 纯 rolling 的统一派发 ---
+        if spec.impl is None:
+            raise ExpressionError(
+                f"函数 {node.name} 尚未注册实现（m1b 范围：REF/DELAY/MA/MEAN/"
+                f"STD/SUM/DELTA/MAX/MIN/ABS/LOG/SIGN；其余函数在 m2 实现）"
+            )
+
+        win_idx = spec.rolling_arg_index
+        args: list[Any] = []
+        for i, arg in enumerate(node.args):
+            if i == win_idx:
+                # parse 阶段已校验为 Constant int ≥ 1
+                assert isinstance(arg, Constant) and isinstance(arg.value, int)
+                args.append(int(arg.value))
+            else:
+                args.append(self._eval(arg))
+        return spec.impl(*args)
+
+
+def evaluate(root: Node, panel: pd.DataFrame) -> Any:
+    """便捷 free function：等价于 Evaluator(panel).evaluate(root)。
+
+    一次性求值场景用此函数；多次对同一 panel 求值请直接复用 Evaluator 实例，
+    避免重复 sort_index 和变量映射重建。
+    """
+    return Evaluator(panel).evaluate(root)

--- a/src/stockbee/factor_data/expression_engine.py
+++ b/src/stockbee/factor_data/expression_engine.py
@@ -883,6 +883,63 @@ def _impl_corr(s1: pd.Series, s2: pd.Series, n: int) -> pd.Series:
 register_impl("CORR", _impl_corr)
 
 
+# ---------------------------------------------------------------------------
+# m2: 横截面函数（RANK / QUANTILE）+ element-wise IF
+# ---------------------------------------------------------------------------
+#
+# RANK/QUANTILE 约定为横截面语义（spec.md 2026-04-11 决策），
+# 在每个 date 内对所有 ticker 做排序 / 分位数，不是时序 rolling。
+# lookback = 0（m1a 已在 FunctionSpec.cross_section=True 分支里处理）。
+#
+# IF 是纯 element-wise，三个参数都可能是 Series 或 scalar。
+# 支持 6 种合法组合（cond ∈ {Series, bool, int/float}, a/b ∈ {Series, scalar}）。
+# scalar cond 来自于两个常量比较（如 IF(1>0, $close, $open)），此时 _apply_binop
+# 返回 Python bool 或 numpy bool_，需要特判走标量路径。
+# ---------------------------------------------------------------------------
+
+
+def _impl_rank(s: pd.Series) -> pd.Series:
+    """横截面 rank (pct=True)。单 ticker 的日期返回 1.0，不 NaN。
+    NaN 输入保持 NaN（na_option='keep' 是 pandas 默认）。"""
+    return (
+        s.groupby(level="date", sort=False, group_keys=False)
+         .rank(pct=True)
+    )
+
+
+def _impl_quantile(s: pd.Series, q: float) -> pd.Series:
+    """横截面 q 分位数，broadcast 回 (date, ticker)。
+    使得 IF($close > QUANTILE($close, 0.5), ...) 这类表达式可用。"""
+    return (
+        s.groupby(level="date", sort=False, group_keys=False)
+         .transform(lambda g: g.quantile(q))
+    )
+
+
+def _impl_if(cond: Any, a: Any, b: Any) -> Any:
+    """三元 IF：cond 为真 → a，否则 → b。
+
+    类型矩阵：
+      - scalar cond (Python bool / np.bool_)：直接返回 a 或 b
+      - Series cond：用 np.where 组合 a/b（可能是 Series 或 scalar），
+        输出 Series 对齐 cond.index
+    """
+    # 标量 cond 路径（_apply_binop 对两个常量比较会返回 bool / np.bool_）
+    if not isinstance(cond, pd.Series):
+        return a if bool(cond) else b
+
+    # Series cond 路径
+    a_arr = a.to_numpy() if isinstance(a, pd.Series) else a
+    b_arr = b.to_numpy() if isinstance(b, pd.Series) else b
+    result = np.where(cond.to_numpy(), a_arr, b_arr)
+    return pd.Series(result, index=cond.index)
+
+
+register_impl("RANK",     _impl_rank)
+register_impl("QUANTILE", _impl_quantile)
+register_impl("IF",       _impl_if)
+
+
 # --- 二元 / 一元运算 ---
 
 def _apply_binop(op: str, left: Any, right: Any) -> Any:

--- a/src/stockbee/factor_data/expression_engine.py
+++ b/src/stockbee/factor_data/expression_engine.py
@@ -704,6 +704,105 @@ register_impl("SIGN",  _impl_sign)
 # overload 语义塞进 FunctionSpec.impl 签名。
 
 
+# ---------------------------------------------------------------------------
+# m2: 共享 rolling OLS kernel（SLOPE / RSQUARE / RESI 复用）
+# ---------------------------------------------------------------------------
+#
+# 约定 x 轴：窗口内位置 i ∈ [0, n-1]，0 = 窗口最早一行，n-1 = 当前行。
+# 这是 qlib Alpha158 的约定：y = β·x + α + ε，回归在"最近 n 天"上。
+#
+# 关键实现难点：Σxy 不能直接 rolling_sum(y * x_literal)，因为 x 是"窗口内位置"
+# 而不是 panel 上的列。解决方案：用 per-ticker 全局行号 k（ticker 内 0,1,2,...）
+# 做代数展开：
+#
+#   窗口 [t-n+1, t] 内，x_i = global_row_i - (t - n + 1)
+#   Σxy_t = Σ_{i ∈ window} (i - (t-n+1)) · y_i
+#         = Σ(i · y_i) − (t − n + 1) · Σy_i
+#         = rolling_sum(k · y, n) − (k_t − n + 1) · rolling_sum(y, n)
+#
+# 其中 k_t 是当前行的 per-ticker 全局行号。x 轴常数：
+#   Σx  = n(n−1)/2
+#   Σxx = n(n−1)(2n−1)/6
+#   n·Σxx − Σx² = n²(n²−1)/12  （分母 D）
+#
+# RSQUARE 闭式（避免二次 pass）：
+#   SSxx  = Σxx − (Σx)²/n = n(n²−1)/12
+#   SStot = Σyy − (Σy)²/n
+#   SSres = SStot − slope²·SSxx
+#   r²    = 1 − SSres/SStot = slope²·SSxx / SStot
+#
+# RESI（last-point 残差，与 qlib 对齐）：
+#   resi_t = y_t − (intercept + slope·(n−1))
+# ---------------------------------------------------------------------------
+
+
+def _rolling_ols(s: pd.Series, n: int) -> tuple[pd.Series, pd.Series, pd.Series]:
+    """Per-ticker rolling OLS 的闭式解。
+
+    Args:
+        s: (date, ticker) MultiIndex Series (y)
+        n: 窗口长度（≥2，由 _validate_function_args 保证）
+
+    Returns:
+        (slope, intercept, rsquare) — 三个与 s 同 index 的 Series。
+        前 n-1 行为 NaN（min_periods=n 的 rolling sum 传播）。
+    """
+    # per-ticker 全局行号 k（ticker 内 0,1,2,...），dtype=int64 → 上转 float 后参与算术
+    k = (
+        s.groupby(level="ticker", sort=False, group_keys=False)
+         .cumcount()
+         .astype(float)
+    )
+
+    sum_y  = _rolling_transform(s, n, "sum")
+    sum_ky = _rolling_transform(k * s, n, "sum")
+    sum_yy = _rolling_transform(s * s, n, "sum")
+
+    # 窗口最早一行的全局行号 k_start = k_t − n + 1
+    k_start = k - (n - 1)
+    # Σxy = Σ(k·y) − k_start · Σy
+    sum_xy = sum_ky - k_start * sum_y
+
+    # x 轴常数（Python 整数 → float 自动上转）
+    n_f = float(n)
+    sum_x  = n_f * (n_f - 1.0) / 2.0
+    sum_xx = n_f * (n_f - 1.0) * (2.0 * n_f - 1.0) / 6.0
+    denom  = n_f * sum_xx - sum_x * sum_x   # = n²(n²−1)/12，n≥2 时 > 0
+
+    slope     = (n_f * sum_xy - sum_x * sum_y) / denom
+    intercept = (sum_y - slope * sum_x) / n_f
+
+    # r² 闭式：SSxx = Σxx − (Σx)²/n，SStot = Σyy − (Σy)²/n
+    ssxx  = sum_xx - (sum_x * sum_x) / n_f
+    sstot = sum_yy - (sum_y * sum_y) / n_f
+    # 当 SStot=0（窗口内 y 恒定） → r² 无定义，NaN 传播符合 numpy 规则
+    with np.errstate(divide="ignore", invalid="ignore"):
+        rsquare = (slope * slope) * ssxx / sstot
+
+    return slope, intercept, rsquare
+
+
+def _impl_slope(s: pd.Series, n: int) -> pd.Series:
+    slope, _, _ = _rolling_ols(s, n)
+    return slope
+
+
+def _impl_rsquare(s: pd.Series, n: int) -> pd.Series:
+    _, _, rsquare = _rolling_ols(s, n)
+    return rsquare
+
+
+def _impl_resi(s: pd.Series, n: int) -> pd.Series:
+    """Last-point residual: y_t − (intercept + slope·(n−1))."""
+    slope, intercept, _ = _rolling_ols(s, n)
+    return s - intercept - slope * (n - 1)
+
+
+register_impl("SLOPE",   _impl_slope)
+register_impl("RSQUARE", _impl_rsquare)
+register_impl("RESI",    _impl_resi)
+
+
 # --- 二元 / 一元运算 ---
 
 def _apply_binop(op: str, left: Any, right: Any) -> Any:

--- a/src/stockbee/factor_data/ic_evaluator.py
+++ b/src/stockbee/factor_data/ic_evaluator.py
@@ -38,6 +38,8 @@ def compute(
         raise ValueError(f"window must be >= 1, got {window}")
 
     factor = _extract_factor(factor_df)
+    if factor.index.duplicated().any():
+        raise ValueError("factor_df has duplicate (date, ticker) rows")
     _validate_multiindex(prices_df, "prices_df")
 
     if _PRICE_COL not in prices_df.columns:

--- a/src/stockbee/factor_data/ic_evaluator.py
+++ b/src/stockbee/factor_data/ic_evaluator.py
@@ -1,0 +1,130 @@
+"""IC Evaluator — 因子 IC / ICIR 离线评估。
+
+纯数值模块，无 provider 依赖。
+计算因子值与前向收益的 Spearman rank 相关系数（Information Coefficient）。
+"""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+
+_MIN_VALID = 20
+_PRICE_COL = "adj_close"
+
+
+def compute(
+    factor_df: pd.DataFrame | pd.Series,
+    prices_df: pd.DataFrame,
+    shift: int = 1,
+    window: int = 252,
+) -> dict[str, float]:
+    """计算因子的 IC / ICIR 统计。
+
+    Args:
+        factor_df: MultiIndex (date, ticker) 的单列 DataFrame 或 Series。
+            多列 DataFrame → ValueError。
+        prices_df: MultiIndex (date, ticker) 的 DataFrame，需含 adj_close 列。
+        shift: 前向收益天数（factor at t vs return at t+shift）。
+        window: 用于汇总统计的最近 IC 数量（默认 252 个交易日）。
+
+    Returns:
+        dict(ic_mean, ic_std, icir)。有效 IC 值不足 20 个时全部返回 NaN。
+    """
+    if shift < 1:
+        raise ValueError(f"shift must be >= 1, got {shift}")
+    if window < 1:
+        raise ValueError(f"window must be >= 1, got {window}")
+
+    factor = _extract_factor(factor_df)
+    _validate_multiindex(prices_df, "prices_df")
+
+    if _PRICE_COL not in prices_df.columns:
+        raise ValueError(
+            f"prices_df must contain '{_PRICE_COL}' column, "
+            f"got columns: {list(prices_df.columns)}"
+        )
+
+    prices_sorted = prices_df.sort_index()
+    _check_no_duplicate_index(prices_sorted, "prices_df")
+
+    price_series = prices_sorted[_PRICE_COL]
+    fwd_price = price_series.groupby(level="ticker").shift(-shift)
+    fwd_ret = fwd_price / price_series - 1
+
+    ic = _ic_series(factor.sort_index(), fwd_ret)
+
+    # 窗口截取
+    ic_windowed = ic.iloc[-window:] if len(ic) > window else ic
+    valid = ic_windowed.dropna()
+
+    if len(valid) < _MIN_VALID:
+        return {"ic_mean": float("nan"), "ic_std": float("nan"), "icir": float("nan")}
+
+    ic_mean = float(valid.mean())
+    ic_std = float(valid.std(ddof=1))
+    icir = ic_mean / ic_std if ic_std != 0 else float("nan")
+    return {"ic_mean": ic_mean, "ic_std": ic_std, "icir": icir}
+
+
+def _ic_series(factor: pd.Series, fwd_ret: pd.Series) -> pd.Series:
+    """逐日截面 Spearman rank IC。
+
+    对每个 date，计算 factor 与 fwd_ret 在 tickers 间的 rank correlation。
+    """
+    combined = pd.DataFrame({"factor": factor, "fwd_ret": fwd_ret}).dropna()
+    if combined.empty:
+        return pd.Series(dtype=float)
+
+    def _spearman(g: pd.DataFrame) -> float:
+        if len(g) < 2:
+            return float("nan")
+        return g["factor"].rank().corr(g["fwd_ret"].rank())
+
+    return combined.groupby(level="date").apply(_spearman)
+
+
+def _extract_factor(factor_df: pd.DataFrame | pd.Series) -> pd.Series:
+    """将 factor_df 统一为 Series，校验 MultiIndex。"""
+    if isinstance(factor_df, pd.Series):
+        _validate_multiindex_series(factor_df, "factor_df")
+        return factor_df
+    _validate_multiindex(factor_df, "factor_df")
+    if len(factor_df.columns) != 1:
+        raise ValueError(
+            f"factor_df must have exactly 1 column, got {len(factor_df.columns)}: "
+            f"{list(factor_df.columns)}"
+        )
+    return factor_df.iloc[:, 0]
+
+
+def _validate_multiindex(df: pd.DataFrame, name: str) -> None:
+    if not isinstance(df.index, pd.MultiIndex):
+        raise ValueError(
+            f"{name} must have MultiIndex (date, ticker), "
+            f"got {type(df.index).__name__}"
+        )
+    if list(df.index.names) != ["date", "ticker"]:
+        raise ValueError(
+            f"{name} MultiIndex names must be ['date', 'ticker'], "
+            f"got {list(df.index.names)}"
+        )
+
+
+def _validate_multiindex_series(s: pd.Series, name: str) -> None:
+    if not isinstance(s.index, pd.MultiIndex):
+        raise ValueError(
+            f"{name} must have MultiIndex (date, ticker), "
+            f"got {type(s.index).__name__}"
+        )
+    if list(s.index.names) != ["date", "ticker"]:
+        raise ValueError(
+            f"{name} MultiIndex names must be ['date', 'ticker'], "
+            f"got {list(s.index.names)}"
+        )
+
+
+def _check_no_duplicate_index(df: pd.DataFrame, name: str) -> None:
+    if df.index.duplicated().any():
+        raise ValueError(f"{name} has duplicate (date, ticker) rows")

--- a/src/stockbee/factor_data/local_provider.py
+++ b/src/stockbee/factor_data/local_provider.py
@@ -45,11 +45,15 @@ def _normalize_date_index(df: pd.DataFrame) -> pd.DataFrame:
     """确保 MultiIndex date 级别是 datetime64，防止 date vs Timestamp 比较 TypeError。"""
     if df.empty or not isinstance(df.index, pd.MultiIndex):
         return df
+    if "date" not in df.index.names:
+        return df
     date_level = df.index.get_level_values("date")
     if not pd.api.types.is_datetime64_any_dtype(date_level):
         df = df.copy()
+        # 按名字定位 level，不依赖 date 在 MultiIndex 的位置
+        date_pos = df.index.names.index("date")
         df.index = df.index.set_levels(
-            pd.to_datetime(df.index.levels[0]), level="date",
+            pd.to_datetime(df.index.levels[date_pos]), level="date",
         )
     return df
 

--- a/src/stockbee/factor_data/local_provider.py
+++ b/src/stockbee/factor_data/local_provider.py
@@ -308,6 +308,17 @@ class LocalFactorProvider(FactorProvider):
 
         return compute_ic(factor_series, prices, shift=_IC_SHIFT, window=window)
 
+    def refresh_precomputed_index(self) -> None:
+        """强制重建 precomputed col → group 反向索引。
+
+        Lazy build 后若有新 group 落盘（e.g. 同 provider 实例内先 get_factors 再
+        write_factors 后又想读新 group），需要显式调用本方法，否则新 group 的
+        列会被当作 "Unknown factor"。
+        """
+        self._precomputed_index = {}
+        self._precomputed_index_built = False
+        self._ensure_precomputed_index()
+
     # ------ Private helpers ------
 
     def _ensure_precomputed_index(self) -> None:

--- a/src/stockbee/factor_data/local_provider.py
+++ b/src/stockbee/factor_data/local_provider.py
@@ -258,8 +258,9 @@ class LocalFactorProvider(FactorProvider):
 
         self._ensure_precomputed_index()
         u = self._ic_universe
-        # 多取 shift 天价格数据，供 compute_ic 计算前向收益
-        price_end = u.end + timedelta(days=_IC_SHIFT * _CALENDAR_MULTIPLIER)
+        # 多取价格数据，供 compute_ic 计算前向收益（shift(-1) 需要 T+1 价格）
+        # 用 5 天 buffer 覆盖周末 + 节假日（原 _IC_SHIFT * 2 = 2 天在周五结尾时不够）
+        price_end = u.end + timedelta(days=max(_IC_SHIFT * _CALENDAR_MULTIPLIER, 5))
 
         if factor_name in self._alpha158:
             lookback = self._alpha158.max_lookback(factor_name)

--- a/src/stockbee/factor_data/local_provider.py
+++ b/src/stockbee/factor_data/local_provider.py
@@ -1,0 +1,343 @@
+"""LocalFactorProvider — 因子数据 Provider 实现。
+
+整合 Alpha158 表达式引擎（动态计算）和 ParquetFactorStore（预计算读取），
+实现 FactorProvider 接口的 get_factors / list_factors / get_ic_report。
+
+MarketDataProvider 通过 setter 注入（表达式因子和 IC 报告需要 OHLCV 数据）。
+IC 评估还需要通过 ic_universe setter 注入 ticker + 日期范围。
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+
+import pandas as pd
+import pyarrow.parquet as pq
+
+from stockbee.providers.base import ProviderConfig
+from stockbee.providers.interfaces import FactorProvider, MarketDataProvider
+
+from .alpha158 import Alpha158
+from .expression_engine import Evaluator
+from .ic_evaluator import compute as compute_ic
+from .parquet_factor import ParquetFactorStore
+
+logger = logging.getLogger(__name__)
+
+# 交易日 → 日历日转换：保守 2x 覆盖周末 + 长假（春节/国庆）。
+_CALENDAR_MULTIPLIER = 2
+_IC_SHIFT = 1
+
+
+@dataclass
+class ICUniverse:
+    """IC 评估所需的 ticker universe + 日期范围。"""
+
+    tickers: list[str]
+    start: date
+    end: date
+
+
+def _normalize_date_index(df: pd.DataFrame) -> pd.DataFrame:
+    """确保 MultiIndex date 级别是 datetime64，防止 date vs Timestamp 比较 TypeError。"""
+    if df.empty or not isinstance(df.index, pd.MultiIndex):
+        return df
+    date_level = df.index.get_level_values("date")
+    if not pd.api.types.is_datetime64_any_dtype(date_level):
+        df = df.copy()
+        df.index = df.index.set_levels(
+            pd.to_datetime(df.index.levels[0]), level="date",
+        )
+    return df
+
+
+class LocalFactorProvider(FactorProvider):
+    """因子数据 Provider — 整合表达式引擎 + 预计算存储。
+
+    Expression factors: Alpha158 registry → Evaluator 动态计算
+    Precomputed factors: ParquetFactorStore 读取
+
+    名字冲突策略: expression 优先，同名 precomputed 被 shadow。
+    """
+
+    def __init__(self, config: ProviderConfig | None = None) -> None:
+        super().__init__(config)
+        params = self._config.params
+        yaml_path = params.get("expression_config")
+        data_path = params.get("precomputed_path", "data/factors")
+
+        self._alpha158 = Alpha158(
+            yaml_path=Path(yaml_path) if yaml_path else None,
+        )
+        self._parquet = ParquetFactorStore(data_path=data_path)
+        self._data_path = Path(data_path)
+        self._market_data: MarketDataProvider | None = None
+        self._ic_universe: ICUniverse | None = None
+        self._precomputed_index: dict[str, str] = {}  # col_name → group
+        self._precomputed_index_built = False
+
+    # ------ Setter injection ------
+
+    @property
+    def market_data(self) -> MarketDataProvider | None:
+        return self._market_data
+
+    @market_data.setter
+    def market_data(self, provider: MarketDataProvider) -> None:
+        self._market_data = provider
+
+    @property
+    def ic_universe(self) -> ICUniverse | None:
+        return self._ic_universe
+
+    @ic_universe.setter
+    def ic_universe(self, universe: ICUniverse) -> None:
+        self._ic_universe = universe
+
+    # ------ Lifecycle ------
+
+    def _do_initialize(self) -> None:
+        self._ensure_precomputed_index()
+
+    def _do_shutdown(self) -> None:
+        pass
+
+    # ------ FactorProvider interface ------
+
+    def get_factors(
+        self,
+        tickers: list[str],
+        factor_names: list[str],
+        start: date,
+        end: date,
+    ) -> pd.DataFrame:
+        """获取因子数据。
+
+        Expression factors → Alpha158 + Evaluator 动态计算（需要 market_data）。
+        Precomputed factors → ParquetFactorStore 读取。
+        未知 factor name → raise ValueError。
+
+        Returns:
+            MultiIndex DataFrame (date, ticker) x factor_names。
+            列顺序 = factor_names 的传入顺序。
+            混合来源使用 outer join，缺失位置为 NaN。
+        """
+        if not factor_names:
+            idx = pd.MultiIndex.from_tuples([], names=["date", "ticker"])
+            return pd.DataFrame(index=idx)
+
+        self._ensure_precomputed_index()
+
+        # --- 分类 ---
+        expression_names: list[str] = []
+        precomputed_names: list[tuple[str, str]] = []  # (col_name, group)
+        for name in factor_names:
+            if name in self._alpha158:
+                expression_names.append(name)
+            elif name in self._precomputed_index:
+                precomputed_names.append((name, self._precomputed_index[name]))
+            else:
+                raise ValueError(f"Unknown factor: {name!r}")
+
+        results: dict[str, pd.Series] = {}
+
+        # --- Expression factors: batched, single Evaluator ---
+        if expression_names:
+            if self._market_data is None:
+                raise RuntimeError(
+                    "MarketDataProvider not set — required for expression factors"
+                )
+            max_lb = max(
+                self._alpha158.max_lookback(n) for n in expression_names
+            )
+            extended_start = start - timedelta(
+                days=int(max_lb * _CALENDAR_MULTIPLIER),
+            )
+            ohlcv = self._market_data.get_daily_bars(
+                tickers, extended_start, end,
+            )
+            ohlcv = _normalize_date_index(ohlcv)
+
+            if ohlcv.empty:
+                for name in expression_names:
+                    results[name] = pd.Series(
+                        dtype=float, name=name,
+                        index=pd.MultiIndex.from_tuples(
+                            [], names=["date", "ticker"],
+                        ),
+                    )
+            else:
+                ev = Evaluator(ohlcv)
+                for name in expression_names:
+                    raw = ev.evaluate(self._alpha158.get_expression(name))
+                    # Scalar guard: constant-only expressions → broadcast
+                    if not isinstance(raw, pd.Series):
+                        raw = pd.Series(raw, index=ohlcv.index)
+                    results[name] = raw.rename(name)
+
+        # --- Precomputed factors: group-batched read ---
+        if precomputed_names:
+            groups: dict[str, list[str]] = {}
+            for name, group in precomputed_names:
+                groups.setdefault(group, []).append(name)
+
+            for group, cols in groups.items():
+                df = self._parquet.read_factors(
+                    group, tickers=tickers, start=start, end=end,
+                )
+                for col in cols:
+                    if col not in df.columns:
+                        raise ValueError(
+                            f"Factor {col!r} expected in group {group!r} "
+                            f"but not found in data"
+                        )
+                    results[col] = df[col].rename(col)
+
+        if not results:
+            idx = pd.MultiIndex.from_tuples([], names=["date", "ticker"])
+            return pd.DataFrame(index=idx, columns=factor_names)
+
+        # --- Merge + trim + column order ---
+        merged = pd.concat(results.values(), axis=1)
+
+        # Trim expression factors' lookback overshoot to [start, end]
+        dates = merged.index.get_level_values("date")
+        mask = (dates >= pd.Timestamp(start)) & (dates <= pd.Timestamp(end))
+        merged = merged[mask]
+
+        merged = merged[factor_names]
+        merged.sort_index(inplace=True)
+        return merged
+
+    def list_factors(self) -> list[dict[str, str]]:
+        """列出所有可用因子及其类型。
+
+        Expression factors 优先：同名 precomputed 被 shadow，不出现在列表中。
+        """
+        self._ensure_precomputed_index()
+        result: list[dict[str, str]] = []
+        expr_names = set(self._alpha158.list_factor_names())
+
+        for name in self._alpha158.list_factor_names():
+            result.append({"name": name, "type": "expression"})
+
+        for col, group in sorted(self._precomputed_index.items()):
+            if col not in expr_names:
+                result.append(
+                    {"name": col, "type": "precomputed", "group": group},
+                )
+
+        return result
+
+    def get_ic_report(
+        self,
+        factor_name: str,
+        window: int = 252,
+    ) -> dict[str, float]:
+        """返回因子的滚动 IC/ICIR 统计。
+
+        需要 market_data 和 ic_universe 均已设置。
+        shift 固定为 1（单日前向收益）。
+        """
+        if self._market_data is None:
+            raise RuntimeError(
+                "MarketDataProvider not set — required for IC report"
+            )
+        if self._ic_universe is None:
+            raise RuntimeError(
+                "IC universe not configured — "
+                "set ic_universe before calling get_ic_report"
+            )
+
+        self._ensure_precomputed_index()
+        u = self._ic_universe
+        # 多取 shift 天价格数据，供 compute_ic 计算前向收益
+        price_end = u.end + timedelta(days=_IC_SHIFT * _CALENDAR_MULTIPLIER)
+
+        if factor_name in self._alpha158:
+            lookback = self._alpha158.max_lookback(factor_name)
+            extended_start = u.start - timedelta(
+                days=int(lookback * _CALENDAR_MULTIPLIER),
+            )
+            ohlcv = self._market_data.get_daily_bars(
+                u.tickers, extended_start, price_end,
+            )
+            ohlcv = _normalize_date_index(ohlcv)
+
+            if ohlcv.empty:
+                return {
+                    "ic_mean": float("nan"),
+                    "ic_std": float("nan"),
+                    "icir": float("nan"),
+                }
+
+            ev = Evaluator(ohlcv)
+            raw = ev.evaluate(self._alpha158.get_expression(factor_name))
+            if not isinstance(raw, pd.Series):
+                raw = pd.Series(raw, index=ohlcv.index)
+            # Trim factor to universe range (prices keep extended range)
+            dates = raw.index.get_level_values("date")
+            factor_series = raw[
+                (dates >= pd.Timestamp(u.start))
+                & (dates <= pd.Timestamp(u.end))
+            ]
+            prices = ohlcv
+        elif factor_name in self._precomputed_index:
+            group = self._precomputed_index[factor_name]
+            df = self._parquet.read_factors(
+                group, tickers=u.tickers, start=u.start, end=u.end,
+            )
+            if factor_name not in df.columns:
+                raise ValueError(
+                    f"Factor {factor_name!r} not in group {group!r}"
+                )
+            factor_series = df[factor_name]
+            prices = self._market_data.get_daily_bars(
+                u.tickers, u.start, price_end,
+            )
+            prices = _normalize_date_index(prices)
+        else:
+            raise ValueError(f"Unknown factor: {factor_name!r}")
+
+        return compute_ic(factor_series, prices, shift=_IC_SHIFT, window=window)
+
+    # ------ Private helpers ------
+
+    def _ensure_precomputed_index(self) -> None:
+        """Lazy-build precomputed col → group reverse index."""
+        if self._precomputed_index_built:
+            return
+        groups = self._parquet.list_precomputed_factors()
+        if groups:
+            self._precomputed_index = self._build_precomputed_index(groups)
+        self._precomputed_index_built = True
+
+    def _build_precomputed_index(
+        self,
+        groups: list[str],
+    ) -> dict[str, str]:
+        """Read Parquet schema metadata to build col_name → group mapping.
+
+        只读 schema，不加载数据。Index 列 (date, ticker) 被排除。
+        跨 group 的同名列会 log warning，后者覆盖前者。
+        """
+        mapping: dict[str, str] = {}
+        for group in groups:
+            path = self._data_path / f"{group}.parquet"
+            if not path.exists():
+                continue
+            schema = pq.read_schema(path)
+            for name in schema.names:
+                if name in ("date", "ticker"):
+                    continue
+                if name in mapping:
+                    logger.warning(
+                        "Precomputed factor %r exists in both group %r and %r; "
+                        "%r wins",
+                        name, mapping[name], group, group,
+                    )
+                mapping[name] = group
+        return mapping

--- a/src/stockbee/factor_data/parquet_factor.py
+++ b/src/stockbee/factor_data/parquet_factor.py
@@ -8,6 +8,7 @@ Index schema: MultiIndex (date, ticker)
 from __future__ import annotations
 
 import logging
+import uuid
 from datetime import date
 from pathlib import Path
 
@@ -154,10 +155,20 @@ class ParquetFactorStore:
         return self._data_path / f"{group}.parquet"
 
     def _atomic_write(self, df: pd.DataFrame, path: Path) -> None:
-        """Write-then-rename 原子写入（POSIX rename 是原子操作）。"""
-        tmp = path.with_suffix(".parquet.tmp")
-        df.to_parquet(tmp)
-        tmp.rename(path)
+        """Write-then-rename 原子写入（POSIX rename 是原子操作）。
+
+        tmp 文件名带 uuid，避免多进程/多线程同时写同 group 时互相覆盖 tmp。
+        注意：本方法保证单次写入的文件完整性，不是跨进程的 read-modify-write 原子性
+        （并发 write_factors 仍可能丢失更新，需上层协调）。
+        """
+        tmp = path.with_suffix(f".parquet.tmp.{uuid.uuid4().hex}")
+        try:
+            df.to_parquet(tmp)
+            tmp.rename(path)
+        except Exception:
+            if tmp.exists():
+                tmp.unlink(missing_ok=True)
+            raise
 
     def _validate_group(self, group: str) -> None:
         """拒绝空 group 名和包含路径穿越字符的 group 名。"""

--- a/src/stockbee/factor_data/parquet_factor.py
+++ b/src/stockbee/factor_data/parquet_factor.py
@@ -1,0 +1,177 @@
+"""ParquetFactorStore — 预计算因子 Parquet 存储。
+
+按 group 分文件存储预计算因子（fundamental / sentiment / ml_score 等）。
+文件布局: data/factors/{group}.parquet
+Index schema: MultiIndex (date, ticker)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+class ParquetFactorStore:
+    """预计算因子的 Parquet 持久化层。
+
+    每个 group 一个文件：{data_path}/{group}.parquet
+    文件 index: MultiIndex (date, ticker)
+    列: 该 group 内的因子列（factor_name → float）
+
+    设计约束：
+    - 纯 I/O 层，不做列级 schema 验证
+    - merge-write 用 reindex + loc 赋值（新数据完全覆盖重叠格，含 NaN）
+    - data_path 目录在首次写入时创建（不在 __init__ 创建）
+    - list_precomputed_factors() 返回 sorted，顺序确定
+    - 写入使用 write-then-rename 保证原子性
+    """
+
+    def __init__(self, data_path: str | Path = "data/factors") -> None:
+        self._data_path = Path(data_path)
+
+    # ------ 公共接口 ------
+
+    def read_factors(
+        self,
+        group: str,
+        tickers: list[str] | None = None,
+        start: date | None = None,
+        end: date | None = None,
+    ) -> pd.DataFrame:
+        """读取预计算因子。
+
+        Args:
+            group: 数据来源分组名（e.g. "fundamental", "sentiment"）
+            tickers: 过滤的 ticker 列表。None 或 [] 均返回全部 tickers。
+            start: 开始日期（含）。None 表示不过滤下界。
+            end: 结束日期（含）。None 表示不过滤上界。
+
+        Returns:
+            MultiIndex DataFrame (date, ticker) x factors。
+            group 文件不存在时返回空 MultiIndex DataFrame。
+        """
+        self._validate_group(group)
+        path = self._group_path(group)
+
+        if not path.exists():
+            idx = pd.MultiIndex.from_tuples([], names=["date", "ticker"])
+            return pd.DataFrame(index=idx)
+
+        df = pd.read_parquet(path)
+
+        # pyarrow 可能将 datetime.date 级别 round-trip 为 object dtype，
+        # 导致与 pd.Timestamp 比较时 TypeError。统一转为 datetime64。
+        date_level = df.index.get_level_values("date")
+        if not pd.api.types.is_datetime64_any_dtype(date_level):
+            df.index = df.index.set_levels(
+                pd.to_datetime(df.index.levels[0]), level="date"
+            )
+
+        # date 过滤（只在非 None 时过滤，避免 pd.Timestamp(None)=NaT 的静默空结果）
+        if start is not None:
+            mask = df.index.get_level_values("date") >= pd.Timestamp(start)
+            df = df[mask]
+        if end is not None:
+            mask = df.index.get_level_values("date") <= pd.Timestamp(end)
+            df = df[mask]
+
+        # ticker 过滤：None = 不过滤；[] = 不过滤（与 None 等价）
+        if tickers is not None and len(tickers) > 0:
+            mask = df.index.get_level_values("ticker").isin(tickers)
+            df = df[mask]
+
+        return df
+
+    def write_factors(self, group: str, df: pd.DataFrame) -> None:
+        """写入/合并预计算因子到 Parquet。
+
+        merge 策略：reindex 扩展 + .loc 直接赋值
+        - 保留旧数据中已有但新数据没有的行/列
+        - 新数据完全覆盖重叠的 (date, ticker, column) 格，包括 NaN
+
+        写入使用 write-then-rename 保证单次写入的原子性。
+
+        Args:
+            group: 数据来源分组名
+            df: MultiIndex (date, ticker) x factors DataFrame
+
+        Raises:
+            ValueError: df 为空（0行）
+            ValueError: df 不是 MultiIndex 或 index names 不是 ["date", "ticker"]
+            ValueError: group 名包含非法字符（路径穿越防护）
+        """
+        self._validate_group(group)
+        self._validate_write_df(df)
+
+        if df.empty:
+            logger.debug("Skipping write of empty DataFrame for group %r", group)
+            return
+
+        self._data_path.mkdir(parents=True, exist_ok=True)
+        path = self._group_path(group)
+
+        if path.exists():
+            existing = pd.read_parquet(path)
+            # 扩展到两者的行/列 union
+            all_idx = existing.index.union(df.index)
+            all_cols = existing.columns.union(df.columns)
+            combined = existing.reindex(index=all_idx, columns=all_cols)
+            # 新数据完全覆盖：.loc 赋值是无条件的，NaN 也会写入
+            combined.loc[df.index, df.columns] = df
+            combined.sort_index(inplace=True)
+            self._atomic_write(combined, path)
+            logger.debug(
+                "Updated factor group %r: %d rows, %d cols",
+                group, len(combined), len(combined.columns),
+            )
+        else:
+            df_out = df.copy()
+            df_out.sort_index(inplace=True)
+            self._atomic_write(df_out, path)
+            logger.debug(
+                "Created factor group %r: %d rows, %d cols",
+                group, len(df_out), len(df_out.columns),
+            )
+
+    def list_precomputed_factors(self) -> list[str]:
+        """返回所有已存储的 group 名列表（sorted，顺序确定）。
+
+        Returns:
+            Parquet 文件 stem 列表，e.g. ["fundamental", "ml_score", "sentiment"]
+        """
+        if not self._data_path.exists():
+            return []
+        return sorted(p.stem for p in self._data_path.glob("*.parquet"))
+
+    # ------ 私有方法 ------
+
+    def _group_path(self, group: str) -> Path:
+        return self._data_path / f"{group}.parquet"
+
+    def _atomic_write(self, df: pd.DataFrame, path: Path) -> None:
+        """Write-then-rename 原子写入（POSIX rename 是原子操作）。"""
+        tmp = path.with_suffix(".parquet.tmp")
+        df.to_parquet(tmp)
+        tmp.rename(path)
+
+    def _validate_group(self, group: str) -> None:
+        """拒绝空 group 名和包含路径穿越字符的 group 名。"""
+        if not group or "/" in group or "\\" in group or ".." in group:
+            raise ValueError(f"Invalid group name: {group!r}")
+
+    def _validate_write_df(self, df: pd.DataFrame) -> None:
+        """确保写入的 df 有正确的 MultiIndex (date, ticker)。"""
+        if not isinstance(df.index, pd.MultiIndex):
+            raise ValueError(
+                "df must have MultiIndex (date, ticker), "
+                f"got {type(df.index).__name__}"
+            )
+        if list(df.index.names) != ["date", "ticker"]:
+            raise ValueError(
+                f"MultiIndex names must be ['date', 'ticker'], got {list(df.index.names)}"
+            )

--- a/tests/test_factor_data.py
+++ b/tests/test_factor_data.py
@@ -1104,3 +1104,146 @@ class TestCorrelation:
         assert result.index.nlevels == 2
         # 必须能与 panel index 完全对齐（不多不少）
         assert set(result.index) == set(panel.index)
+
+
+# ===========================================================================
+# m2 — 横截面函数（RANK / QUANTILE）+ element-wise IF
+# ===========================================================================
+#
+# Panel 设计确保两 ticker 每日可比：
+#   AAA adj_close = 2, 4, ..., 20 （递增）
+#   BBB adj_close = 40, 38, ..., 22（递减）
+# Day 0: AAA=2  BBB=40 → AAA rank=0.5, BBB rank=1.0（BBB 大）
+# Day 9: AAA=20 BBB=22 → AAA rank=0.5, BBB rank=1.0（BBB 仍大）
+# BBB adj_close 始终 > AAA → BBB rank=1.0, AAA rank=0.5，每日恒定。
+# ---------------------------------------------------------------------------
+
+
+class TestCrossSectionRank:
+    def test_rank_cross_section_two_tickers(self, panel):
+        """BBB adj_close 每日都大于 AAA → BBB rank=1.0, AAA rank=0.5。"""
+        result = evaluate(parse("RANK($close)"), panel)
+        aaa = _aaa(result)
+        bbb = _bbb(result)
+        # pct=True + 2 个 ticker → 小的=0.5, 大的=1.0
+        assert aaa.to_numpy() == pytest.approx([0.5] * 10)
+        assert bbb.to_numpy() == pytest.approx([1.0] * 10)
+
+    def test_rank_single_ticker_date(self):
+        """单 ticker 退化：每日只有一个值 → rank=1.0（不 NaN 不崩）。"""
+        df = pd.DataFrame(
+            {"open": [1.0, 2.0], "high": [1.5, 2.5], "low": [0.5, 1.5],
+             "close": [1.0, 2.0], "adj_close": [1.0, 2.0], "volume": [100, 200]},
+            index=pd.MultiIndex.from_tuples(
+                [(pd.Timestamp("2024-01-01"), "AAA"),
+                 (pd.Timestamp("2024-01-02"), "AAA")],
+                names=["date", "ticker"],
+            ),
+        )
+        result = evaluate(parse("RANK($close)"), df)
+        assert result.to_numpy() == pytest.approx([1.0, 1.0])
+
+    def test_rank_nan_input(self, panel):
+        """NaN 输入保留 NaN（pandas rank 默认 na_option='keep'）。
+        构造：LOG(0) = -inf（numpy 警告忽略），LOG(-1) = NaN。这里用 REF 制造前缀 NaN。"""
+        result = evaluate(parse("RANK(REF($close, 3))"), panel)
+        # 前 3 行 REF 是 NaN，因此 RANK 也应是 NaN
+        aaa = _aaa(result)
+        assert aaa.iloc[:3].isna().all()
+        # 第 3 行起有值（两 ticker 都能参与排序）
+        assert not aaa.iloc[3:].isna().any()
+
+
+class TestCrossSectionQuantile:
+    def test_quantile_median_broadcast(self, panel):
+        """q=0.5 两 ticker → 每日返回两值中位数，AAA/BBB 同值。
+        Day 0: median(2, 40) = 21.0  （adj_close 空间）
+        Day 9: median(20, 22) = 21.0
+        """
+        result = evaluate(parse("QUANTILE($close, 0.5)"), panel)
+        # 两 ticker 同一日期应得到相同值（广播）
+        for date in _DATES:
+            aaa_val = result.loc[(date, "AAA")]
+            bbb_val = result.loc[(date, "BBB")]
+            assert aaa_val == pytest.approx(bbb_val)
+        # 第 0 天中位数
+        assert result.loc[(_DATES[0], "AAA")] == pytest.approx(21.0)
+
+    def test_quantile_multiindex_shape(self, panel):
+        """QUANTILE 输出 index 与 panel.index 完全一致（shape preservation via transform）。"""
+        result = evaluate(parse("QUANTILE($close, 0.5)"), panel)
+        assert isinstance(result.index, pd.MultiIndex)
+        assert set(result.index) == set(panel.index)
+        assert len(result) == len(panel)
+
+    def test_quantile_usable_in_if_predicate(self, panel):
+        """QUANTILE 广播语义的意义：允许 IF($close > QUANTILE($close, 0.5), ...)。"""
+        result = evaluate(
+            parse("IF($close > QUANTILE($close, 0.5), 1, 0)"),
+            panel,
+        )
+        # BBB 每日都高于中位数 → 1，AAA 每日都低于中位数 → 0
+        assert _bbb(result).to_numpy() == pytest.approx([1] * 10)
+        assert _aaa(result).to_numpy() == pytest.approx([0] * 10)
+
+
+class TestIfFunction:
+    def test_if_series_cond_series_branches(self, panel):
+        """IF(Series, Series, Series) → 按 cond 逐点挑选。
+        $close > $open 恒为 True（open=close-0.5）→ 全部取 $close。"""
+        result = evaluate(parse("IF($close > $open, $close, $open)"), panel)
+        pd.testing.assert_series_equal(
+            result.sort_index(),
+            panel["adj_close"].sort_index(),
+            check_names=False,
+        )
+
+    def test_if_series_cond_scalar_branches(self, panel):
+        """IF(Series, scalar, scalar) → 全 1（cond 恒 True）。"""
+        result = evaluate(parse("IF($close > $open, 1, -1)"), panel)
+        assert result.to_numpy() == pytest.approx([1] * 20)
+
+    def test_if_scalar_cond_scalar_branches(self, panel):
+        """IF(scalar, scalar, scalar) → 纯标量路径，返回原生数字。"""
+        result = evaluate(parse("IF(1 > 0, 42, -1)"), panel)
+        assert result == 42
+        result2 = evaluate(parse("IF(0 > 1, 42, -1)"), panel)
+        assert result2 == -1
+
+    def test_if_scalar_cond_series_branches(self, panel):
+        """IF(scalar, Series, Series) → 标量 cond 直接选分支（返回整条 Series）。"""
+        result = evaluate(parse("IF(1 > 0, $close, $open)"), panel)
+        # cond 为 True → 返回 $close = adj_close
+        pd.testing.assert_series_equal(
+            result.sort_index(),
+            panel["adj_close"].sort_index(),
+            check_names=False,
+        )
+
+
+class TestAdvancedIntegration:
+    def test_nested_ma_slope(self, panel):
+        """MA(SLOPE($close, 5), 3) — 验证 SLOPE 输出可嵌入另一个 rolling。
+        线性 panel 下 SLOPE=2.0（AAA）/ -2.0（BBB），再 MA(.,3) 仍 = ±2.0。"""
+        result = evaluate(parse("MA(SLOPE($close, 5), 3)"), panel)
+        aaa = _aaa(result)
+        bbb = _bbb(result)
+        # SLOPE 前 4 行 NaN，再 MA 需要 3 行有效 → 前 4+2=6 行 NaN
+        assert aaa.iloc[:6].isna().all()
+        assert aaa.iloc[6:].to_numpy() == pytest.approx([2.0] * 4)
+        assert bbb.iloc[6:].to_numpy() == pytest.approx([-2.0] * 4)
+
+    def test_nested_ma_slope_lookback(self):
+        """nested lookback：MA(SLOPE($close,5),3) = 5+3 = 8（嵌套相加）。"""
+        assert parse("MA(SLOPE($close, 5), 3)").lookback() == 8
+
+    def test_m2_impls_all_registered(self):
+        """契约冒烟：m2 的 10 个函数必须全部有 impl 注册。"""
+        m2_funcs = (
+            "EMA", "SLOPE", "RSQUARE", "RESI", "CORR",
+            "RANK", "QUANTILE", "IF", "IDXMAX", "IDXMIN",
+        )
+        for name in m2_funcs:
+            assert _REGISTRY[name].impl is not None, (
+                f"m2 函数 {name} 缺少 impl 注册"
+            )

--- a/tests/test_factor_data.py
+++ b/tests/test_factor_data.py
@@ -1247,3 +1247,99 @@ class TestAdvancedIntegration:
             assert _REGISTRY[name].impl is not None, (
                 f"m2 函数 {name} 缺少 impl 注册"
             )
+
+
+# ===========================================================================
+# m3 — 时序滚动 TS_RANK / TS_QUANTILE
+# ===========================================================================
+
+class TestTsRank:
+    def test_monotonic_increasing_rank_1(self, panel):
+        """AAA close 递增 → 最后一行 rolling rank 应为 1.0 (最高百分位)。"""
+        result = evaluate(parse("TS_RANK($close, 5)"), panel)
+        aaa = _aaa(result)
+        assert np.isnan(aaa.iloc[3])
+        assert aaa.iloc[9] == pytest.approx(1.0)
+
+    def test_monotonic_decreasing_rank(self, panel):
+        """BBB close 递减 → 当前值总是窗口最小，rolling rank 应为最低百分位。"""
+        result = evaluate(parse("TS_RANK($close, 5)"), panel)
+        bbb = _bbb(result)
+        for i in range(4, 10):
+            assert bbb.iloc[i] == pytest.approx(1.0 / 5.0), f"row {i}"
+
+    def test_min_periods_respected(self, panel):
+        """窗口不满 → NaN (min_periods=window)。"""
+        result = evaluate(parse("TS_RANK($close, 5)"), panel)
+        aaa = _aaa(result)
+        for i in range(4):
+            assert np.isnan(aaa.iloc[i])
+
+    def test_ties_average(self, panel):
+        """Ties 用 average 策略（pandas 默认）。构造全等值窗口。"""
+        idx = pd.MultiIndex.from_arrays(
+            [pd.date_range("2024-01-01", periods=5, freq="D"), ["X"] * 5],
+            names=["date", "ticker"],
+        )
+        p = pd.DataFrame({"adj_close": [1.0, 1.0, 1.0, 1.0, 1.0]}, index=idx)
+        result = evaluate(parse("TS_RANK($close, 3)"), p)
+        assert result.iloc[4] == pytest.approx(2.0 / 3.0, abs=0.01)
+
+    def test_ticker_isolation(self, panel):
+        """TS_RANK 不跨 ticker 串数据。"""
+        result = evaluate(parse("TS_RANK($close, 5)"), panel)
+        assert result.index.equals(panel.sort_index().index)
+
+    def test_lookback(self):
+        ast = parse("TS_RANK($close, 10)")
+        assert ast.lookback() == 10
+
+    def test_min_window_validation(self):
+        with pytest.raises(ParseError):
+            parse("TS_RANK($close, 1)")
+
+
+class TestTsQuantile:
+    def test_q08_monotonic(self, panel):
+        """AAA close 递增 → TS_QUANTILE($close, 5, 0.8) 应接近窗口第4大值。"""
+        result = evaluate(parse("TS_QUANTILE($close, 5, 0.8)"), panel)
+        aaa = _aaa(result)
+        assert np.isnan(aaa.iloc[3])
+        assert aaa.iloc[4] == pytest.approx(
+            pd.Series([2.0, 4.0, 6.0, 8.0, 10.0]).quantile(0.8), abs=0.01
+        )
+
+    def test_q0_returns_min(self, panel):
+        result = evaluate(parse("TS_QUANTILE($close, 5, 0)"), panel)
+        aaa = _aaa(result)
+        assert aaa.iloc[4] == pytest.approx(2.0)
+
+    def test_q1_returns_max(self, panel):
+        result = evaluate(parse("TS_QUANTILE($close, 5, 1)"), panel)
+        aaa = _aaa(result)
+        assert aaa.iloc[4] == pytest.approx(10.0)
+
+    def test_q_validation_range(self):
+        with pytest.raises(ParseError):
+            parse("TS_QUANTILE($close, 5, 1.5)")
+        with pytest.raises(ParseError):
+            parse("TS_QUANTILE($close, 5, -0.1)")
+
+    def test_min_window_validation(self):
+        with pytest.raises(ParseError):
+            parse("TS_QUANTILE($close, 1, 0.5)")
+
+    def test_lookback(self):
+        ast = parse("TS_QUANTILE($close, 20, 0.8)")
+        assert ast.lookback() == 20
+
+    def test_nested_lookback(self):
+        ast = parse("TS_QUANTILE(REF($close, 3), 10, 0.5)")
+        assert ast.lookback() == 13
+
+    def test_m3_ts_impls_registered(self):
+        """契约冒烟：m3 的 TS_RANK / TS_QUANTILE 必须有 impl 注册。"""
+        for name in ("TS_RANK", "TS_QUANTILE"):
+            assert _REGISTRY[name].impl is not None, (
+                f"m3 函数 {name} 缺少 impl 注册"
+            )

--- a/tests/test_factor_data.py
+++ b/tests/test_factor_data.py
@@ -1607,3 +1607,214 @@ class TestAlpha158EvalSmoke:
         ev = Evaluator(p)
         with pytest.raises(ExpressionError, match="vwap"):
             ev.evaluate(alpha.get_expression("VWAP0"))
+
+
+# ---------------------------------------------------------------------------
+# m4: ParquetFactorStore
+# ---------------------------------------------------------------------------
+
+from stockbee.factor_data.parquet_factor import ParquetFactorStore
+from datetime import date as _date
+
+
+def _make_factor_df(
+    tickers: list[str],
+    dates: list[str],
+    columns: dict[str, list[float]] | None = None,
+) -> pd.DataFrame:
+    """构造 MultiIndex (date, ticker) 因子 DataFrame 的测试辅助函数。"""
+    idx_tuples = [
+        (pd.Timestamp(d), t)
+        for d in dates
+        for t in tickers
+    ]
+    idx = pd.MultiIndex.from_tuples(idx_tuples, names=["date", "ticker"])
+    n = len(idx_tuples)
+    if columns is None:
+        columns = {"factor_a": list(range(n))}
+    data = {k: v for k, v in columns.items()}
+    return pd.DataFrame(data, index=idx, dtype=float)
+
+
+class TestParquetFactorStore:
+    """m4: 预计算因子 Parquet 存储。"""
+
+    def test_write_and_read_roundtrip(self, tmp_path):
+        """write → read，shape 和值完全一致。"""
+        store = ParquetFactorStore(tmp_path)
+        df = _make_factor_df(["AAPL", "TSLA"], ["2024-01-01", "2024-01-02"])
+        store.write_factors("fundamental", df)
+        result = store.read_factors("fundamental")
+        pd.testing.assert_frame_equal(result.sort_index(), df.sort_index())
+
+    def test_read_filter_tickers(self, tmp_path):
+        """write 2 tickers，read 只请求 1，返回只含该 ticker。"""
+        store = ParquetFactorStore(tmp_path)
+        df = _make_factor_df(["AAPL", "TSLA"], ["2024-01-01"])
+        store.write_factors("fundamental", df)
+        result = store.read_factors("fundamental", tickers=["AAPL"])
+        assert list(result.index.get_level_values("ticker").unique()) == ["AAPL"]
+        assert len(result) == 1
+
+    def test_read_filter_date_range(self, tmp_path):
+        """write 10 天，read [3,7]，返回 5 行（每天 1 ticker）。"""
+        store = ParquetFactorStore(tmp_path)
+        dates = [f"2024-01-{d:02d}" for d in range(1, 11)]
+        df = _make_factor_df(["AAPL"], dates)
+        store.write_factors("fundamental", df)
+        result = store.read_factors(
+            "fundamental",
+            start=_date(2024, 1, 3),
+            end=_date(2024, 1, 7),
+        )
+        assert len(result) == 5
+        dates_out = result.index.get_level_values("date")
+        assert dates_out.min() == pd.Timestamp("2024-01-03")
+        assert dates_out.max() == pd.Timestamp("2024-01-07")
+
+    def test_merge_write_dedup_new_wins(self, tmp_path):
+        """同 (date, ticker) 写两次，第二次值覆盖第一次。"""
+        store = ParquetFactorStore(tmp_path)
+        df1 = _make_factor_df(["AAPL"], ["2024-01-01"], {"factor_a": [1.0]})
+        df2 = _make_factor_df(["AAPL"], ["2024-01-01"], {"factor_a": [99.0]})
+        store.write_factors("fundamental", df1)
+        store.write_factors("fundamental", df2)
+        result = store.read_factors("fundamental")
+        assert result.loc[(pd.Timestamp("2024-01-01"), "AAPL"), "factor_a"] == 99.0
+        assert len(result) == 1
+
+    def test_merge_write_new_columns_preserves_old(self, tmp_path):
+        """第二次 write 加新列；旧列值也保留（不被丢弃）。"""
+        store = ParquetFactorStore(tmp_path)
+        df1 = _make_factor_df(["AAPL"], ["2024-01-01"], {"factor_a": [1.0]})
+        df2 = _make_factor_df(["AAPL"], ["2024-01-01"], {"factor_b": [2.0]})
+        store.write_factors("fundamental", df1)
+        store.write_factors("fundamental", df2)
+        result = store.read_factors("fundamental")
+        # 两列都应存在
+        assert "factor_a" in result.columns
+        assert "factor_b" in result.columns
+        # 旧值也保留
+        assert result.loc[(pd.Timestamp("2024-01-01"), "AAPL"), "factor_a"] == 1.0
+        assert result.loc[(pd.Timestamp("2024-01-01"), "AAPL"), "factor_b"] == 2.0
+
+    def test_read_missing_group_returns_empty(self, tmp_path):
+        """请求不存在的 group → 空 MultiIndex DataFrame，names 正确。"""
+        store = ParquetFactorStore(tmp_path)
+        result = store.read_factors("nonexistent")
+        assert isinstance(result.index, pd.MultiIndex)
+        assert list(result.index.names) == ["date", "ticker"]
+        assert len(result) == 0
+
+    def test_list_precomputed_factors_sorted(self, tmp_path):
+        """write 多个 groups → list 返回 sorted stems，顺序确定。"""
+        store = ParquetFactorStore(tmp_path)
+        df = _make_factor_df(["AAPL"], ["2024-01-01"])
+        store.write_factors("sentiment", df)
+        store.write_factors("fundamental", df)
+        store.write_factors("ml_score", df)
+        result = store.list_precomputed_factors()
+        assert result == sorted(result)
+        assert set(result) == {"fundamental", "ml_score", "sentiment"}
+
+    def test_read_none_tickers_returns_all(self, tmp_path):
+        """tickers=None → 返回全部 tickers（不过滤）。"""
+        store = ParquetFactorStore(tmp_path)
+        df = _make_factor_df(["AAPL", "TSLA", "GOOG"], ["2024-01-01"])
+        store.write_factors("fundamental", df)
+        result = store.read_factors("fundamental", tickers=None)
+        assert len(result) == 3
+
+    def test_read_empty_tickers_list_returns_all(self, tmp_path):
+        """tickers=[] → 与 tickers=None 行为相同，返回全部。"""
+        store = ParquetFactorStore(tmp_path)
+        df = _make_factor_df(["AAPL", "TSLA"], ["2024-01-01"])
+        store.write_factors("fundamental", df)
+        result = store.read_factors("fundamental", tickers=[])
+        assert len(result) == 2
+
+    def test_read_none_start_end_returns_all_dates(self, tmp_path):
+        """start=None, end=None → 返回全量日期，不截断。"""
+        store = ParquetFactorStore(tmp_path)
+        dates = ["2024-01-01", "2024-06-15", "2024-12-31"]
+        df = _make_factor_df(["AAPL"], dates)
+        store.write_factors("fundamental", df)
+        result = store.read_factors("fundamental", start=None, end=None)
+        assert len(result) == 3
+
+    def test_write_invalid_index_raises(self, tmp_path):
+        """非 MultiIndex df → ValueError。"""
+        store = ParquetFactorStore(tmp_path)
+        df = pd.DataFrame({"factor_a": [1.0, 2.0]}, index=pd.date_range("2024-01-01", periods=2))
+        with pytest.raises(ValueError, match="MultiIndex"):
+            store.write_factors("fundamental", df)
+
+    def test_write_wrong_index_names_raises(self, tmp_path):
+        """MultiIndex 但 names 不是 ['date', 'ticker'] → ValueError。"""
+        store = ParquetFactorStore(tmp_path)
+        idx = pd.MultiIndex.from_tuples(
+            [(pd.Timestamp("2024-01-01"), "AAPL")],
+            names=["timestamp", "symbol"],  # 错误的 names
+        )
+        df = pd.DataFrame({"factor_a": [1.0]}, index=idx)
+        with pytest.raises(ValueError, match="names must be"):
+            store.write_factors("fundamental", df)
+
+    def test_invalid_group_name_raises(self, tmp_path):
+        """包含路径穿越字符的 group 名 → ValueError。"""
+        store = ParquetFactorStore(tmp_path)
+        df = _make_factor_df(["AAPL"], ["2024-01-01"])
+        with pytest.raises(ValueError, match="Invalid group name"):
+            store.write_factors("../evil", df)
+        with pytest.raises(ValueError, match="Invalid group name"):
+            store.read_factors("../evil")
+        with pytest.raises(ValueError, match="Invalid group name"):
+            store.write_factors("", df)
+        # backslash（Windows 路径穿越）
+        with pytest.raises(ValueError, match="Invalid group name"):
+            store.write_factors("..\\evil", df)
+
+    # --- v3 新增：review 发现的 corner case ---
+
+    def test_merge_write_nan_overwrites_existing(self, tmp_path):
+        """新写入的 NaN 必须覆盖旧的非 NaN 值（新数据无条件胜出）。"""
+        store = ParquetFactorStore(tmp_path)
+        df1 = _make_factor_df(["AAPL"], ["2024-01-01"], {"factor_a": [1.0]})
+        df2 = _make_factor_df(["AAPL"], ["2024-01-01"], {"factor_a": [float("nan")]})
+        store.write_factors("fundamental", df1)
+        store.write_factors("fundamental", df2)
+        result = store.read_factors("fundamental")
+        assert pd.isna(result.loc[(pd.Timestamp("2024-01-01"), "AAPL"), "factor_a"])
+
+    def test_read_unknown_ticker_returns_empty(self, tmp_path):
+        """请求存在的 group 但不存在的 ticker → 空 DataFrame。"""
+        store = ParquetFactorStore(tmp_path)
+        df = _make_factor_df(["AAPL"], ["2024-01-01"])
+        store.write_factors("fundamental", df)
+        result = store.read_factors("fundamental", tickers=["UNKNOWN"])
+        assert len(result) == 0
+        assert isinstance(result.index, pd.MultiIndex)
+
+    def test_read_start_equals_end_single_day(self, tmp_path):
+        """start == end → 只返回该日的数据。"""
+        store = ParquetFactorStore(tmp_path)
+        dates = ["2024-01-01", "2024-01-02", "2024-01-03"]
+        df = _make_factor_df(["AAPL"], dates)
+        store.write_factors("fundamental", df)
+        result = store.read_factors(
+            "fundamental",
+            start=_date(2024, 1, 2),
+            end=_date(2024, 1, 2),
+        )
+        assert len(result) == 1
+        assert result.index.get_level_values("date")[0] == pd.Timestamp("2024-01-02")
+
+    def test_write_empty_df_skipped(self, tmp_path):
+        """写入空 DataFrame（0行）不创建文件。"""
+        store = ParquetFactorStore(tmp_path)
+        idx = pd.MultiIndex.from_tuples([], names=["date", "ticker"])
+        df = pd.DataFrame({"factor_a": pd.Series(dtype=float)}, index=idx)
+        store.write_factors("fundamental", df)
+        # 文件不应被创建
+        assert not (tmp_path / "fundamental.parquet").exists()
+        assert store.list_precomputed_factors() == []

--- a/tests/test_factor_data.py
+++ b/tests/test_factor_data.py
@@ -1058,3 +1058,49 @@ class TestIdxMaxMin:
         result = evaluate(parse("IDXMAX($close, 1)"), panel)
         # 每个窗口只有一个元素 → argmax = 0
         assert _aaa(result).to_numpy() == pytest.approx([0.0] * 10)
+
+
+# ===========================================================================
+# m2 — CORR（per-ticker rolling 相关系数）
+# ===========================================================================
+
+class TestCorrelation:
+    def test_corr_identical_series(self, panel):
+        """CORR($close, $close, 5) ≈ 1.0（恒等相关）。"""
+        result = evaluate(parse("CORR($close, $close, 5)"), panel)
+        aaa = _aaa(result)
+        assert aaa.iloc[:4].isna().all()
+        assert aaa.iloc[4:].to_numpy() == pytest.approx([1.0] * 6, abs=1e-10)
+
+    def test_corr_anti_correlated(self, panel):
+        """CORR($close, -$close, 5) = -1.0（完美反相关）。"""
+        result = evaluate(parse("CORR($close, -$close, 5)"), panel)
+        aaa = _aaa(result)
+        assert aaa.iloc[4:].to_numpy() == pytest.approx([-1.0] * 6, abs=1e-10)
+
+    def test_corr_constant_series_nan(self, panel):
+        """恒定序列 → var=0 → 除零 → NaN，不应抛异常。"""
+        # 构造一个恒定为 1 的 Series：$close - $close + 1
+        result = evaluate(parse("CORR($close - $close + 1, $close, 5)"), panel)
+        aaa = _aaa(result)
+        # 窗口填满后所有位置应为 NaN（不是值也不是崩溃）
+        assert aaa.iloc[4:].isna().all()
+
+    def test_corr_ticker_isolation(self, panel):
+        """CORR 在每 ticker 内独立计算，不跨 ticker 串。
+        AAA close 与 volume 完全线性相关 → 1.0；BBB 两列也线性相关 → 1.0。"""
+        result = evaluate(parse("CORR($close, $volume, 5)"), panel)
+        aaa = _aaa(result).iloc[4:]
+        bbb = _bbb(result).iloc[4:]
+        # AAA close=1..10 递增，volume=100..1000 递增 → 线性相关
+        assert aaa.to_numpy() == pytest.approx([1.0] * 6, abs=1e-10)
+        # BBB close=20..11 递减，volume=200..2000 递增 → 反相关
+        assert bbb.to_numpy() == pytest.approx([-1.0] * 6, abs=1e-10)
+
+    def test_corr_output_index_matches_panel(self, panel):
+        """CORR 输出 index 必须与 panel.index 完全对齐（droplevel + reindex 防御）。"""
+        result = evaluate(parse("CORR($close, $open, 5)"), panel)
+        assert isinstance(result.index, pd.MultiIndex)
+        assert result.index.nlevels == 2
+        # 必须能与 panel index 完全对齐（不多不少）
+        assert set(result.index) == set(panel.index)

--- a/tests/test_factor_data.py
+++ b/tests/test_factor_data.py
@@ -804,3 +804,53 @@ class TestMaxMinScalarConstants:
         result = evaluate(parse("MAX($close, 3)"), panel)
         # 之前已经验证过的数值，必须依然正确
         assert _aaa(result).iloc[2] == pytest.approx(6.0)
+
+
+# ===========================================================================
+# m2 — 最小窗口校验（FunctionSpec.min_window）
+# ===========================================================================
+#
+# SLOPE/RSQUARE/RESI/CORR/EMA 的 n=1 数学上退化（OLS 分母为 0，EMA α=1 不平滑），
+# _validate_function_args 必须在 parse 阶段就 raise，不能让 n=1 流到 Evaluator。
+# m1b 的 REF/MA/STD/SUM/DELTA/IDXMAX/IDXMIN 仍保持 min_window=1。
+# ---------------------------------------------------------------------------
+
+class TestMinWindowValidation:
+    def test_slope_n1_rejected(self):
+        """SLOPE 要求 min_window=2，n=1 → ParseError。"""
+        with pytest.raises(ParseError, match="≥2"):
+            parse("SLOPE($close, 1)")
+
+    def test_ema_n1_rejected(self):
+        """EMA 要求 min_window=2。"""
+        with pytest.raises(ParseError, match="≥2"):
+            parse("EMA($close, 1)")
+
+    def test_corr_n1_rejected(self):
+        """CORR 要求 min_window=2。"""
+        with pytest.raises(ParseError, match="≥2"):
+            parse("CORR($close, $open, 1)")
+
+    def test_rsquare_n1_rejected(self):
+        with pytest.raises(ParseError, match="≥2"):
+            parse("RSQUARE($close, 1)")
+
+    def test_resi_n1_rejected(self):
+        with pytest.raises(ParseError, match="≥2"):
+            parse("RESI($close, 1)")
+
+    def test_ma_n1_still_allowed(self):
+        """m1b 函数 min_window=1 保持不变，不应被本次改动破坏。"""
+        # 不抛异常即通过
+        parse("MA($close, 1)")
+        parse("REF($close, 1)")
+
+    def test_idxmax_n1_allowed(self):
+        """IDXMAX 保持 min_window=1（单元素窗口 argmax=0 合法）。"""
+        parse("IDXMAX($close, 1)")
+
+    def test_min_window_field_exists_on_spec(self):
+        """契约测试：FunctionSpec 必须暴露 min_window 字段。"""
+        assert _REGISTRY["SLOPE"].min_window == 2
+        assert _REGISTRY["MA"].min_window == 1
+        assert _REGISTRY["CORR"].min_window == 2

--- a/tests/test_factor_data.py
+++ b/tests/test_factor_data.py
@@ -1567,3 +1567,43 @@ class TestAlpha158EvalSmoke:
         result = ev.evaluate(alpha.get_expression("WVMA60"))
         aaa = result.xs("AAA", level="ticker").sort_index()
         assert not aaa.iloc[-1:].isna().all()
+
+    def test_157_evaluate_without_vwap(self, alpha):
+        """无 vwap 列的 panel 上 157 因子（排除 VWAP0）全部正常。
+
+        真实数据源 OHLCV_FIELDS 不含 vwap，VWAP0 是可选因子。
+        此测试验证其余 157 个因子不依赖 vwap 列。
+        """
+        rows = []
+        for ticker, base_close in (("AAA", 50.0), ("BBB", 100.0)):
+            for i, date in enumerate(_EVAL_DATES):
+                c = base_close + i * 0.5
+                rows.append({
+                    "date": date, "ticker": ticker,
+                    "open": c - 0.3, "high": c + 0.8, "low": c - 0.6,
+                    "close": c, "adj_close": c * 1.5,
+                    "volume": 1000.0 + i * 10.0,
+                })
+        no_vwap_panel = pd.DataFrame(rows).set_index(["date", "ticker"]).sort_index()
+        ev = Evaluator(no_vwap_panel)
+        non_vwap_factors = [n for n in alpha.list_factor_names() if n != "VWAP0"]
+        assert len(non_vwap_factors) == 157
+        for name in non_vwap_factors:
+            ast = alpha.get_expression(name)
+            result = ev.evaluate(ast)
+            assert isinstance(result, pd.Series), f"{name} failed without vwap"
+
+    def test_vwap0_raises_without_vwap(self, alpha):
+        """无 vwap 列时 VWAP0 应 raise ExpressionError。"""
+        idx = pd.MultiIndex.from_arrays(
+            [pd.date_range("2024-01-01", periods=3, freq="D"), ["X"] * 3],
+            names=["date", "ticker"],
+        )
+        p = pd.DataFrame({
+            "open": [1.0, 2.0, 3.0], "high": [1.5, 2.5, 3.5],
+            "low": [0.5, 1.5, 2.5], "adj_close": [1.0, 2.0, 3.0],
+            "volume": [100.0, 200.0, 300.0],
+        }, index=idx)
+        ev = Evaluator(p)
+        with pytest.raises(ExpressionError, match="vwap"):
+            ev.evaluate(alpha.get_expression("VWAP0"))

--- a/tests/test_factor_data.py
+++ b/tests/test_factor_data.py
@@ -2039,11 +2039,450 @@ class TestICEvaluator:
         result = compute(factor_df, prices_df, shift=1)
         assert math.isnan(result["ic_mean"])
 
-    def test_duplicate_index_raises(self):
+    def test_duplicate_prices_index_raises(self):
         """prices_df 有重复 (date, ticker) 行 → ValueError。"""
         prices_df, fwd_ret = _make_ic_data(n_tickers=3, n_dates=30)
-        # 人为制造重复行
         dup_prices = pd.concat([prices_df, prices_df.iloc[:3]])
         factor_df = pd.DataFrame({"f": fwd_ret}, index=fwd_ret.index).dropna()
         with pytest.raises(ValueError, match="duplicate"):
             compute(factor_df, dup_prices)
+
+    def test_duplicate_factor_index_raises(self):
+        """factor_df 有重复 (date, ticker) 行 → ValueError。"""
+        prices_df, fwd_ret = _make_ic_data(n_tickers=3, n_dates=30)
+        factor_df = pd.DataFrame({"f": fwd_ret}, index=fwd_ret.index).dropna()
+        dup_factor = pd.concat([factor_df, factor_df.iloc[:3]])
+        with pytest.raises(ValueError, match="duplicate"):
+            compute(dup_factor, prices_df)
+
+
+# ===========================================================================
+# m6: LocalFactorProvider + Module Exports
+# ===========================================================================
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+from stockbee.factor_data import ICUniverse, LocalFactorProvider
+from stockbee.factor_data.local_provider import _normalize_date_index
+from stockbee.factor_data.parquet_factor import ParquetFactorStore
+from stockbee.providers.base import ProviderConfig
+
+
+def _make_ohlcv(
+    tickers: list[str],
+    start: str,
+    n_days: int = 60,
+) -> pd.DataFrame:
+    """合成 OHLCV MultiIndex (date, ticker) DataFrame。含 adj_close。"""
+    rng = np.random.default_rng(42)
+    dates = pd.bdate_range(start, periods=n_days)
+    rows = []
+    for t in tickers:
+        price = 100.0
+        for d in dates:
+            rows.append({
+                "date": d,
+                "ticker": t,
+                "open": price - 0.5,
+                "high": price + 0.5,
+                "low": price - 1.0,
+                "close": price,
+                "adj_close": price,
+                "volume": rng.integers(1000, 10000),
+            })
+            price *= 1 + rng.normal(0, 0.02)
+    df = pd.DataFrame(rows).set_index(["date", "ticker"]).sort_index()
+    return df
+
+
+def _mock_market_data(ohlcv: pd.DataFrame) -> MagicMock:
+    """创建一个返回固定 ohlcv 数据的 mock MarketDataProvider。"""
+    mock = MagicMock()
+    mock.get_daily_bars.return_value = ohlcv
+    return mock
+
+
+def _write_precomputed(
+    tmp_path,
+    group: str,
+    tickers: list[str],
+    dates: list[str],
+    columns: dict[str, list[float]] | None = None,
+) -> None:
+    """往 tmp_path 写一个 precomputed parquet group。"""
+    store = ParquetFactorStore(tmp_path)
+    idx_tuples = [
+        (pd.Timestamp(d), t)
+        for d in dates
+        for t in tickers
+    ]
+    idx = pd.MultiIndex.from_tuples(idx_tuples, names=["date", "ticker"])
+    n = len(idx_tuples)
+    if columns is None:
+        columns = {"pe_ratio": [float(i) for i in range(n)]}
+    df = pd.DataFrame(columns, index=idx, dtype=float)
+    store.write_factors(group, df)
+
+
+class TestLocalFactorProvider:
+    """m6: LocalFactorProvider — 路由、合并、IC 报告。"""
+
+    # --- Happy path ---
+
+    def test_expression_factors_happy_path(self, tmp_path):
+        """2 tickers, 2 expression factors → 正确 shape 和 MultiIndex。"""
+        ohlcv = _make_ohlcv(["AAPL", "TSLA"], "2024-01-01", n_days=60)
+        provider = LocalFactorProvider(
+            ProviderConfig(
+                implementation="LocalFactorProvider",
+                params={"precomputed_path": str(tmp_path)},
+            ),
+        )
+        provider.market_data = _mock_market_data(ohlcv)
+
+        result = provider.get_factors(
+            ["AAPL", "TSLA"],
+            ["KMID", "MA5"],
+            _date(2024, 2, 1),
+            _date(2024, 3, 1),
+        )
+        assert isinstance(result.index, pd.MultiIndex)
+        assert list(result.index.names) == ["date", "ticker"]
+        assert list(result.columns) == ["KMID", "MA5"]
+        assert len(result) > 0
+
+    def test_precomputed_factors_happy_path(self, tmp_path):
+        """1 precomputed factor → 读取 Parquet，无需 MarketDataProvider。"""
+        _write_precomputed(
+            tmp_path, "fundamental",
+            ["AAPL", "TSLA"],
+            ["2024-01-15", "2024-01-16", "2024-01-17"],
+        )
+        provider = LocalFactorProvider(
+            ProviderConfig(
+                implementation="LocalFactorProvider",
+                params={"precomputed_path": str(tmp_path)},
+            ),
+        )
+        result = provider.get_factors(
+            ["AAPL", "TSLA"],
+            ["pe_ratio"],
+            _date(2024, 1, 15),
+            _date(2024, 1, 17),
+        )
+        assert list(result.columns) == ["pe_ratio"]
+        assert len(result) == 6  # 3 dates × 2 tickers
+
+    def test_mixed_expression_and_precomputed(self, tmp_path):
+        """2 expression + 1 precomputed → merged DataFrame, 列顺序一致。"""
+        ohlcv = _make_ohlcv(["AAPL", "TSLA"], "2024-01-01", n_days=60)
+        _write_precomputed(
+            tmp_path, "fundamental",
+            ["AAPL", "TSLA"],
+            [str(d.date()) for d in pd.bdate_range("2024-01-01", periods=60)],
+        )
+        provider = LocalFactorProvider(
+            ProviderConfig(
+                implementation="LocalFactorProvider",
+                params={"precomputed_path": str(tmp_path)},
+            ),
+        )
+        provider.market_data = _mock_market_data(ohlcv)
+
+        factor_names = ["pe_ratio", "KMID", "MA5"]
+        result = provider.get_factors(
+            ["AAPL", "TSLA"],
+            factor_names,
+            _date(2024, 2, 1),
+            _date(2024, 3, 1),
+        )
+        assert list(result.columns) == factor_names
+
+    # --- Column order ---
+
+    def test_column_order_preserved(self, tmp_path):
+        """请求 ["B", "A"] 顺序 → 输出列顺序也是 ["B", "A"]。"""
+        ohlcv = _make_ohlcv(["AAPL"], "2024-01-01", n_days=60)
+        provider = LocalFactorProvider(
+            ProviderConfig(
+                implementation="LocalFactorProvider",
+                params={"precomputed_path": str(tmp_path)},
+            ),
+        )
+        provider.market_data = _mock_market_data(ohlcv)
+
+        result = provider.get_factors(
+            ["AAPL"],
+            ["MA5", "KMID"],
+            _date(2024, 2, 1),
+            _date(2024, 3, 1),
+        )
+        assert list(result.columns) == ["MA5", "KMID"]
+
+    # --- Error handling ---
+
+    def test_unknown_factor_raises(self, tmp_path):
+        """未知 factor name → ValueError。"""
+        provider = LocalFactorProvider(
+            ProviderConfig(
+                implementation="LocalFactorProvider",
+                params={"precomputed_path": str(tmp_path)},
+            ),
+        )
+        with pytest.raises(ValueError, match="Unknown factor"):
+            provider.get_factors(
+                ["AAPL"], ["NONEXISTENT"], _date(2024, 1, 1), _date(2024, 1, 2),
+            )
+
+    def test_expression_without_market_data_raises(self, tmp_path):
+        """请求 expression factor 但未设置 MarketDataProvider → RuntimeError。"""
+        provider = LocalFactorProvider(
+            ProviderConfig(
+                implementation="LocalFactorProvider",
+                params={"precomputed_path": str(tmp_path)},
+            ),
+        )
+        with pytest.raises(RuntimeError, match="MarketDataProvider not set"):
+            provider.get_factors(
+                ["AAPL"], ["KMID"], _date(2024, 1, 1), _date(2024, 1, 2),
+            )
+
+    def test_precomputed_without_market_data_ok(self, tmp_path):
+        """只请求 precomputed factor，不设 market_data → 应正常返回。"""
+        _write_precomputed(
+            tmp_path, "fundamental",
+            ["AAPL"],
+            ["2024-01-15", "2024-01-16"],
+        )
+        provider = LocalFactorProvider(
+            ProviderConfig(
+                implementation="LocalFactorProvider",
+                params={"precomputed_path": str(tmp_path)},
+            ),
+        )
+        # 不设 market_data
+        result = provider.get_factors(
+            ["AAPL"], ["pe_ratio"], _date(2024, 1, 15), _date(2024, 1, 16),
+        )
+        assert len(result) == 2
+
+    # --- Empty inputs ---
+
+    def test_empty_factor_names(self, tmp_path):
+        """factor_names=[] → 返回空 DataFrame。"""
+        provider = LocalFactorProvider(
+            ProviderConfig(
+                implementation="LocalFactorProvider",
+                params={"precomputed_path": str(tmp_path)},
+            ),
+        )
+        result = provider.get_factors(
+            ["AAPL"], [], _date(2024, 1, 1), _date(2024, 1, 2),
+        )
+        assert result.empty
+        assert list(result.index.names) == ["date", "ticker"]
+
+    def test_empty_ohlcv_returns_empty(self, tmp_path):
+        """market_data 返回空 → 不 crash，返回空 DataFrame。"""
+        empty_ohlcv = pd.DataFrame(
+            columns=["open", "high", "low", "close", "adj_close", "volume"],
+            index=pd.MultiIndex.from_tuples([], names=["date", "ticker"]),
+        )
+        provider = LocalFactorProvider(
+            ProviderConfig(
+                implementation="LocalFactorProvider",
+                params={"precomputed_path": str(tmp_path)},
+            ),
+        )
+        provider.market_data = _mock_market_data(empty_ohlcv)
+        result = provider.get_factors(
+            ["AAPL"], ["KMID"], _date(2024, 1, 1), _date(2024, 1, 2),
+        )
+        assert result.empty
+
+    # --- list_factors ---
+
+    def test_list_factors_expression_and_precomputed(self, tmp_path):
+        """list_factors 返回 expression + precomputed 条目。"""
+        _write_precomputed(
+            tmp_path, "sentiment",
+            ["AAPL"], ["2024-01-01"],
+            {"mood_score": [0.5]},
+        )
+        provider = LocalFactorProvider(
+            ProviderConfig(
+                implementation="LocalFactorProvider",
+                params={"precomputed_path": str(tmp_path)},
+            ),
+        )
+        factors = provider.list_factors()
+        names = {f["name"] for f in factors}
+        types = {f["type"] for f in factors}
+
+        assert "KMID" in names  # expression
+        assert "mood_score" in names  # precomputed
+        assert types == {"expression", "precomputed"}
+
+    def test_list_factors_expression_shadows_precomputed(self, tmp_path):
+        """precomputed 列名和 expression 因子同名 → expression 优先，precomputed 不出现。"""
+        # KMID is an Alpha158 expression factor
+        _write_precomputed(
+            tmp_path, "test_group",
+            ["AAPL"], ["2024-01-01"],
+            {"KMID": [42.0]},
+        )
+        provider = LocalFactorProvider(
+            ProviderConfig(
+                implementation="LocalFactorProvider",
+                params={"precomputed_path": str(tmp_path)},
+            ),
+        )
+        factors = provider.list_factors()
+        kmid_entries = [f for f in factors if f["name"] == "KMID"]
+        assert len(kmid_entries) == 1
+        assert kmid_entries[0]["type"] == "expression"
+
+    # --- get_ic_report ---
+
+    def test_ic_report_no_market_data_raises(self, tmp_path):
+        """get_ic_report 未设 market_data → RuntimeError。"""
+        provider = LocalFactorProvider(
+            ProviderConfig(
+                implementation="LocalFactorProvider",
+                params={"precomputed_path": str(tmp_path)},
+            ),
+        )
+        with pytest.raises(RuntimeError, match="MarketDataProvider not set"):
+            provider.get_ic_report("KMID")
+
+    def test_ic_report_no_universe_raises(self, tmp_path):
+        """get_ic_report 设了 market_data 但没设 ic_universe → RuntimeError。"""
+        provider = LocalFactorProvider(
+            ProviderConfig(
+                implementation="LocalFactorProvider",
+                params={"precomputed_path": str(tmp_path)},
+            ),
+        )
+        provider.market_data = MagicMock()
+        with pytest.raises(RuntimeError, match="IC universe not configured"):
+            provider.get_ic_report("KMID")
+
+    def test_ic_report_expression_factor(self, tmp_path):
+        """expression factor IC 报告返回正确 keys。"""
+        ohlcv = _make_ohlcv(["AAPL", "TSLA"], "2023-01-01", n_days=300)
+        provider = LocalFactorProvider(
+            ProviderConfig(
+                implementation="LocalFactorProvider",
+                params={"precomputed_path": str(tmp_path)},
+            ),
+        )
+        provider.market_data = _mock_market_data(ohlcv)
+        provider.ic_universe = ICUniverse(
+            tickers=["AAPL", "TSLA"],
+            start=_date(2023, 6, 1),
+            end=_date(2024, 1, 1),
+        )
+        result = provider.get_ic_report("KMID")
+        assert set(result.keys()) == {"ic_mean", "ic_std", "icir"}
+
+    def test_ic_report_unknown_factor_raises(self, tmp_path):
+        """get_ic_report 传入未知 factor → ValueError。"""
+        provider = LocalFactorProvider(
+            ProviderConfig(
+                implementation="LocalFactorProvider",
+                params={"precomputed_path": str(tmp_path)},
+            ),
+        )
+        provider.market_data = MagicMock()
+        provider.ic_universe = ICUniverse(
+            tickers=["AAPL"], start=_date(2024, 1, 1), end=_date(2024, 6, 1),
+        )
+        with pytest.raises(ValueError, match="Unknown factor"):
+            provider.get_ic_report("NONEXISTENT")
+
+    # --- Precomputed index ---
+
+    def test_precomputed_index_lazy_build(self, tmp_path):
+        """首次 get_factors 触发 lazy build，不需要手动 initialize。"""
+        _write_precomputed(
+            tmp_path, "fundamental",
+            ["AAPL"], ["2024-01-15"],
+        )
+        provider = LocalFactorProvider(
+            ProviderConfig(
+                implementation="LocalFactorProvider",
+                params={"precomputed_path": str(tmp_path)},
+            ),
+        )
+        # 不调 initialize()，直接 get_factors
+        result = provider.get_factors(
+            ["AAPL"], ["pe_ratio"], _date(2024, 1, 15), _date(2024, 1, 15),
+        )
+        assert len(result) == 1
+
+    def test_precomputed_index_via_initialize(self, tmp_path):
+        """initialize() 也触发 index build。"""
+        _write_precomputed(
+            tmp_path, "fundamental",
+            ["AAPL"], ["2024-01-15"],
+        )
+        provider = LocalFactorProvider(
+            ProviderConfig(
+                implementation="LocalFactorProvider",
+                params={"precomputed_path": str(tmp_path)},
+            ),
+        )
+        provider.initialize()
+        assert provider._precomputed_index_built
+        assert "pe_ratio" in provider._precomputed_index
+
+    # --- Name collision ---
+
+    def test_expression_wins_over_precomputed_collision(self, tmp_path):
+        """同名因子：expression 优先 routing，不读 precomputed 的 999.0。"""
+        ohlcv = _make_ohlcv(["AAPL"], "2024-01-01", n_days=60)
+        # 写一个和 KMID 同名的 precomputed factor（全 999）
+        _write_precomputed(
+            tmp_path, "test_group",
+            ["AAPL"],
+            [str(d.date()) for d in pd.bdate_range("2024-01-01", periods=60)],
+            {"KMID": [999.0] * 60},
+        )
+        provider = LocalFactorProvider(
+            ProviderConfig(
+                implementation="LocalFactorProvider",
+                params={"precomputed_path": str(tmp_path)},
+            ),
+        )
+        provider.market_data = _mock_market_data(ohlcv)
+
+        result = provider.get_factors(
+            ["AAPL"], ["KMID"], _date(2024, 2, 1), _date(2024, 3, 1),
+        )
+        # Expression KMID = ($close - $open) / $open
+        # 不应该全是 999.0
+        assert not (result["KMID"] == 999.0).all()
+
+    # --- Date normalization ---
+
+    def test_normalize_date_index_converts_date_objects(self):
+        """datetime.date index → datetime64 index。"""
+        from datetime import date as dt_date
+        idx = pd.MultiIndex.from_tuples(
+            [(dt_date(2024, 1, 1), "AAPL"), (dt_date(2024, 1, 2), "AAPL")],
+            names=["date", "ticker"],
+        )
+        df = pd.DataFrame({"x": [1.0, 2.0]}, index=idx)
+        result = _normalize_date_index(df)
+        assert pd.api.types.is_datetime64_any_dtype(
+            result.index.get_level_values("date"),
+        )
+
+    # --- Default config ---
+
+    def test_default_config_no_params(self, tmp_path):
+        """无 config 参数 → 使用默认值（Alpha158 default yaml, data/factors）。"""
+        provider = LocalFactorProvider()
+        assert len(provider._alpha158) == 158  # 默认 Alpha158 registry
+        assert provider.market_data is None
+        assert provider.ic_universe is None

--- a/tests/test_factor_data.py
+++ b/tests/test_factor_data.py
@@ -18,6 +18,8 @@ m1b 造 2 tickers 合成 OHLCV，验证：
     pytest tests/test_factor_data.py -v
 """
 
+import math
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -1818,3 +1820,230 @@ class TestParquetFactorStore:
         # 文件不应被创建
         assert not (tmp_path / "fundamental.parquet").exists()
         assert store.list_precomputed_factors() == []
+
+
+# ===========================================================================
+# IC Evaluator（12 个 case）
+# ===========================================================================
+
+from stockbee.factor_data.ic_evaluator import compute
+
+
+def _make_ic_data(
+    n_tickers: int = 5,
+    n_dates: int = 60,
+    seed: int = 42,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """构造 IC 测试用的 factor + prices 数据。
+
+    Returns:
+        (prices_df, fwd_returns) — prices 有 adj_close 列，
+        fwd_returns 是每 ticker 的前向收益（方便外部构造 factor）。
+    """
+    rng = np.random.default_rng(seed)
+    dates = pd.bdate_range("2024-01-01", periods=n_dates)
+    tickers = [f"T{i:03d}" for i in range(n_tickers)]
+
+    rows = []
+    for t in tickers:
+        price = 100.0
+        for d in dates:
+            rows.append((d, t, price))
+            price *= 1 + rng.normal(0, 0.02)  # ~2% daily vol
+
+    idx = pd.MultiIndex.from_tuples(
+        [(d, t) for d, t, _ in rows], names=["date", "ticker"]
+    )
+    prices_df = pd.DataFrame({"adj_close": [p for _, _, p in rows]}, index=idx)
+
+    # 前向收益（shift=-1）
+    fwd_price = prices_df["adj_close"].groupby(level="ticker").shift(-1)
+    fwd_ret = fwd_price / prices_df["adj_close"] - 1
+
+    return prices_df, fwd_ret
+
+
+class TestICEvaluator:
+    """m5: IC / ICIR 离线评估。"""
+
+    def test_perfect_positive_ic(self):
+        """factor == fwd_return → IC ≈ 1.0（完美正相关）。"""
+        prices_df, fwd_ret = _make_ic_data(n_tickers=10, n_dates=80)
+        # factor = forward return 本身
+        factor_df = pd.DataFrame({"f": fwd_ret}, index=fwd_ret.index).dropna()
+        # prices 需要对齐到 factor 的日期范围
+        result = compute(factor_df, prices_df, shift=1)
+        assert result["ic_mean"] > 0.9
+
+    def test_perfect_negative_ic(self):
+        """factor == -fwd_return → IC ≈ -1.0（完美负相关）。"""
+        prices_df, fwd_ret = _make_ic_data(n_tickers=10, n_dates=80)
+        factor_df = pd.DataFrame({"f": -fwd_ret}, index=fwd_ret.index).dropna()
+        result = compute(factor_df, prices_df, shift=1)
+        assert result["ic_mean"] < -0.9
+
+    def test_noisy_positive_ic(self):
+        """factor = return + noise → ic_mean > 0.5（有信号但有噪声）。"""
+        rng = np.random.default_rng(123)
+        prices_df, fwd_ret = _make_ic_data(n_tickers=10, n_dates=80, seed=123)
+        noise = pd.Series(
+            rng.normal(0, 0.01, size=len(fwd_ret)), index=fwd_ret.index
+        )
+        factor_df = pd.DataFrame(
+            {"f": fwd_ret + noise}, index=fwd_ret.index
+        ).dropna()
+        result = compute(factor_df, prices_df, shift=1)
+        assert result["ic_mean"] > 0.5
+
+    def test_zero_correlation(self):
+        """随机因子 → |ic_mean| 应接近 0。"""
+        rng = np.random.default_rng(7777)  # 不同于 prices seed，避免序列相关
+        prices_df, _ = _make_ic_data(n_tickers=10, n_dates=80, seed=99)
+        random_factor = pd.Series(
+            rng.standard_normal(len(prices_df)), index=prices_df.index
+        )
+        result = compute(random_factor, prices_df, shift=1)
+        assert abs(result["ic_mean"]) < 0.3
+
+    def test_single_ticker_nan(self):
+        """截面只有 1 个 ticker → 每日 IC 全 NaN → 结果全 NaN。"""
+        prices_df, fwd_ret = _make_ic_data(n_tickers=1, n_dates=80)
+        factor_df = pd.DataFrame({"f": fwd_ret}, index=fwd_ret.index).dropna()
+        result = compute(factor_df, prices_df, shift=1)
+        assert math.isnan(result["ic_mean"])
+        assert math.isnan(result["ic_std"])
+        assert math.isnan(result["icir"])
+
+    def test_sparse_below_min_valid(self):
+        """有效 IC 恰好 19 个（< 20）→ 全 NaN。"""
+        # 构造只有 19 个有效日期的数据
+        prices_df, fwd_ret = _make_ic_data(n_tickers=5, n_dates=21)
+        # shift=1 → 最后 1 天无前向收益 → 20 天有返回，但第一天 fwd_ret 可能也会 dropna
+        # 用 21 天数据 shift=1 → 20 天有 fwd_ret → IC 序列 20 个
+        # 为确保恰好 19 个，手动截取
+        factor_df = pd.DataFrame({"f": fwd_ret}, index=fwd_ret.index).dropna()
+        # 手动减少到 19 天
+        dates = factor_df.index.get_level_values("date").unique()[:19]
+        mask = factor_df.index.get_level_values("date").isin(dates)
+        factor_19 = factor_df[mask]
+        result = compute(factor_19, prices_df, shift=1, window=252)
+        assert math.isnan(result["ic_mean"])
+
+    def test_sparse_at_min_valid(self):
+        """有效 IC 恰好 20 个 → 应返回有效值。"""
+        prices_df, fwd_ret = _make_ic_data(n_tickers=5, n_dates=22)
+        factor_df = pd.DataFrame({"f": fwd_ret}, index=fwd_ret.index).dropna()
+        dates = factor_df.index.get_level_values("date").unique()[:20]
+        mask = factor_df.index.get_level_values("date").isin(dates)
+        factor_20 = factor_df[mask]
+        result = compute(factor_20, prices_df, shift=1, window=252)
+        assert not math.isnan(result["ic_mean"])
+
+    def test_shift_2(self):
+        """shift=2 → 使用 t+2 收益。"""
+        prices_df, _ = _make_ic_data(n_tickers=5, n_dates=80)
+        # 手动算 shift=2 的前向收益作为 factor
+        fwd2 = prices_df["adj_close"].groupby(level="ticker").shift(-2)
+        fwd_ret2 = fwd2 / prices_df["adj_close"] - 1
+        factor_df = pd.DataFrame({"f": fwd_ret2}, index=fwd_ret2.index).dropna()
+        result = compute(factor_df, prices_df, shift=2)
+        assert result["ic_mean"] > 0.9
+
+    def test_small_window(self):
+        """window=5 → 只用最近 5 天 IC 计算汇总。"""
+        prices_df, fwd_ret = _make_ic_data(n_tickers=10, n_dates=80)
+        factor_df = pd.DataFrame({"f": fwd_ret}, index=fwd_ret.index).dropna()
+        # window=5 低于 min_valid=20 → 应返回 NaN
+        result = compute(factor_df, prices_df, shift=1, window=5)
+        assert math.isnan(result["ic_mean"])
+
+    def test_constant_factor_nan(self):
+        """所有 ticker 因子值相同 → rank 无区分度 → IC = NaN。"""
+        prices_df, _ = _make_ic_data(n_tickers=5, n_dates=80)
+        # 每天所有 ticker 因子值都是 1.0
+        factor_df = pd.DataFrame(
+            {"f": [1.0] * len(prices_df)}, index=prices_df.index
+        )
+        result = compute(factor_df, prices_df, shift=1)
+        assert math.isnan(result["ic_mean"])
+
+    def test_wrong_index_raises(self):
+        """非 MultiIndex → ValueError。"""
+        bad_factor = pd.DataFrame(
+            {"f": [1.0, 2.0]}, index=pd.date_range("2024-01-01", periods=2)
+        )
+        prices_df, _ = _make_ic_data(n_tickers=2, n_dates=5)
+        with pytest.raises(ValueError, match="MultiIndex"):
+            compute(bad_factor, prices_df)
+
+    def test_multi_column_factor_raises(self):
+        """factor_df 有 2+ 列 → ValueError。"""
+        prices_df, fwd_ret = _make_ic_data(n_tickers=5, n_dates=30)
+        factor_df = pd.DataFrame(
+            {"f1": fwd_ret, "f2": fwd_ret}, index=fwd_ret.index
+        ).dropna()
+        with pytest.raises(ValueError, match="exactly 1 column"):
+            compute(factor_df, prices_df)
+
+    def test_price_col_missing_raises(self):
+        """prices_df 无 adj_close 列 → ValueError。"""
+        prices_df, fwd_ret = _make_ic_data(n_tickers=5, n_dates=30)
+        prices_no_col = prices_df.rename(columns={"adj_close": "close"})
+        factor_df = pd.DataFrame({"f": fwd_ret}, index=fwd_ret.index).dropna()
+        with pytest.raises(ValueError, match="adj_close"):
+            compute(factor_df, prices_no_col)
+
+    def test_shift_zero_raises(self):
+        """shift=0 → ValueError。"""
+        prices_df, fwd_ret = _make_ic_data(n_tickers=5, n_dates=30)
+        factor_df = pd.DataFrame({"f": fwd_ret}, index=fwd_ret.index).dropna()
+        with pytest.raises(ValueError, match="shift must be >= 1"):
+            compute(factor_df, prices_df, shift=0)
+
+    def test_negative_shift_raises(self):
+        """shift=-1 → ValueError。"""
+        prices_df, fwd_ret = _make_ic_data(n_tickers=5, n_dates=30)
+        factor_df = pd.DataFrame({"f": fwd_ret}, index=fwd_ret.index).dropna()
+        with pytest.raises(ValueError, match="shift must be >= 1"):
+            compute(factor_df, prices_df, shift=-1)
+
+    def test_window_zero_raises(self):
+        """window=0 → ValueError。"""
+        prices_df, fwd_ret = _make_ic_data(n_tickers=5, n_dates=30)
+        factor_df = pd.DataFrame({"f": fwd_ret}, index=fwd_ret.index).dropna()
+        with pytest.raises(ValueError, match="window must be >= 1"):
+            compute(factor_df, prices_df, window=0)
+
+    def test_partial_overlap(self):
+        """factor 只覆盖 prices 的部分日期 → 用交集计算，不 crash。"""
+        prices_df, fwd_ret = _make_ic_data(n_tickers=10, n_dates=80)
+        # factor 只取后 40 天
+        dates = fwd_ret.index.get_level_values("date").unique()
+        late_dates = dates[-40:]
+        mask = fwd_ret.index.get_level_values("date").isin(late_dates)
+        factor_df = pd.DataFrame({"f": fwd_ret[mask]}, index=fwd_ret.index[mask]).dropna()
+        result = compute(factor_df, prices_df, shift=1)
+        # 40 天减去最后 1 天无 fwd_ret = 39 天 IC，>= 20 → 有值
+        assert not math.isnan(result["ic_mean"])
+        assert result["ic_mean"] > 0.9  # 完美因子
+
+    def test_flat_prices_nan(self):
+        """常量价格 → fwd_ret=0 → ranks 全 tied → IC = NaN。"""
+        dates = pd.bdate_range("2024-01-01", periods=60)
+        tickers = ["A", "B", "C", "D", "E"]
+        idx = pd.MultiIndex.from_product([dates, tickers], names=["date", "ticker"])
+        prices_df = pd.DataFrame({"adj_close": 100.0}, index=idx)
+        factor_df = pd.DataFrame(
+            {"f": np.arange(len(idx), dtype=float)}, index=idx
+        )
+        result = compute(factor_df, prices_df, shift=1)
+        assert math.isnan(result["ic_mean"])
+
+    def test_duplicate_index_raises(self):
+        """prices_df 有重复 (date, ticker) 行 → ValueError。"""
+        prices_df, fwd_ret = _make_ic_data(n_tickers=3, n_dates=30)
+        # 人为制造重复行
+        dup_prices = pd.concat([prices_df, prices_df.iloc[:3]])
+        factor_df = pd.DataFrame({"f": fwd_ret}, index=fwd_ret.index).dropna()
+        with pytest.raises(ValueError, match="duplicate"):
+            compute(factor_df, dup_prices)

--- a/tests/test_factor_data.py
+++ b/tests/test_factor_data.py
@@ -1343,3 +1343,113 @@ class TestTsQuantile:
             assert _REGISTRY[name].impl is not None, (
                 f"m3 函数 {name} 缺少 impl 注册"
             )
+
+
+# ===========================================================================
+# m3 — Alpha158 Loader / Registry / Lookback
+# ===========================================================================
+
+from stockbee.factor_data.alpha158 import Alpha158
+
+_WINDOWS = [5, 10, 20, 30, 60]
+
+_LOOKBACK_W = [
+    "ROC", "MA", "STD", "BETA", "RSQR", "RESI", "MAX", "MIN",
+    "QTLU", "QTLD", "RANK", "RSV", "IMAX", "IMIN", "IMXD",
+    "CORR", "VMA", "VSTD",
+]
+
+_LOOKBACK_W_PLUS_1 = [
+    "CORD", "CNTP", "CNTN", "CNTD", "SUMP", "SUMN", "SUMD",
+    "WVMA", "VSUMP", "VSUMN", "VSUMD",
+]
+
+
+class TestAlpha158Loader:
+    def test_factor_count_158(self):
+        assert len(Alpha158()) == 158
+
+    def test_factor_names_unique(self):
+        names = Alpha158().list_factor_names()
+        assert len(names) == len(set(names))
+
+    def test_kbar_9_factors_present(self):
+        a = Alpha158()
+        kbar = ["KMID", "KLEN", "KMID2", "KUP", "KUP2",
+                "KLOW", "KLOW2", "KSFT", "KSFT2"]
+        for name in kbar:
+            assert name in a, f"KBAR factor {name} missing"
+
+    def test_price_4_factors_present(self):
+        a = Alpha158()
+        for name in ["OPEN0", "HIGH0", "LOW0", "VWAP0"]:
+            assert name in a, f"price factor {name} missing"
+
+    def test_rolling_cartesian_expansion(self):
+        """每个 rolling 算子对 5 个窗口展开。"""
+        a = Alpha158()
+        for prefix in _LOOKBACK_W + _LOOKBACK_W_PLUS_1:
+            for w in _WINDOWS:
+                name = f"{prefix}{w}"
+                assert name in a, f"rolling factor {name} missing"
+
+    def test_exact_order_frozen(self):
+        """因子顺序是 contract，固定不变。"""
+        a = Alpha158()
+        names = a.list_factor_names()
+        assert names[:9] == [
+            "KMID", "KLEN", "KMID2", "KUP", "KUP2",
+            "KLOW", "KLOW2", "KSFT", "KSFT2",
+        ]
+        assert names[9:13] == ["OPEN0", "HIGH0", "LOW0", "VWAP0"]
+        assert names[13] == "ROC5"
+        assert names[-1] == "VSUMD60"
+
+    def test_unknown_name_raises(self):
+        a = Alpha158()
+        with pytest.raises(KeyError, match="未知因子"):
+            a.get_expression("BOGUS")
+        with pytest.raises(KeyError, match="未知因子"):
+            a.get_expression_str("BOGUS")
+
+    def test_all_158_parse_success(self):
+        """全部 158 个表达式 parse 无异常。"""
+        a = Alpha158()
+        for name in a.list_factor_names():
+            node = a.get_expression(name)
+            assert isinstance(node, Node), f"{name} parse 返回类型错误"
+
+
+class TestAlpha158Lookback:
+    """全部 158 因子 lookback 参数化断言。"""
+
+    def test_kbar_lookback_zero(self):
+        a = Alpha158()
+        for name in ["KMID", "KLEN", "KMID2", "KUP", "KUP2",
+                      "KLOW", "KLOW2", "KSFT", "KSFT2"]:
+            assert a.max_lookback(name) == 0, f"{name} expected lookback=0"
+
+    def test_price_lookback_zero(self):
+        a = Alpha158()
+        for name in ["OPEN0", "HIGH0", "LOW0", "VWAP0"]:
+            assert a.max_lookback(name) == 0, f"{name} expected lookback=0"
+
+    @pytest.mark.parametrize("w", _WINDOWS)
+    def test_simple_rolling_lookback_equals_window(self, w):
+        """18 个简单滚动算子 lookback = window。"""
+        a = Alpha158()
+        for prefix in _LOOKBACK_W:
+            name = f"{prefix}{w}"
+            assert a.max_lookback(name) == w, (
+                f"{name} expected lookback={w}, got {a.max_lookback(name)}"
+            )
+
+    @pytest.mark.parametrize("w", _WINDOWS)
+    def test_ref_nested_lookback_equals_window_plus_1(self, w):
+        """11 个 REF 嵌套算子 lookback = window + 1。"""
+        a = Alpha158()
+        for prefix in _LOOKBACK_W_PLUS_1:
+            name = f"{prefix}{w}"
+            assert a.max_lookback(name) == w + 1, (
+                f"{name} expected lookback={w+1}, got {a.max_lookback(name)}"
+            )

--- a/tests/test_factor_data.py
+++ b/tests/test_factor_data.py
@@ -945,6 +945,15 @@ class TestRollingOLS:
         assert aaa.iloc[4:].to_numpy() == pytest.approx([0.0] * 6, abs=1e-10)
         assert bbb.iloc[4:].to_numpy() == pytest.approx([0.0] * 6, abs=1e-10)
 
+    def test_ols_nan_propagation_prefix(self, panel):
+        """rolling 前 n-1 行 NaN 必须传播到 OLS 的所有输出（slope/rsquare/resi）。"""
+        slope = evaluate(parse("SLOPE($close, 5)"), panel)
+        rsq   = evaluate(parse("RSQUARE($close, 5)"), panel)
+        resi  = evaluate(parse("RESI($close, 5)"), panel)
+        assert _aaa(slope).iloc[:4].isna().all()
+        assert _aaa(rsq).iloc[:4].isna().all()
+        assert _aaa(resi).iloc[:4].isna().all()
+
     def test_resi_last_point_formula(self, panel_nonlinear):
         """RESI 必须返回最后一点的残差，不是整段残差序列。
 
@@ -963,3 +972,89 @@ class TestRollingOLS:
         # AAA 第 i=5 行（窗口 [3..5]） → 对应 iloc[5]
         aaa_resi_5 = _aaa(result).iloc[5]
         assert aaa_resi_5 == pytest.approx(1.0 / 6.0, abs=1e-10)
+
+
+# ===========================================================================
+# m2 — EMA / IDXMAX / IDXMIN
+# ===========================================================================
+
+class TestEMA:
+    def test_ema_hand_computed(self, panel):
+        """n=3, alpha=2/4=0.5，IIR 递推 y_t = α·x_t + (1−α)·y_{t−1}。
+        AAA adj_close = 2,4,6,... 前 2 行 NaN（min_periods=3），第 3 行起：
+          y2 = 0.5·6 + 0.5·(0.5·4 + 0.5·2) = 3 + 0.5·3 = 4.5
+          Wait: adjust=False 的 ewm 初始化用第一个观测值 y_0 = x_0 = 2，
+                递推：y1 = 0.5·4 + 0.5·2 = 3
+                      y2 = 0.5·6 + 0.5·3 = 4.5
+                      y3 = 0.5·8 + 0.5·4.5 = 6.25
+          min_periods=3 → 前 2 行输出 NaN，iloc[2]=4.5，iloc[3]=6.25
+        """
+        result = evaluate(parse("EMA($close, 3)"), panel)
+        aaa = _aaa(result)
+        assert aaa.iloc[0:2].isna().all()
+        assert aaa.iloc[2] == pytest.approx(4.5)
+        assert aaa.iloc[3] == pytest.approx(6.25)
+
+    def test_ema_min_periods(self, panel):
+        """min_periods=n → 前 n-1 行 NaN。"""
+        result = evaluate(parse("EMA($close, 5)"), panel)
+        aaa = _aaa(result)
+        assert aaa.iloc[:4].isna().all()
+        # iloc[4] 起有值
+        assert not np.isnan(aaa.iloc[4])
+
+    def test_ema_ticker_isolation(self, panel):
+        """AAA/BBB EMA 不跨 ticker 串：两条 ticker 各自独立递推。"""
+        result = evaluate(parse("EMA($close, 3)"), panel)
+        aaa = _aaa(result)
+        bbb = _bbb(result)
+        # BBB adj_close = 40, 38, 36, ... 递减；前 2 行 NaN
+        # y0=40, y1=0.5·38 + 0.5·40 = 39, y2=0.5·36 + 0.5·39 = 37.5
+        assert bbb.iloc[2] == pytest.approx(37.5)
+        # AAA 的 iloc[2] 应 = 4.5（与 BBB 独立）
+        assert aaa.iloc[2] == pytest.approx(4.5)
+
+
+class TestIdxMaxMin:
+    def test_idxmax_rolling_3(self, panel):
+        """AAA adj_close=2,4,...,20 递增，窗口 3 每行的 argmax 位置都是 2（最新 = 最大）。"""
+        result = evaluate(parse("IDXMAX($close, 3)"), panel)
+        aaa = _aaa(result)
+        assert aaa.iloc[:2].isna().all()  # min_periods=3
+        assert aaa.iloc[2:].to_numpy() == pytest.approx([2.0] * 8)
+
+    def test_idxmin_rolling_3(self, panel):
+        """AAA 递增序列 → 窗口 3 的 argmin 位置都是 0（最早 = 最小）。"""
+        result = evaluate(parse("IDXMIN($close, 3)"), panel)
+        aaa = _aaa(result)
+        assert aaa.iloc[:2].isna().all()
+        assert aaa.iloc[2:].to_numpy() == pytest.approx([0.0] * 8)
+
+    def test_idxmax_bbb_decreasing(self, panel):
+        """BBB 递减序列 → 窗口 3 argmax = 0（最早 = 最大）。"""
+        result = evaluate(parse("IDXMAX($close, 3)"), panel)
+        bbb = _bbb(result)
+        assert bbb.iloc[2:].to_numpy() == pytest.approx([0.0] * 8)
+
+    def test_idxmax_ties_first_position(self, panel):
+        """平局（恒定序列）→ np.argmax 返回首个位置 0。
+        造一个 AAA 与 BBB 都一致的常数 close，通过 SIGN($close - $close) + 1 构造常数 1。"""
+        # 用表达式构造一个常数 Series：$close - $close + 1 → 全 1
+        result = evaluate(parse("IDXMAX($close - $close + 1, 3)"), panel)
+        aaa = _aaa(result)
+        # 常数序列 [1,1,1] 的 argmax = 0
+        assert aaa.iloc[2:].to_numpy() == pytest.approx([0.0] * 8)
+
+    def test_idxmax_ticker_isolation(self, panel):
+        """AAA 递增 / BBB 递减 在同一次调用中应各自独立 argmax。"""
+        result = evaluate(parse("IDXMAX($close, 5)"), panel)
+        # AAA 递增 → argmax = 4 (n-1)
+        assert _aaa(result).iloc[4:].to_numpy() == pytest.approx([4.0] * 6)
+        # BBB 递减 → argmax = 0
+        assert _bbb(result).iloc[4:].to_numpy() == pytest.approx([0.0] * 6)
+
+    def test_idxmax_n1_allowed(self, panel):
+        """IDXMAX/IDXMIN 保持 min_window=1（单元素窗口 argmax=0 合法）。"""
+        result = evaluate(parse("IDXMAX($close, 1)"), panel)
+        # 每个窗口只有一个元素 → argmax = 0
+        assert _aaa(result).to_numpy() == pytest.approx([0.0] * 10)

--- a/tests/test_factor_data.py
+++ b/tests/test_factor_data.py
@@ -1,0 +1,323 @@
+# tests/test_factor_data.py
+"""m1a — Tokenizer / Parser / AST 单元测试。
+
+不跑 OHLCV 数据，只验证：
+  - Token 流正确性
+  - AST 结构形状
+  - lookback() 数值
+  - walk() DFS 顺序
+
+运行方式（仓库根目录）：
+    pytest tests/test_factor_data.py -v
+"""
+
+import pytest
+
+from stockbee.factor_data.expression_engine import (
+    BinaryOp,
+    Constant,
+    ExpressionError,
+    FunctionCall,
+    Node,
+    ParseError,
+    Token,
+    TokenType,
+    TokenizerError,
+    UnaryOp,
+    Variable,
+    _REGISTRY,
+    parse,
+    tokenize,
+)
+
+
+# ===========================================================================
+# Tokenizer（6 个 case）
+# ===========================================================================
+
+class TestTokenizer:
+    def test_integer_and_float_distinct(self):
+        """整数和浮点保留原生 Python 类型。"""
+        toks = tokenize("10 2.5")
+        assert toks[0].type == TokenType.NUMBER
+        assert isinstance(toks[0].value, int) and toks[0].value == 10
+        assert toks[1].type == TokenType.NUMBER
+        assert isinstance(toks[1].value, float) and toks[1].value == 2.5
+
+    def test_var_long_and_short_alias_normalize(self):
+        """$close / $Close / c / C 全部归一化为 CLOSE；v -> VOLUME。"""
+        for expr in ("$close", "$Close", "$CLOSE"):
+            toks = tokenize(expr)
+            assert toks[0].type == TokenType.VAR
+            assert toks[0].value == "CLOSE"
+
+        toks_c = tokenize("c")
+        assert toks_c[0].type == TokenType.VAR and toks_c[0].value == "CLOSE"
+
+        toks_C = tokenize("C")
+        assert toks_C[0].type == TokenType.VAR and toks_C[0].value == "CLOSE"
+
+        toks_v = tokenize("v")
+        assert toks_v[0].type == TokenType.VAR and toks_v[0].value == "VOLUME"
+
+    def test_operators_parens_comma(self):
+        """运算符、括号、逗号均被正确 Token 化。"""
+        toks = tokenize("(a+b, c<=d)")
+        types = [t.type for t in toks if t.type != TokenType.EOF]
+        assert TokenType.LPAREN in types
+        assert TokenType.RPAREN in types
+        assert TokenType.COMMA in types
+        assert TokenType.OP in types
+
+    def test_whitespace_skipped(self):
+        """空白字符不产生 Token。"""
+        toks = tokenize("  MA ( $close ,  20 )  ")
+        types = [t.type for t in toks]
+        assert TokenType.IDENT == types[0]
+        assert TokenType.EOF == types[-1]
+        # 没有 SKIP 类型的 Token（空白已丢弃）
+        assert all(t.type != TokenType.NUMBER or t.value in (20,) for t in toks
+                   if t.type == TokenType.NUMBER)
+
+    def test_illegal_char_raises(self):
+        """非法字符抛 TokenizerError。"""
+        with pytest.raises(TokenizerError):
+            tokenize("$close @ 1")
+
+    def test_dollar_alone_raises(self):
+        """单独的 $ 或 $123 等非法变量抛 TokenizerError。"""
+        with pytest.raises(TokenizerError):
+            tokenize("$123")
+
+        with pytest.raises(TokenizerError):
+            tokenize("$ ")
+
+
+# ===========================================================================
+# Parser（10 个 case）
+# ===========================================================================
+
+class TestParser:
+    def test_basic_binop(self):
+        """$close + 1 生成 BinaryOp(+, Variable(CLOSE), Constant(1))。"""
+        node = parse("$close + 1")
+        assert isinstance(node, BinaryOp)
+        assert node.op == "+"
+        assert isinstance(node.left, Variable) and node.left.name == "CLOSE"
+        assert isinstance(node.right, Constant) and node.right.value == 1
+
+    def test_operator_precedence(self):
+        """a + b * c 中乘法优先：BinaryOp(+, a, BinaryOp(*, b, c))。"""
+        node = parse("$close + $open * $high")
+        assert isinstance(node, BinaryOp) and node.op == "+"
+        assert isinstance(node.right, BinaryOp) and node.right.op == "*"
+
+    def test_paren_overrides_precedence(self):
+        """(a + b) * c：括号改变优先级。"""
+        node = parse("($close + $open) * $high")
+        assert isinstance(node, BinaryOp) and node.op == "*"
+        assert isinstance(node.left, BinaryOp) and node.left.op == "+"
+
+    def test_unary_minus(self):
+        """一元负 -$close 和 -MA($close, 20) 均正确解析。"""
+        n1 = parse("-$close")
+        assert isinstance(n1, UnaryOp) and n1.op == "-"
+        assert isinstance(n1.operand, Variable)
+
+        n2 = parse("-MA($close, 20)")
+        assert isinstance(n2, UnaryOp) and n2.op == "-"
+        assert isinstance(n2.operand, FunctionCall) and n2.operand.name == "MA"
+
+    def test_nested_function_call(self):
+        """MA(REF($close,5),20) 解析为嵌套 FunctionCall。"""
+        node = parse("MA(REF($close,5),20)")
+        assert isinstance(node, FunctionCall) and node.name == "MA"
+        inner = node.args[0]
+        assert isinstance(inner, FunctionCall) and inner.name == "REF"
+        assert isinstance(inner.args[0], Variable) and inner.args[0].name == "CLOSE"
+        assert isinstance(inner.args[1], Constant) and inner.args[1].value == 5
+        assert isinstance(node.args[1], Constant) and node.args[1].value == 20
+
+    def test_function_case_insensitive(self):
+        """ma($close, 20) 与 MA($close, 20) 解析结果相同。"""
+        n1 = parse("MA($close, 20)")
+        n2 = parse("ma($close, 20)")
+        assert n1 == n2
+
+    def test_unknown_function_raises(self):
+        """未知函数名抛 ExpressionError（ParseError 是其子类）。"""
+        with pytest.raises(ExpressionError):
+            parse("UNKNOWN($close, 10)")
+
+    def test_wrong_arity_raises(self):
+        """参数个数不对抛 ParseError。"""
+        with pytest.raises(ParseError):
+            parse("MA($close)")        # 少一个参数
+        with pytest.raises(ParseError):
+            parse("ABS($close, $open)")  # 多一个参数
+
+    def test_trailing_garbage_raises(self):
+        """表达式后有多余字符抛 ParseError。"""
+        with pytest.raises(ParseError):
+            parse("$close + 1 garbage")
+
+    def test_if_with_comparison(self):
+        """IF($close > $open, 1, 0) 完整解析。"""
+        node = parse("IF($close > $open, 1, 0)")
+        assert isinstance(node, FunctionCall) and node.name == "IF"
+        cond = node.args[0]
+        assert isinstance(cond, BinaryOp) and cond.op == ">"
+        assert isinstance(node.args[1], Constant) and node.args[1].value == 1
+        assert isinstance(node.args[2], Constant) and node.args[2].value == 0
+
+    def test_chained_comparison_rejected(self):
+        """链式比较（0 < $close < 1）必须被显式拒绝，防止静默左结合误读。"""
+        with pytest.raises(ParseError):
+            parse("IF(0 < $close < 1, 1, 0)")
+
+    def test_non_constant_rolling_window_raises_at_parse(self):
+        """严格滚动函数的窗口必须是正整数 Constant，parse 阶段就 raise。"""
+        # 窗口是 Variable
+        with pytest.raises(ParseError):
+            parse("MA($close, $open)")
+        # 窗口是嵌套表达式
+        with pytest.raises(ParseError):
+            parse("MA($close, REF($open, 5))")
+        # 窗口是 float
+        with pytest.raises(ParseError):
+            parse("MA($close, 1.5)")
+        # 窗口是 0（< 1）
+        with pytest.raises(ParseError):
+            parse("MA($close, 0)")
+        # 负窗口（UnaryOp 非 Constant）
+        with pytest.raises(ParseError):
+            parse("MA($close, -5)")
+
+    def test_quantile_q_must_be_constant(self):
+        """QUANTILE 的 q 参数必须是数字 Constant，非常量直接 ParseError。"""
+        with pytest.raises(ParseError):
+            parse("QUANTILE($close, $open)")
+        with pytest.raises(ParseError):
+            parse("QUANTILE($close, REF($open, 5))")
+
+    def test_quantile_q_out_of_range(self):
+        """QUANTILE 的 q 参数必须在 [0,1]，否则 ParseError。"""
+        with pytest.raises(ParseError):
+            parse("QUANTILE($close, 1.5)")
+        with pytest.raises(ParseError):
+            parse("QUANTILE($close, 2)")
+
+    def test_quantile_q_boundary_valid(self):
+        """QUANTILE 的 q 边界值 0 和 1 都合法。"""
+        assert parse("QUANTILE($close, 0)").lookback() == 0
+        assert parse("QUANTILE($close, 1)").lookback() == 0
+        assert parse("QUANTILE($close, 0.5)").lookback() == 0
+
+
+# ===========================================================================
+# AST walk / lookback（16 个 case）
+# ===========================================================================
+
+class TestASTWalk:
+    def test_walk_preorder_dfs(self):
+        """walk() 前序 DFS：先 FunctionCall，再 REF，再 Variable，再 Constant（窗口）。"""
+        # MA(REF($close,5),20) 的前序：MA → REF → CLOSE → 5 → 20
+        node = parse("MA(REF($close,5),20)")
+        walked = list(node.walk())
+        names = []
+        for n in walked:
+            if isinstance(n, FunctionCall):
+                names.append(n.name)
+            elif isinstance(n, Variable):
+                names.append(n.name)
+            elif isinstance(n, Constant):
+                names.append(n.value)
+        assert names == ["MA", "REF", "CLOSE", 5, 20]
+
+
+class TestLookback:
+    def test_primitive_zero(self):
+        """常量和变量的 lookback 为 0。"""
+        assert parse("$close").lookback() == 0
+        assert parse("42").lookback() == 0
+        assert parse("3.14").lookback() == 0
+
+    def test_ma_single(self):
+        """MA($close, 20) → 20。"""
+        assert parse("MA($close, 20)").lookback() == 20
+
+    def test_ref_single(self):
+        """REF($close, 5) → 5。"""
+        assert parse("REF($close, 5)").lookback() == 5
+
+    def test_nested_ma_ref(self):
+        """MA(REF($close,5),20) → 25（核心用例）。"""
+        assert parse("MA(REF($close,5),20)").lookback() == 25
+
+    def test_triple_nested(self):
+        """STD(MA(REF($close,5),20),10) → 35。"""
+        assert parse("STD(MA(REF($close,5),20),10)").lookback() == 35
+
+    def test_binop_inside_rolling(self):
+        """MA($close + $open, 20) → 20（binop 内部 lookback=0，不相加）。"""
+        assert parse("MA($close + $open, 20)").lookback() == 20
+
+    def test_corr_three_args(self):
+        """CORR($close, $open, 10) → 10。"""
+        assert parse("CORR($close, $open, 10)").lookback() == 10
+
+    def test_corr_nested_first_arg(self):
+        """CORR(REF($close,5), $volume, 10) → 15（5 + 10）。"""
+        assert parse("CORR(REF($close,5), $volume, 10)").lookback() == 15
+
+    def test_max_rolling(self):
+        """MAX($close, 10) → 10（第二参数 int ≥ 2 → 滚动）。"""
+        assert parse("MAX($close, 10)").lookback() == 10
+
+    def test_max_elementwise(self):
+        """MAX($close, $open) → 0（第二参数是 Variable → element-wise）。"""
+        assert parse("MAX($close, $open)").lookback() == 0
+
+    def test_max_float_elementwise(self):
+        """MAX($close, 1.5) → 0（float 字面量，非 int → element-wise）。"""
+        assert parse("MAX($close, 1.5)").lookback() == 0
+
+    def test_binop_max_not_sum(self):
+        """REF($close,5) + MA($close,20) → 20（binop 取 max，不相加）。"""
+        assert parse("REF($close,5) + MA($close,20)").lookback() == 20
+
+    def test_rank_zero(self):
+        """RANK($close) → 0（横截面，无时序窗口）。"""
+        assert parse("RANK($close)").lookback() == 0
+
+    def test_quantile_cross_section(self):
+        """QUANTILE($close, 0.5) → 0（横截面，q 不是窗口）。"""
+        assert parse("QUANTILE($close, 0.5)").lookback() == 0
+
+    def test_if_max_of_all_args(self):
+        """IF($close > REF($close,5), MA($close,20), 0) → 20。"""
+        assert parse("IF($close > REF($close,5), MA($close,20), 0)").lookback() == 20
+
+
+
+# ===========================================================================
+# FunctionSpec contract（保证 m2 Evaluator 能依赖 metadata 做派发）
+# ===========================================================================
+
+class TestFunctionSpecContract:
+    def test_rank_is_cross_section(self):
+        """RANK 必须带 cross_section=True，m2 Evaluator 才能走 groupby(date) 路径。"""
+        assert _REGISTRY["RANK"].cross_section is True
+
+    def test_quantile_is_cross_section(self):
+        """QUANTILE 必须带 cross_section=True。"""
+        assert _REGISTRY["QUANTILE"].cross_section is True
+
+    def test_rolling_functions_not_cross_section(self):
+        """时序滚动函数不应被标记为 cross_section。"""
+        for name in ("MA", "REF", "STD", "SUM", "DELTA", "EMA",
+                     "SLOPE", "RSQUARE", "RESI", "CORR",
+                     "IDXMAX", "IDXMIN"):
+            assert _REGISTRY[name].cross_section is False, (
+                f"{name} 不应被标记为 cross_section"
+            )

--- a/tests/test_factor_data.py
+++ b/tests/test_factor_data.py
@@ -1453,3 +1453,117 @@ class TestAlpha158Lookback:
             assert a.max_lookback(name) == w + 1, (
                 f"{name} expected lookback={w+1}, got {a.max_lookback(name)}"
             )
+
+
+# ===========================================================================
+# m3 — Alpha158 全量 Evaluation Smoke + 数值金标
+# ===========================================================================
+
+_EVAL_DATES = pd.date_range("2024-01-01", periods=80, freq="B")
+
+
+def _make_eval_panel() -> pd.DataFrame:
+    """2 tickers × 80 交易日合成 panel（覆盖 max lookback 61）。"""
+    rows = []
+    for ticker, base_close in (("AAA", 50.0), ("BBB", 100.0)):
+        for i, date in enumerate(_EVAL_DATES):
+            c = base_close + i * 0.5
+            rows.append({
+                "date": date,
+                "ticker": ticker,
+                "open": c - 0.3,
+                "high": c + 0.8,
+                "low": c - 0.6,
+                "close": c,
+                "adj_close": c * 1.5,
+                "volume": 1000.0 + i * 10.0,
+                "vwap": c + 0.05,
+            })
+    return pd.DataFrame(rows).set_index(["date", "ticker"]).sort_index()
+
+
+@pytest.fixture(scope="module")
+def eval_panel() -> pd.DataFrame:
+    return _make_eval_panel()
+
+
+@pytest.fixture(scope="module")
+def alpha() -> Alpha158:
+    return Alpha158()
+
+
+class TestAlpha158EvalSmoke:
+    """全量 158 因子 evaluate smoke：无异常、返回 Series、index 对齐。"""
+
+    def test_all_158_evaluate_no_exception(self, eval_panel, alpha):
+        ev = Evaluator(eval_panel)
+        for name in alpha.list_factor_names():
+            ast = alpha.get_expression(name)
+            result = ev.evaluate(ast)
+            assert isinstance(result, pd.Series), (
+                f"{name} evaluate 返回 {type(result).__name__}，期望 Series"
+            )
+            assert result.index.equals(eval_panel.sort_index().index), (
+                f"{name} index 不对齐"
+            )
+
+    def test_kmid_numeric(self, eval_panel, alpha):
+        """KMID = ($close-$open)/$open 数值核对。"""
+        ev = Evaluator(eval_panel)
+        result = ev.evaluate(alpha.get_expression("KMID"))
+        p = eval_panel.sort_index()
+        expected = (p["adj_close"] - p["open"]) / p["open"]
+        pd.testing.assert_series_equal(result, expected, check_names=False)
+
+    def test_open0_numeric(self, eval_panel, alpha):
+        """OPEN0 = $open/$close 数值核对。"""
+        ev = Evaluator(eval_panel)
+        result = ev.evaluate(alpha.get_expression("OPEN0"))
+        p = eval_panel.sort_index()
+        expected = p["open"] / p["adj_close"]
+        pd.testing.assert_series_equal(result, expected, check_names=False)
+
+    def test_ma5_against_groundtruth(self, eval_panel, alpha):
+        """MA5 = MEAN($close,5)/$close vs pandas groupby rolling。"""
+        ev = Evaluator(eval_panel)
+        result = ev.evaluate(alpha.get_expression("MA5"))
+        p = eval_panel.sort_index()
+        ma = (
+            p["adj_close"]
+            .groupby(level="ticker", sort=False, group_keys=False)
+            .transform(lambda x: x.rolling(5, min_periods=5).mean())
+        )
+        expected = ma / p["adj_close"]
+        pd.testing.assert_series_equal(result, expected, check_names=False)
+
+    def test_ts_rank5_monotonic(self, eval_panel, alpha):
+        """TS_RANK5：AAA adj_close 单调递增 → rank = 1.0。"""
+        ev = Evaluator(eval_panel)
+        result = ev.evaluate(alpha.get_expression("RANK5"))
+        aaa = result.xs("AAA", level="ticker").sort_index()
+        for i in range(4, len(aaa)):
+            assert aaa.iloc[i] == pytest.approx(1.0), f"row {i}"
+
+    def test_cntp5_nan_comparison_behavior(self, eval_panel, alpha):
+        """CNTP5 第一行 NaN 比较→False（qlib 兼容，非 NaN 传播）。"""
+        ev = Evaluator(eval_panel)
+        result = ev.evaluate(alpha.get_expression("CNTP5"))
+        aaa = result.xs("AAA", level="ticker").sort_index()
+        for i in range(4):
+            assert np.isnan(aaa.iloc[i])
+        assert not np.isnan(aaa.iloc[4])
+
+    def test_vwap0_div_by_close(self, eval_panel, alpha):
+        """VWAP0 = $vwap/$close，分母不为零时正常。"""
+        ev = Evaluator(eval_panel)
+        result = ev.evaluate(alpha.get_expression("VWAP0"))
+        p = eval_panel.sort_index()
+        expected = p["vwap"] / p["adj_close"]
+        pd.testing.assert_series_equal(result, expected, check_names=False)
+
+    def test_wvma60_not_all_nan(self, eval_panel, alpha):
+        """WVMA60 80 天 panel 最后几行应有值（非全 NaN）。"""
+        ev = Evaluator(eval_panel)
+        result = ev.evaluate(alpha.get_expression("WVMA60"))
+        aaa = result.xs("AAA", level="ticker").sort_index()
+        assert not aaa.iloc[-1:].isna().all()

--- a/tests/test_factor_data.py
+++ b/tests/test_factor_data.py
@@ -854,3 +854,112 @@ class TestMinWindowValidation:
         assert _REGISTRY["SLOPE"].min_window == 2
         assert _REGISTRY["MA"].min_window == 1
         assert _REGISTRY["CORR"].min_window == 2
+
+
+# ===========================================================================
+# m2 — 共享 rolling OLS kernel：SLOPE / RSQUARE / RESI
+# ===========================================================================
+#
+# Panel 复用 m1b _make_panel() 的线性 adj_close：
+#   AAA: adj_close = 2, 4, 6, ..., 20   （step = +2）
+#   BBB: adj_close = 40, 38, 36, ..., 22 （step = -2）
+# 完美线性 → 任意窗口 slope=±2.0，r²=1.0，resi=0.0。
+# ---------------------------------------------------------------------------
+
+
+def _make_panel_nonlinear() -> pd.DataFrame:
+    """单 ticker Fibonacci 序列 + 第二个 ticker 保持线性，用于验证 r² < 1。"""
+    rows = []
+    fib = [1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
+    for i, date in enumerate(_DATES):
+        # AAA: Fibonacci (非线性)
+        rows.append({
+            "date": date, "ticker": "AAA",
+            "open": fib[i] - 0.5, "high": fib[i] + 0.5, "low": fib[i] - 1.0,
+            "close": fib[i], "adj_close": float(fib[i]), "volume": 100 * (i + 1),
+        })
+        # BBB: 线性（对照组）
+        close = 20 - i
+        rows.append({
+            "date": date, "ticker": "BBB",
+            "open": close - 0.5, "high": close + 0.5, "low": close - 1.0,
+            "close": close, "adj_close": float(close), "volume": 200 * (i + 1),
+        })
+    return pd.DataFrame(rows).set_index(["date", "ticker"]).sort_index()
+
+
+@pytest.fixture
+def panel_nonlinear() -> pd.DataFrame:
+    return _make_panel_nonlinear()
+
+
+class TestRollingOLS:
+    def test_slope_linear_aaa_window_5(self, panel):
+        """adj_close AAA = 2,4,...,20 (step=2) → 任意窗口 slope = 2.0。"""
+        result = evaluate(parse("SLOPE($close, 5)"), panel)
+        aaa = _aaa(result)
+        # 前 n-1=4 行 NaN
+        assert aaa.iloc[:4].isna().all()
+        # 其余全为 2.0
+        assert aaa.iloc[4:].to_numpy() == pytest.approx([2.0] * 6)
+
+    def test_slope_linear_bbb_negative(self, panel):
+        """BBB adj_close = 40,38,...,22 (step=-2) → slope = -2.0。"""
+        result = evaluate(parse("SLOPE($close, 5)"), panel)
+        bbb = _bbb(result)
+        assert bbb.iloc[4:].to_numpy() == pytest.approx([-2.0] * 6)
+
+    def test_slope_n_equals_2(self, panel):
+        """最小窗口 n=2，两点 OLS = 相邻差。
+        AAA step=2 → slope=2.0；BBB step=-2 → slope=-2.0。"""
+        result = evaluate(parse("SLOPE($close, 2)"), panel)
+        aaa = _aaa(result)
+        bbb = _bbb(result)
+        assert aaa.iloc[0] != aaa.iloc[0] or np.isnan(aaa.iloc[0])  # 第 0 行 NaN
+        assert aaa.iloc[1:].to_numpy() == pytest.approx([2.0] * 9)
+        assert bbb.iloc[1:].to_numpy() == pytest.approx([-2.0] * 9)
+
+    def test_rsquare_linear_is_one(self, panel):
+        """完美线性 → r² ≈ 1.0（两个 ticker 都一样）。"""
+        result = evaluate(parse("RSQUARE($close, 5)"), panel)
+        aaa = _aaa(result)
+        bbb = _bbb(result)
+        assert aaa.iloc[4:].to_numpy() == pytest.approx([1.0] * 6, abs=1e-12)
+        assert bbb.iloc[4:].to_numpy() == pytest.approx([1.0] * 6, abs=1e-12)
+
+    def test_rsquare_nonlinear_less_than_one(self, panel_nonlinear):
+        """Fibonacci 输入 → r² < 1（非线性）；线性对照组 r² = 1。"""
+        result = evaluate(parse("RSQUARE($close, 5)"), panel_nonlinear)
+        aaa_r2 = _aaa(result).iloc[4:]   # Fibonacci
+        bbb_r2 = _bbb(result).iloc[4:]   # 线性
+        # AAA 非线性：每一个 r² 都 < 1（但仍 > 0.9，因为指数增长近似线性）
+        assert (aaa_r2 < 1.0 - 1e-6).all()
+        # BBB 线性对照：r² = 1
+        assert bbb_r2.to_numpy() == pytest.approx([1.0] * 6, abs=1e-12)
+
+    def test_resi_linear_is_zero(self, panel):
+        """线性输入 → resi ≈ 0（两个 ticker 都一样）。"""
+        result = evaluate(parse("RESI($close, 5)"), panel)
+        aaa = _aaa(result)
+        bbb = _bbb(result)
+        assert aaa.iloc[4:].to_numpy() == pytest.approx([0.0] * 6, abs=1e-10)
+        assert bbb.iloc[4:].to_numpy() == pytest.approx([0.0] * 6, abs=1e-10)
+
+    def test_resi_last_point_formula(self, panel_nonlinear):
+        """RESI 必须返回最后一点的残差，不是整段残差序列。
+
+        手算 AAA Fibonacci 窗口 [i=3..5] = [3, 5, 8]，n=3：
+          Σy = 16, Σxy = Σ(i·y) − k_start·Σy where k_start = 3
+               = (3·3 + 4·5 + 5·8) − 3·16
+               = (9 + 20 + 40) − 48 = 21
+          Σx = n(n-1)/2 = 3, Σxx = n(n-1)(2n-1)/6 = 5
+          D  = n·Σxx − Σx² = 15 − 9 = 6
+          slope     = (n·Σxy − Σx·Σy) / D = (3·21 − 3·16) / 6 = (63 − 48)/6 = 2.5
+          intercept = (Σy − slope·Σx) / n = (16 − 7.5) / 3 = 8.5/3 ≈ 2.8333
+          resi_t = y_t − (intercept + slope·(n−1))
+                 = 8 − (2.8333 + 2.5·2) = 8 − 7.8333 = 0.1667
+        """
+        result = evaluate(parse("RESI($close, 3)"), panel_nonlinear)
+        # AAA 第 i=5 行（窗口 [3..5]） → 对应 iloc[5]
+        aaa_resi_5 = _aaa(result).iloc[5]
+        assert aaa_resi_5 == pytest.approx(1.0 / 6.0, abs=1e-10)

--- a/tests/test_factor_data.py
+++ b/tests/test_factor_data.py
@@ -1,21 +1,31 @@
 # tests/test_factor_data.py
-"""m1a — Tokenizer / Parser / AST 单元测试。
+"""m1a — Tokenizer / Parser / AST 单元测试
+m1b — Evaluator + 12 基础函数数值测试。
 
-不跑 OHLCV 数据，只验证：
+m1a 不跑 OHLCV 数据，只验证：
   - Token 流正确性
   - AST 结构形状
   - lookback() 数值
   - walk() DFS 顺序
 
+m1b 造 2 tickers 合成 OHLCV，验证：
+  - 变量映射（CLOSE→adj_close，OPEN 非复权等）
+  - 每个基础函数数值正确
+  - ticker 隔离（rolling/shift 不跨 ticker 串数据）
+  - MAX/MIN overload 两条分支
+
 运行方式（仓库根目录）：
     pytest tests/test_factor_data.py -v
 """
 
+import numpy as np
+import pandas as pd
 import pytest
 
 from stockbee.factor_data.expression_engine import (
     BinaryOp,
     Constant,
+    Evaluator,
     ExpressionError,
     FunctionCall,
     Node,
@@ -26,6 +36,7 @@ from stockbee.factor_data.expression_engine import (
     UnaryOp,
     Variable,
     _REGISTRY,
+    evaluate,
     parse,
     tokenize,
 )
@@ -321,3 +332,475 @@ class TestFunctionSpecContract:
             assert _REGISTRY[name].cross_section is False, (
                 f"{name} 不应被标记为 cross_section"
             )
+
+
+# ===========================================================================
+# m1b — Evaluator + 基础函数（含合成 OHLCV 数值验证）
+# ===========================================================================
+#
+# Panel 设计（2 tickers × 10 天，日期对齐）：
+#   AAA: close = 1..10 递增
+#   BBB: close = 20..11 递减
+#   adj_close ≠ close（验证 CLOSE→adj_close 映射）：adj_close = close * 2
+#   open = close - 0.5（用于 MAX/MIN element-wise 和非复权验证）
+#   volume = 100..1000（AAA），200..2000（BBB）
+# ---------------------------------------------------------------------------
+
+_DATES = pd.date_range("2024-01-01", periods=10, freq="D")
+
+
+def _make_panel(include_vwap: bool = False) -> pd.DataFrame:
+    """造 2 tickers × 10 天合成 OHLCV。索引 (date, ticker)。"""
+    rows = []
+    for ticker, close_series in (
+        ("AAA", list(range(1, 11))),              # 1..10
+        ("BBB", list(range(20, 10, -1))),         # 20..11
+    ):
+        for i, date in enumerate(_DATES):
+            close = close_series[i]
+            row = {
+                "date":      date,
+                "ticker":    ticker,
+                "open":      close - 0.5,          # 非复权，MAX elem 测试用
+                "high":      close + 0.5,
+                "low":       close - 1.0,
+                "close":     close,                # 非复权原价
+                "adj_close": close * 2.0,          # 复权价 = 2 × close
+                "volume":    (100 if ticker == "AAA" else 200) * (i + 1),
+            }
+            if include_vwap:
+                row["vwap"] = close + 0.1
+            rows.append(row)
+
+    df = pd.DataFrame(rows).set_index(["date", "ticker"]).sort_index()
+    return df
+
+
+@pytest.fixture
+def panel() -> pd.DataFrame:
+    return _make_panel()
+
+
+@pytest.fixture
+def panel_with_vwap() -> pd.DataFrame:
+    return _make_panel(include_vwap=True)
+
+
+def _aaa(s: pd.Series) -> pd.Series:
+    """从 (date, ticker) 索引 Series 中取 AAA 子序列，按日期排序。"""
+    return s.xs("AAA", level="ticker").sort_index()
+
+
+def _bbb(s: pd.Series) -> pd.Series:
+    return s.xs("BBB", level="ticker").sort_index()
+
+
+# ---------------------------------------------------------------------------
+# TestEvaluator — 基础求值 + 变量映射
+# ---------------------------------------------------------------------------
+
+class TestEvaluator:
+    def test_constant_only_returns_scalar(self, panel):
+        """Constant root → 返回原生 Python 标量。"""
+        assert evaluate(parse("42"), panel) == 42
+        assert evaluate(parse("3.14"), panel) == pytest.approx(3.14)
+
+    def test_close_maps_to_adj_close(self, panel):
+        """$close → panel['adj_close'] 而非 panel['close']。"""
+        result = evaluate(parse("$close"), panel)
+        expected = panel["adj_close"]
+        pd.testing.assert_series_equal(
+            result.sort_index(), expected.sort_index(), check_names=False
+        )
+        # 显式验证 AAA 第一行是 2.0（= 1 * 2），不是 1.0
+        assert _aaa(result).iloc[0] == 2.0
+
+    def test_open_is_not_adjusted(self, panel):
+        """$open → panel['open']，不被当作 adj_open。"""
+        result = evaluate(parse("$open"), panel)
+        pd.testing.assert_series_equal(
+            result.sort_index(), panel["open"].sort_index(), check_names=False
+        )
+
+    def test_high_low_volume_direct(self, panel):
+        """HIGH/LOW/VOLUME 直连对应列。"""
+        pd.testing.assert_series_equal(
+            evaluate(parse("$high"), panel).sort_index(),
+            panel["high"].sort_index(),
+            check_names=False,
+        )
+        pd.testing.assert_series_equal(
+            evaluate(parse("$low"), panel).sort_index(),
+            panel["low"].sort_index(),
+            check_names=False,
+        )
+        pd.testing.assert_series_equal(
+            evaluate(parse("$volume"), panel).sort_index(),
+            panel["volume"].sort_index(),
+            check_names=False,
+        )
+
+    def test_vwap_when_present(self, panel_with_vwap):
+        """带 vwap 列的 panel 可以引用 $vwap。"""
+        result = evaluate(parse("$vwap"), panel_with_vwap)
+        pd.testing.assert_series_equal(
+            result.sort_index(),
+            panel_with_vwap["vwap"].sort_index(),
+            check_names=False,
+        )
+
+    def test_vwap_missing_raises(self, panel):
+        """panel 无 vwap 列时引用 $vwap → ExpressionError。"""
+        with pytest.raises(ExpressionError, match="vwap"):
+            evaluate(parse("$vwap"), panel)
+
+    def test_binop_arithmetic(self, panel):
+        """$close + $open：基于复权 close + 非复权 open。"""
+        result = evaluate(parse("$close + $open"), panel)
+        expected = panel["adj_close"] + panel["open"]
+        pd.testing.assert_series_equal(
+            result.sort_index(), expected.sort_index(), check_names=False
+        )
+
+    def test_binop_with_constant(self, panel):
+        """$close * 2 → adj_close * 2。"""
+        result = evaluate(parse("$close * 2"), panel)
+        expected = panel["adj_close"] * 2
+        pd.testing.assert_series_equal(
+            result.sort_index(), expected.sort_index(), check_names=False
+        )
+
+    def test_unary_negation(self, panel):
+        """-$close → -adj_close。"""
+        result = evaluate(parse("-$close"), panel)
+        expected = -panel["adj_close"]
+        pd.testing.assert_series_equal(
+            result.sort_index(), expected.sort_index(), check_names=False
+        )
+
+    def test_evaluator_reuse_across_asts(self, panel):
+        """同一 Evaluator 实例可连续求值多个 AST。"""
+        ev = Evaluator(panel)
+        r1 = ev.evaluate(parse("$close"))
+        r2 = ev.evaluate(parse("MA($close, 3)"))
+        assert isinstance(r1, pd.Series)
+        assert isinstance(r2, pd.Series)
+        # 第二次 evaluate 不影响第一次结果
+        pd.testing.assert_series_equal(
+            r1.sort_index(), panel["adj_close"].sort_index(), check_names=False
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestBasicFunctions — 12 个函数的数值正确性
+# ---------------------------------------------------------------------------
+
+class TestBasicFunctions:
+    def test_ref_shift_positive_n(self, panel):
+        """REF($close, 1)：每个 ticker 内沿时间 shift(1)，首行 NaN。"""
+        result = evaluate(parse("REF($close, 1)"), panel)
+        aaa = _aaa(result)
+        assert pd.isna(aaa.iloc[0])
+        # AAA: adj_close = 2,4,6,...；REF(1) 第 2 行 = 2（第 1 行 adj_close）
+        assert aaa.iloc[1] == 2.0
+        assert aaa.iloc[9] == 18.0   # 第 10 行 = 第 9 行 adj_close = 9*2
+
+    def test_delay_equals_ref(self, panel):
+        """DELAY 和 REF 是别名，结果必须完全相等。"""
+        r_ref = evaluate(parse("REF($close, 3)"), panel)
+        r_delay = evaluate(parse("DELAY($close, 3)"), panel)
+        pd.testing.assert_series_equal(r_ref, r_delay)
+
+    def test_ma_rolling_3(self, panel):
+        """MA($close, 3) 每个 ticker 手算 + 前 2 行 NaN。"""
+        result = evaluate(parse("MA($close, 3)"), panel)
+        aaa = _aaa(result)
+        # adj_close AAA = 2,4,6,8,10,12,14,16,18,20
+        # MA(3) 第 3 行 = (2+4+6)/3 = 4
+        assert pd.isna(aaa.iloc[0])
+        assert pd.isna(aaa.iloc[1])
+        assert aaa.iloc[2] == pytest.approx(4.0)
+        assert aaa.iloc[3] == pytest.approx(6.0)
+        assert aaa.iloc[9] == pytest.approx(18.0)  # (16+18+20)/3
+
+        bbb = _bbb(result)
+        # adj_close BBB = 40,38,36,34,32,30,28,26,24,22
+        # MA(3) 第 3 行 = (40+38+36)/3 = 38
+        assert bbb.iloc[2] == pytest.approx(38.0)
+        assert bbb.iloc[9] == pytest.approx(24.0)  # (26+24+22)/3
+
+    def test_mean_equals_ma(self, panel):
+        """MEAN 是 MA 的别名。"""
+        r_ma = evaluate(parse("MA($close, 5)"), panel)
+        r_mean = evaluate(parse("MEAN($close, 5)"), panel)
+        pd.testing.assert_series_equal(r_ma, r_mean)
+
+    def test_std_ddof1(self, panel):
+        """STD($close, 3) 用 ddof=1 样本方差。"""
+        result = evaluate(parse("STD($close, 3)"), panel)
+        aaa = _aaa(result)
+        # adj_close AAA 第 1-3 行 = 2,4,6；样本 std = 2.0
+        assert pd.isna(aaa.iloc[0])
+        assert pd.isna(aaa.iloc[1])
+        assert aaa.iloc[2] == pytest.approx(2.0)
+        # numpy std ddof=1 验证
+        expected = float(np.std([2.0, 4.0, 6.0], ddof=1))
+        assert aaa.iloc[2] == pytest.approx(expected)
+
+    def test_sum_rolling(self, panel):
+        """SUM($volume, 2)：滚动 2 日和。"""
+        result = evaluate(parse("SUM($volume, 2)"), panel)
+        aaa = _aaa(result)
+        # volume AAA = 100,200,300,400,...,1000
+        assert pd.isna(aaa.iloc[0])
+        assert aaa.iloc[1] == 300.0  # 100+200
+        assert aaa.iloc[9] == 1900.0  # 900+1000
+
+    def test_delta_equals_minus_ref(self, panel):
+        """DELTA(x, n) = x - REF(x, n)。"""
+        r_delta = evaluate(parse("DELTA($close, 2)"), panel)
+        r_manual = evaluate(parse("$close - REF($close, 2)"), panel)
+        pd.testing.assert_series_equal(r_delta, r_manual)
+        # 具体数值：AAA adj_close 差 2 行 = 每个 4.0（等差 2×2）
+        aaa = _aaa(r_delta)
+        assert pd.isna(aaa.iloc[0])
+        assert pd.isna(aaa.iloc[1])
+        assert aaa.iloc[2] == pytest.approx(4.0)
+
+    def test_abs_of_negative(self, panel):
+        """ABS(-$close) == $close。"""
+        r_abs = evaluate(parse("ABS(-$close)"), panel)
+        r_close = evaluate(parse("$close"), panel)
+        pd.testing.assert_series_equal(r_abs, r_close, check_names=False)
+        assert (r_abs >= 0).all()
+
+    def test_log_positive(self, panel):
+        """LOG($close) vs np.log(adj_close)。"""
+        result = evaluate(parse("LOG($close)"), panel)
+        expected = pd.Series(
+            np.log(panel["adj_close"].to_numpy()),
+            index=panel.index,
+        )
+        pd.testing.assert_series_equal(
+            result.sort_index(), expected.sort_index(), check_names=False
+        )
+
+    def test_sign_delta(self, panel):
+        """SIGN($close - REF($close, 1)) 对递增 AAA 应全为 +1（除首行 NaN）。"""
+        result = evaluate(parse("SIGN($close - REF($close, 1))"), panel)
+        aaa = _aaa(result)
+        assert pd.isna(aaa.iloc[0])
+        # AAA adj_close 递增 2→4→6...，diff 恒正 → sign = 1
+        assert (aaa.iloc[1:] == 1.0).all()
+
+        bbb = _bbb(result)
+        # BBB adj_close 递减 40→38→36...，diff 恒负 → sign = -1
+        assert pd.isna(bbb.iloc[0])
+        assert (bbb.iloc[1:] == -1.0).all()
+
+    def test_max_rolling_branch(self, panel):
+        """MAX($close, 3)：arg[1]=int≥2 → rolling max。"""
+        result = evaluate(parse("MAX($close, 3)"), panel)
+        aaa = _aaa(result)
+        # AAA 递增 → rolling max 就是窗口末端
+        assert pd.isna(aaa.iloc[0])
+        assert pd.isna(aaa.iloc[1])
+        assert aaa.iloc[2] == pytest.approx(6.0)    # max(2,4,6)
+        assert aaa.iloc[9] == pytest.approx(20.0)   # max(16,18,20)
+
+        bbb = _bbb(result)
+        # BBB 递减 → rolling max 就是窗口起点
+        assert bbb.iloc[2] == pytest.approx(40.0)   # max(40,38,36)
+        assert bbb.iloc[9] == pytest.approx(26.0)   # max(26,24,22)
+
+    def test_max_elementwise_branch_two_series(self, panel):
+        """MAX($close, $open)：arg[1] 是 Variable → element-wise max。
+
+        adj_close 始终 > open（AAA: 2..20 vs 0.5..9.5），结果等于 $close。
+        """
+        result = evaluate(parse("MAX($close, $open)"), panel)
+        expected = panel["adj_close"]   # 因为 adj_close > open
+        pd.testing.assert_series_equal(
+            result.sort_index(), expected.sort_index(), check_names=False,
+            check_dtype=False,
+        )
+
+    def test_max_elementwise_branch_with_float_constant(self, panel):
+        """MAX($close, 5.0)：float 常量 → element-wise，不触发 rolling。"""
+        result = evaluate(parse("MAX($close, 5.0)"), panel)
+        aaa = _aaa(result)
+        # AAA adj_close = 2..20，clip 下界到 5
+        # iloc[0] = max(2, 5) = 5, iloc[1] = max(4, 5) = 5, iloc[2] = max(6, 5) = 6
+        assert aaa.iloc[0] == 5.0
+        assert aaa.iloc[1] == 5.0
+        assert aaa.iloc[2] == 6.0
+        assert aaa.iloc[9] == 20.0
+
+    def test_min_rolling_branch(self, panel):
+        """MIN($close, 3) rolling 分支。"""
+        result = evaluate(parse("MIN($close, 3)"), panel)
+        aaa = _aaa(result)
+        assert aaa.iloc[2] == pytest.approx(2.0)   # min(2,4,6)
+        assert aaa.iloc[9] == pytest.approx(16.0)  # min(16,18,20)
+
+    def test_min_elementwise_with_integer_one(self, panel):
+        """MIN($close, 1)：arg[1]=1 < 2 → element-wise（clip 上限到 1）。"""
+        result = evaluate(parse("MIN($close, 1)"), panel)
+        aaa = _aaa(result)
+        # 所有 adj_close 都 ≥ 2，取 min 与 1 → 全部 1
+        assert (aaa == 1.0).all()
+
+
+# ---------------------------------------------------------------------------
+# TestTickerIsolation — rolling / shift 不跨 ticker 串数据
+# ---------------------------------------------------------------------------
+
+class TestTickerIsolation:
+    def test_ma_does_not_leak_across_tickers(self, panel):
+        """AAA 第 3 行的 MA(3) 必须只用 AAA 的前 3 日，不掺 BBB。"""
+        result = evaluate(parse("MA($close, 3)"), panel)
+
+        # AAA 前 3 行 adj_close = 2,4,6 → mean = 4
+        # 如果跨 ticker 串数据，BBB 的 40 会污染结果
+        aaa_row3 = _aaa(result).iloc[2]
+        assert aaa_row3 == pytest.approx(4.0)
+        assert aaa_row3 != pytest.approx(
+            (2 + 4 + 40) / 3, abs=1e-3
+        ), "rolling 串了 BBB 的数据"
+
+    def test_ref_shift_is_ticker_scoped(self, panel):
+        """REF($close, 1) 对 BBB 首行 NaN，不把 AAA 的末值接过去。"""
+        result = evaluate(parse("REF($close, 1)"), panel)
+        bbb = _bbb(result)
+        assert pd.isna(bbb.iloc[0])
+        # BBB 第 2 行 = 40（BBB 首行 adj_close），不是 AAA 末行 20
+        assert bbb.iloc[1] == 40.0
+
+
+# ---------------------------------------------------------------------------
+# TestEndToEnd — parse → evaluate 整链路
+# ---------------------------------------------------------------------------
+
+class TestEndToEnd:
+    def test_ma_diff(self, panel):
+        """MA($close, 3) - MA($close, 5)：组合表达式跑通。"""
+        result = evaluate(parse("MA($close, 3) - MA($close, 5)"), panel)
+        # AAA adj_close = 2,4,6,8,10,12,14,16,18,20
+        # 第 5 行（iloc=4）：MA3=(6+8+10)/3=8, MA5=(2+4+6+8+10)/5=6, diff=2
+        aaa = _aaa(result)
+        assert pd.isna(aaa.iloc[3])   # MA5 还没到位
+        assert aaa.iloc[4] == pytest.approx(2.0)
+
+    def test_nested_ma_ref(self, panel):
+        """MA(REF($close, 1), 3)：嵌套函数调用。
+
+        等价于：先对 close 做 shift(1)，再对结果做 MA(3)。
+        AAA adj_close = 2,4,6,8,...；shift(1) = NaN,2,4,6,...
+        MA(3) 需要窗口满 → iloc[3] = (2+4+6)/3 = 4
+        """
+        result = evaluate(parse("MA(REF($close, 1), 3)"), panel)
+        aaa = _aaa(result)
+        # 前 3 行 NaN（shift 吃 1 + 窗口前 2）
+        assert pd.isna(aaa.iloc[0])
+        assert pd.isna(aaa.iloc[1])
+        assert pd.isna(aaa.iloc[2])
+        assert aaa.iloc[3] == pytest.approx(4.0)
+
+
+# ---------------------------------------------------------------------------
+# TestEvaluatorErrors — 错误路径
+# ---------------------------------------------------------------------------
+
+class TestEvaluatorErrors:
+    def test_non_multiindex_raises(self):
+        """单层索引 panel → raise。"""
+        df = pd.DataFrame({"adj_close": [1, 2, 3]})
+        with pytest.raises(ExpressionError, match="MultiIndex"):
+            Evaluator(df)
+
+    def test_missing_ticker_level_raises(self):
+        """MultiIndex 但无 ticker 一级 → raise。"""
+        idx = pd.MultiIndex.from_product(
+            [pd.date_range("2024-01-01", periods=3), ["X"]],
+            names=["date", "symbol"],   # 故意不叫 ticker
+        )
+        df = pd.DataFrame({"adj_close": [1, 2, 3]}, index=idx)
+        with pytest.raises(ExpressionError, match="ticker"):
+            Evaluator(df)
+
+    def test_not_a_dataframe_raises(self):
+        with pytest.raises(ExpressionError, match="DataFrame"):
+            Evaluator([1, 2, 3])  # type: ignore[arg-type]
+
+    def test_missing_column_raises_on_reference(self):
+        """panel 无 adj_close 列时 evaluate $close → raise。"""
+        idx = pd.MultiIndex.from_product(
+            [pd.date_range("2024-01-01", periods=3), ["X"]],
+            names=["date", "ticker"],
+        )
+        # 故意不放 adj_close
+        df = pd.DataFrame({"open": [1, 2, 3]}, index=idx)
+        with pytest.raises(ExpressionError, match="adj_close"):
+            evaluate(parse("$close"), df)
+
+    def test_three_level_index_raises(self):
+        """(date, exchange, ticker) 三级索引必须被拒绝。
+
+        否则 groupby(level='ticker') 只挑一级分组，rolling 会跨 exchange
+        把同一 ticker 在不同 exchange 的行串成一段假连续序列，
+        输出数值错误且无法被 unit test 捕获（bug 由 Codex P2 review 发现）。
+        """
+        idx = pd.MultiIndex.from_tuples(
+            [
+                (pd.Timestamp("2024-01-01"), "NYSE",   "X"),
+                (pd.Timestamp("2024-01-01"), "NASDAQ", "X"),
+                (pd.Timestamp("2024-01-02"), "NYSE",   "X"),
+                (pd.Timestamp("2024-01-02"), "NASDAQ", "X"),
+            ],
+            names=["date", "exchange", "ticker"],
+        )
+        df = pd.DataFrame({"adj_close": [1.0, 2.0, 3.0, 4.0]}, index=idx)
+        with pytest.raises(ExpressionError, match="2 级"):
+            Evaluator(df)
+
+
+# ---------------------------------------------------------------------------
+# TestEvaluatorEdgeCases — 回归测试（P2/P3 Codex review fixes）
+# ---------------------------------------------------------------------------
+
+class TestMaxMinScalarConstants:
+    """MAX/MIN overload 在纯标量表达式上必须正常返回，不崩溃。
+
+    Bug 由 Codex P3 review 发现：pure-scalar MAX(1, 2) 会错误地命中
+    rolling 分支（因为 arg[1]=2 满足 int≥2 条件），然后把标量 1 传给
+    _impl_max_rolling → .groupby(...) → AttributeError。
+    修复：rolling 分支增加 isinstance(a, Series) 守卫，退化到 element-wise。
+    """
+
+    def test_max_two_int_constants(self, panel):
+        """MAX(1, 2) 纯标量 → 返回 Python int 2。"""
+        assert evaluate(parse("MAX(1, 2)"), panel) == 2
+        # 类型保留为 Python int（不是 numpy 标量）
+        assert type(evaluate(parse("MAX(1, 2)"), panel)) is int
+
+    def test_min_two_int_constants(self, panel):
+        """MIN(5, 3) 纯标量 → 3。"""
+        assert evaluate(parse("MIN(5, 3)"), panel) == 3
+        assert type(evaluate(parse("MIN(5, 3)"), panel)) is int
+
+    def test_max_int_with_large_window_syntax(self, panel):
+        """MAX(7, 10) 虽然 arg[1]=10 满足 rolling 语法，
+        但 arg[0] 是标量，必须回落到 element-wise，返回 10。"""
+        assert evaluate(parse("MAX(7, 10)"), panel) == 10
+
+    def test_max_float_constants(self, panel):
+        """MAX(1.5, 2.5)：float 常量本就走 elem-wise 分支。"""
+        result = evaluate(parse("MAX(1.5, 2.5)"), panel)
+        assert result == pytest.approx(2.5)
+        assert isinstance(result, float)
+
+    def test_max_series_with_rolling_window_still_works(self, panel):
+        """回归测试：修复 P3 不能破坏正常的 rolling 分支。"""
+        result = evaluate(parse("MAX($close, 3)"), panel)
+        # 之前已经验证过的数值，必须依然正确
+        assert _aaa(result).iloc[2] == pytest.approx(6.0)

--- a/tests/test_factor_integration.py
+++ b/tests/test_factor_integration.py
@@ -1,0 +1,512 @@
+# tests/test_factor_integration.py
+"""m7 — 集成层 edge case 测试（LocalFactorProvider 跨模块交互）。
+
+这里测试的是 expression engine / Alpha158 / ParquetFactorStore / ic_evaluator /
+LocalFactorProvider 组合后才会暴露的 corner case。单元层已经覆盖的路径
+（base happy path、基础 setter 校验、list_factors shadowing）在 test_factor_data.py
+的 TestLocalFactorProvider 中，这里不再重复。
+
+运行：
+    pytest tests/test_factor_integration.py -v
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from stockbee.factor_data import (
+    ICUniverse,
+    LocalFactorProvider,
+    ParquetFactorStore,
+)
+from stockbee.providers.base import ProviderConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers —— 文件内 local，保持 m7 文件自包含
+# ---------------------------------------------------------------------------
+
+def _make_ohlcv(
+    tickers: list[str],
+    start: str | pd.Timestamp,
+    n_days: int = 60,
+    *,
+    adj_ratio: float = 1.0,
+    volume: int | None = None,
+    seed: int = 42,
+) -> pd.DataFrame:
+    """合成 MultiIndex (date, ticker) OHLCV。
+
+    adj_ratio != 1.0 时 adj_close = close * adj_ratio，用于验证 $close → adj_close。
+    volume 给定时 volume 列被写为常数，便于 VMA 类因子确定性断言。
+    """
+    rng = np.random.default_rng(seed)
+    dates = pd.bdate_range(start, periods=n_days)
+    rows = []
+    for t in tickers:
+        price = 100.0 + rng.uniform(-5, 5)
+        for d in dates:
+            rows.append({
+                "date": d,
+                "ticker": t,
+                "open": price * 0.99,
+                "high": price * 1.01,
+                "low": price * 0.98,
+                "close": price,
+                "adj_close": price * adj_ratio,
+                "volume": volume if volume is not None
+                    else int(rng.integers(1000, 10000)),
+            })
+            price *= 1 + rng.normal(0, 0.02)
+    return pd.DataFrame(rows).set_index(["date", "ticker"]).sort_index()
+
+
+def _make_ohlcv_per_ticker(specs: dict[str, tuple[str, int]]) -> pd.DataFrame:
+    """每个 ticker 独立起止日期：specs={ticker: (start, n_days)}。"""
+    frames = [_make_ohlcv([t], start, n, seed=hash(t) & 0xFFFF)
+              for t, (start, n) in specs.items()]
+    return pd.concat(frames).sort_index()
+
+
+def _mock_market_data(ohlcv: pd.DataFrame) -> MagicMock:
+    mock = MagicMock()
+    mock.get_daily_bars.return_value = ohlcv
+    return mock
+
+
+def _write_precomputed(
+    tmp_path,
+    group: str,
+    tickers: list[str],
+    dates: list[str] | list[pd.Timestamp],
+    columns: dict[str, list[float]] | None = None,
+) -> None:
+    store = ParquetFactorStore(tmp_path)
+    idx_tuples = [(pd.Timestamp(d), t) for d in dates for t in tickers]
+    idx = pd.MultiIndex.from_tuples(idx_tuples, names=["date", "ticker"])
+    n = len(idx_tuples)
+    if columns is None:
+        columns = {"pe_ratio": [float(i) for i in range(n)]}
+    df = pd.DataFrame(columns, index=idx, dtype=float)
+    store.write_factors(group, df)
+
+
+def _build_provider(
+    tmp_path,
+    market_data=None,
+    ic_universe: ICUniverse | None = None,
+) -> LocalFactorProvider:
+    provider = LocalFactorProvider(
+        ProviderConfig(
+            implementation="LocalFactorProvider",
+            params={"precomputed_path": str(tmp_path)},
+        ),
+    )
+    if market_data is not None:
+        provider.market_data = market_data
+    if ic_universe is not None:
+        provider.ic_universe = ic_universe
+    return provider
+
+
+# ===========================================================================
+# A. Lookback & date arithmetic
+# ===========================================================================
+
+class TestLookbackAndDateArithmetic:
+
+    def test_nested_ref_lookback_through_provider(self, tmp_path):
+        """MA(REF($close,5),20) 类嵌套表达式 lookback = 5+20=25，trim 后首日 ≥ user_start。"""
+        from stockbee.factor_data.alpha158 import Alpha158
+        from stockbee.factor_data.expression_engine import parse
+        # Alpha158 暂无 MA(REF) 类工厂，用已有 RANK30 (TS_RANK($close,30)) 自带 lookback=30 做代理
+        # 这里先验证 Alpha158 暴露的 max_lookback 和 AST 嵌套一致。
+        a = Alpha158()
+        # 手工 parse 嵌套表达式验证 AST 语义
+        nested = parse("MEAN(REF($close,5),20)")
+        assert nested.lookback() == 25
+        # 并验证 Alpha158 中 RANK30 factor 的 lookback 等于 30（作为集成 sanity）
+        assert a.max_lookback("RANK30") == 30
+
+    def test_lookback_extended_start_uses_calendar_multiplier(self, tmp_path):
+        """验证 provider 向 get_daily_bars 传入的 start = user_start − lookback × 2 日历日。"""
+        ohlcv = _make_ohlcv(["AAPL"], "2024-01-01", n_days=120)
+        mock = _mock_market_data(ohlcv)
+        provider = _build_provider(tmp_path, market_data=mock)
+
+        user_start = date(2024, 3, 1)
+        user_end = date(2024, 3, 31)
+        provider.get_factors(["AAPL"], ["MA30"], user_start, user_end)
+
+        _args, kwargs = mock.get_daily_bars.call_args
+        # signature: get_daily_bars(tickers, start, end)
+        start_arg = mock.get_daily_bars.call_args.args[1]
+        assert start_arg == user_start - timedelta(days=30 * 2)
+
+    def test_trim_removes_lookback_overshoot(self, tmp_path):
+        """market_data 返回超出 user_start 的历史数据，最终结果首日 ≥ user_start。"""
+        ohlcv = _make_ohlcv(["AAPL"], "2024-01-01", n_days=120)
+        provider = _build_provider(tmp_path, market_data=_mock_market_data(ohlcv))
+
+        user_start = date(2024, 3, 1)
+        user_end = date(2024, 3, 15)
+        result = provider.get_factors(["AAPL"], ["MA30"], user_start, user_end)
+
+        dates = result.index.get_level_values("date")
+        assert dates.min() >= pd.Timestamp(user_start)
+        assert dates.max() <= pd.Timestamp(user_end)
+
+    def test_max_lookback_aggregated_across_factors(self, tmp_path):
+        """请求 [MA5, MA30, MA60] → extended_start 用 max(60)*2 天，不是每因子独立扩展。"""
+        ohlcv = _make_ohlcv(["AAPL"], "2023-10-01", n_days=200)
+        mock = _mock_market_data(ohlcv)
+        provider = _build_provider(tmp_path, market_data=mock)
+
+        user_start = date(2024, 3, 1)
+        user_end = date(2024, 3, 31)
+        provider.get_factors(
+            ["AAPL"], ["MA5", "MA30", "MA60"], user_start, user_end,
+        )
+
+        start_arg = mock.get_daily_bars.call_args.args[1]
+        # max lookback = 60, extended = user_start - 60*2 = 120 calendar days
+        assert start_arg == user_start - timedelta(days=60 * 2)
+        # get_daily_bars 只被调用一次（batched，不是每因子一次）
+        assert mock.get_daily_bars.call_count == 1
+
+
+# ===========================================================================
+# B. Ticker / Index isolation
+# ===========================================================================
+
+class TestTickerAndIndexIsolation:
+
+    def test_multiindex_groupby_isolation(self, tmp_path):
+        """2 tickers 不同起止日，MA5 在各自前 4 天为 NaN，不从另一个 ticker 串数据。"""
+        ohlcv = _make_ohlcv_per_ticker({
+            "AAPL": ("2024-01-01", 60),
+            "TSLA": ("2024-02-01", 40),  # TSLA 晚 1 个月入场
+        })
+        provider = _build_provider(tmp_path, market_data=_mock_market_data(ohlcv))
+
+        result = provider.get_factors(
+            ["AAPL", "TSLA"], ["MA5"],
+            date(2024, 2, 1), date(2024, 3, 15),
+        )
+        # TSLA 在 2024-02-01 起的前 4 天应该是 NaN（MA5 min_periods=5）
+        tsla_first_4 = result.xs("TSLA", level="ticker").head(4)["MA5"]
+        assert tsla_first_4.isna().all()
+        # TSLA 第 5 天开始非 NaN
+        tsla_day5 = result.xs("TSLA", level="ticker").iloc[4]["MA5"]
+        assert not pd.isna(tsla_day5)
+        # AAPL 在同期已有 20+ 历史数据，MA5 应全部有值
+        aapl_slice = result.xs("AAPL", level="ticker")
+        assert aapl_slice["MA5"].notna().all()
+
+    def test_ticker_subset_returned_by_market_data(self, tmp_path):
+        """请求 [AAPL, TSLA, NVDA]，market_data 只返回 [AAPL, TSLA] → 输出只含 AAPL/TSLA，不崩。"""
+        ohlcv = _make_ohlcv(["AAPL", "TSLA"], "2024-01-01", n_days=60)
+        provider = _build_provider(tmp_path, market_data=_mock_market_data(ohlcv))
+
+        result = provider.get_factors(
+            ["AAPL", "TSLA", "NVDA"], ["KMID"],
+            date(2024, 2, 1), date(2024, 3, 1),
+        )
+        tickers_in_result = set(result.index.get_level_values("ticker").unique())
+        assert tickers_in_result == {"AAPL", "TSLA"}
+
+    def test_date_level_normalization_end_to_end(self, tmp_path):
+        """market_data 返回 datetime.date level index（非 Timestamp）→ 合并不 TypeError。"""
+        # 构造 object dtype date level
+        tuples = [(date(2024, 1, d), "AAPL")
+                  for d in range(2, 21) if date(2024, 1, d).weekday() < 5]
+        idx = pd.MultiIndex.from_tuples(tuples, names=["date", "ticker"])
+        n = len(idx)
+        ohlcv = pd.DataFrame({
+            "open": np.linspace(100, 120, n),
+            "high": np.linspace(101, 121, n),
+            "low": np.linspace(99, 119, n),
+            "close": np.linspace(100, 120, n),
+            "adj_close": np.linspace(100, 120, n),
+            "volume": [1000] * n,
+        }, index=idx)
+        assert not pd.api.types.is_datetime64_any_dtype(
+            ohlcv.index.get_level_values("date"),
+        )
+        provider = _build_provider(tmp_path, market_data=_mock_market_data(ohlcv))
+
+        result = provider.get_factors(
+            ["AAPL"], ["KMID"], date(2024, 1, 2), date(2024, 1, 20),
+        )
+        # 最关键：不抛 TypeError，且 date 级别已被规范成 datetime64
+        assert pd.api.types.is_datetime64_any_dtype(
+            result.index.get_level_values("date"),
+        )
+        assert len(result) > 0
+
+
+# ===========================================================================
+# D. Precomputed merge & routing
+# ===========================================================================
+
+class TestPrecomputedMergeAndRouting:
+
+    def test_expression_plus_precomputed_index_alignment(self, tmp_path):
+        """Parquet (date,ticker) 与 Evaluator 结果 (date,ticker) 合并后索引完全对齐、列顺序稳定。"""
+        ohlcv = _make_ohlcv(["AAPL", "TSLA"], "2024-01-01", n_days=60)
+        dates_str = [str(d.date()) for d in pd.bdate_range("2024-01-01", periods=60)]
+        _write_precomputed(tmp_path, "fundamental",
+                           ["AAPL", "TSLA"], dates_str)
+        provider = _build_provider(tmp_path, market_data=_mock_market_data(ohlcv))
+
+        result = provider.get_factors(
+            ["AAPL", "TSLA"], ["KMID", "pe_ratio"],
+            date(2024, 2, 1), date(2024, 3, 1),
+        )
+        # 索引是 (date, ticker) MultiIndex，完整 sort，无重复
+        assert list(result.index.names) == ["date", "ticker"]
+        assert not result.index.duplicated().any()
+        assert result.index.is_monotonic_increasing
+        assert list(result.columns) == ["KMID", "pe_ratio"]
+
+    def test_cross_group_precomputed_merge(self, tmp_path):
+        """请求跨两个 Parquet group 的 precomputed 因子 → 合并成一个 DataFrame。"""
+        dates_str = ["2024-01-15", "2024-01-16", "2024-01-17"]
+        _write_precomputed(
+            tmp_path, "fundamental", ["AAPL", "TSLA"], dates_str,
+            {"pe_ratio": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]},
+        )
+        _write_precomputed(
+            tmp_path, "sentiment", ["AAPL", "TSLA"], dates_str,
+            {"mood_score": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]},
+        )
+        provider = _build_provider(tmp_path)
+
+        result = provider.get_factors(
+            ["AAPL", "TSLA"], ["pe_ratio", "mood_score"],
+            date(2024, 1, 15), date(2024, 1, 17),
+        )
+        assert list(result.columns) == ["pe_ratio", "mood_score"]
+        assert result["pe_ratio"].notna().all()
+        assert result["mood_score"].notna().all()
+        assert len(result) == 6  # 3 dates × 2 tickers
+
+    def test_expression_and_precomputed_different_date_ranges(self, tmp_path):
+        """precomputed 只覆盖部分日期 → 合并后 precomputed 在未覆盖日为 NaN，expression 仍有值。"""
+        ohlcv = _make_ohlcv(["AAPL"], "2024-01-01", n_days=60)
+        # Precomputed 只有 2024-02-01 ~ 2024-02-05
+        pre_dates = [str(d.date()) for d in
+                     pd.bdate_range("2024-02-01", periods=5)]
+        _write_precomputed(tmp_path, "fundamental",
+                           ["AAPL"], pre_dates, {"pe_ratio": [10.0] * 5})
+        provider = _build_provider(tmp_path, market_data=_mock_market_data(ohlcv))
+
+        # 请求范围超过 precomputed 实际覆盖
+        result = provider.get_factors(
+            ["AAPL"], ["KMID", "pe_ratio"],
+            date(2024, 2, 1), date(2024, 2, 15),
+        )
+        # precomputed 在覆盖范围内非 NaN
+        covered = result.loc[
+            pd.IndexSlice[pd.Timestamp("2024-02-02"):pd.Timestamp("2024-02-07"), :],
+            "pe_ratio",
+        ]
+        assert covered.notna().any()
+        # precomputed 在 2024-02-10 之后应为 NaN
+        uncovered = result.loc[
+            pd.IndexSlice[pd.Timestamp("2024-02-10"):, :], "pe_ratio",
+        ]
+        assert uncovered.isna().all()
+        # KMID（expression）全程非 NaN
+        assert result["KMID"].notna().all()
+
+
+# ===========================================================================
+# E. Variable mapping & price semantics
+# ===========================================================================
+
+class TestVariableMappingSemantics:
+
+    def test_dollar_close_maps_to_adj_close_not_close(self, tmp_path):
+        """adj_close=2×close，KMID=($close-$open)/$open 应使用 adj_close，断言数值与 adj 版对齐。"""
+        ohlcv = _make_ohlcv(
+            ["AAPL"], "2024-01-01", n_days=30, adj_ratio=2.0,
+        )
+        # 此时 adj_close = close * 2，open 未被改动
+        # KMID = (adj_close - open)/open ≈ (2*close - open)/open
+        # 若错误地用 close 而不是 adj_close，KMID ≈ (close - open)/open
+        # 两者差显著。
+        provider = _build_provider(tmp_path, market_data=_mock_market_data(ohlcv))
+
+        result = provider.get_factors(
+            ["AAPL"], ["KMID"], date(2024, 1, 2), date(2024, 1, 30),
+        )
+        # 手算期望：对齐 provider trim 后的范围
+        merged = ohlcv.loc[
+            (ohlcv.index.get_level_values("date") >= pd.Timestamp("2024-01-02"))
+            & (ohlcv.index.get_level_values("date") <= pd.Timestamp("2024-01-30"))
+        ]
+        expected = (merged["adj_close"] - merged["open"]) / merged["open"]
+        wrong = (merged["close"] - merged["open"]) / merged["open"]
+        # provider 结果与 adj 版一致，与非 adj 版显著不同
+        np.testing.assert_allclose(
+            result["KMID"].values, expected.values, rtol=1e-9,
+        )
+        assert not np.allclose(result["KMID"].values, wrong.values, rtol=1e-3)
+
+    def test_dollar_volume_not_adjusted(self, tmp_path):
+        """volume 常数 1000 → VMA5 = MEAN/volume ≈ 1.0，证明 $volume → volume 原始列。"""
+        ohlcv = _make_ohlcv(
+            ["AAPL"], "2024-01-01", n_days=30, volume=1000,
+        )
+        provider = _build_provider(tmp_path, market_data=_mock_market_data(ohlcv))
+
+        result = provider.get_factors(
+            ["AAPL"], ["VMA5"], date(2024, 1, 10), date(2024, 1, 30),
+        )
+        # 常数 volume → MEAN = volume → ratio ≈ 1.0（带 +1e-12 扰动）
+        np.testing.assert_allclose(
+            result["VMA5"].dropna().values, 1.0, rtol=1e-6,
+        )
+
+
+# ===========================================================================
+# F. IC report integration
+# ===========================================================================
+
+class TestICReportIntegration:
+
+    def test_oracle_factor_gives_high_ic(self, tmp_path):
+        """precomputed factor = 未来 1 日收益（oracle） → IC 应接近 +1，证明 provider 不破坏 shift 语义。"""
+        tickers = ["AAPL", "TSLA", "NVDA"]
+        ohlcv = _make_ohlcv(tickers, "2024-01-01", n_days=80, seed=7)
+        # Oracle factor = fwd_ret = adj_close[t+1]/adj_close[t] - 1
+        fwd_ret = (
+            ohlcv.groupby(level="ticker")["adj_close"].shift(-1)
+            / ohlcv["adj_close"] - 1
+        ).dropna()
+        oracle_df = fwd_ret.to_frame("oracle")
+        store = ParquetFactorStore(tmp_path)
+        store.write_factors("signals", oracle_df)
+
+        provider = _build_provider(
+            tmp_path, market_data=_mock_market_data(ohlcv),
+            ic_universe=ICUniverse(
+                tickers=tickers,
+                start=date(2024, 1, 2),
+                end=date(2024, 4, 15),
+            ),
+        )
+        report = provider.get_ic_report("oracle", window=80)
+        # Oracle 因子与前向收益完全同构 → 每日 rank IC = 1.0，ic_mean 应 ≈ 1
+        assert report["ic_mean"] > 0.99
+        # 完美 oracle 使 ic_std=0 → icir=NaN（ic_evaluator 约定），
+        # ic_std ≈ 0 本身就证明 provider 未二次 shift（否则 IC 会偏离 1.0）。
+        assert report["ic_std"] < 1e-9 or pd.isna(report["ic_std"])
+
+    def test_ic_report_missing_adj_close_raises(self, tmp_path):
+        """market_data 返回 prices 缺 adj_close → ic_evaluator 抛 ValueError，经 provider 透传。"""
+        # Precomputed 因子（不需要 Evaluator，所以走 IC 路径时只会因 prices 缺列而炸）
+        tickers = ["AAPL", "TSLA"]
+        dates_str = [str(d.date()) for d in
+                     pd.bdate_range("2024-01-01", periods=30)]
+        n = len(dates_str) * len(tickers)
+        _write_precomputed(
+            tmp_path, "signals", tickers, dates_str,
+            {"pe_ratio": list(np.linspace(0, 1, n))},
+        )
+        # 故意不带 adj_close 列
+        idx = pd.MultiIndex.from_tuples(
+            [(pd.Timestamp(d), t) for d in dates_str for t in tickers],
+            names=["date", "ticker"],
+        )
+        bad_prices = pd.DataFrame({
+            "open": [100.0] * n,
+            "close": [101.0] * n,
+        }, index=idx)
+        provider = _build_provider(
+            tmp_path, market_data=_mock_market_data(bad_prices),
+            ic_universe=ICUniverse(
+                tickers=tickers,
+                start=date(2024, 1, 1),
+                end=date(2024, 2, 9),
+            ),
+        )
+        with pytest.raises(ValueError, match="adj_close"):
+            provider.get_ic_report("pe_ratio")
+
+    def test_ic_universe_range_outside_data_returns_nan(self, tmp_path):
+        """ic_universe 范围超出 ohlcv 实际数据 → 报告全 NaN，不崩。"""
+        ohlcv = _make_ohlcv(["AAPL", "TSLA"], "2024-01-01", n_days=30)
+        provider = _build_provider(
+            tmp_path, market_data=_mock_market_data(ohlcv),
+            ic_universe=ICUniverse(
+                tickers=["AAPL", "TSLA"],
+                start=date(2025, 6, 1),   # 数据外
+                end=date(2025, 12, 1),
+            ),
+        )
+        # mock 返回的 ohlcv 是 2024 年的，trim 到 2025 后应全部丢弃
+        # 注意 mock 每次返回相同 ohlcv —— trim 后 factor 部分会为空 → < 20 valid → NaN
+        report = provider.get_ic_report("KMID")
+        assert pd.isna(report["ic_mean"])
+        assert pd.isna(report["ic_std"])
+        assert pd.isna(report["icir"])
+
+
+# ===========================================================================
+# G. Column order, empty range, numerical anomaly
+# ===========================================================================
+
+class TestColumnOrderAndAnomalies:
+
+    def test_column_order_preserved_mixed_sources_interleaved(self, tmp_path):
+        """[precomp, expr, precomp, expr] 交错请求 → 输出列严格保序。"""
+        ohlcv = _make_ohlcv(["AAPL"], "2024-01-01", n_days=60)
+        dates_str = [str(d.date()) for d in pd.bdate_range("2024-01-01", periods=60)]
+        _write_precomputed(
+            tmp_path, "fundamental", ["AAPL"], dates_str,
+            {"pe_ratio": [1.0] * 60, "pb_ratio": [2.0] * 60},
+        )
+        provider = _build_provider(tmp_path, market_data=_mock_market_data(ohlcv))
+
+        ordered = ["pb_ratio", "KMID", "pe_ratio", "MA5"]
+        result = provider.get_factors(
+            ["AAPL"], ordered, date(2024, 2, 1), date(2024, 3, 1),
+        )
+        assert list(result.columns) == ordered
+
+    def test_open_zero_produces_inf_or_nan_without_crash(self, tmp_path):
+        """$open=0 使 KMID=($close-$open)/$open = inf/NaN，其他行仍有有限值，不抛异常。"""
+        ohlcv = _make_ohlcv(["AAPL"], "2024-01-01", n_days=10)
+        # 强行把第 5 行 open 改成 0
+        ohlcv.loc[(ohlcv.index[4]), "open"] = 0.0
+        provider = _build_provider(tmp_path, market_data=_mock_market_data(ohlcv))
+
+        result = provider.get_factors(
+            ["AAPL"], ["KMID"], date(2024, 1, 1), date(2024, 1, 12),
+        )
+        values = result["KMID"].values
+        # 至少一行不是有限数（inf 或 NaN）
+        assert not np.isfinite(values).all()
+        # 至少一行是有限数（其他正常行）
+        assert np.isfinite(values).any()
+
+    def test_empty_date_range_returns_empty_dataframe(self, tmp_path):
+        """请求的 date range 完全在数据之外 → 空 MultiIndex DataFrame，不 crash。"""
+        ohlcv = _make_ohlcv(["AAPL"], "2024-01-01", n_days=30)
+        provider = _build_provider(tmp_path, market_data=_mock_market_data(ohlcv))
+
+        result = provider.get_factors(
+            ["AAPL"], ["KMID", "MA5"],
+            date(2025, 6, 1), date(2025, 6, 30),
+        )
+        assert isinstance(result.index, pd.MultiIndex)
+        assert list(result.index.names) == ["date", "ticker"]
+        assert len(result) == 0
+        assert list(result.columns) == ["KMID", "MA5"]

--- a/tests/test_factor_integration.py
+++ b/tests/test_factor_integration.py
@@ -511,6 +511,49 @@ class TestColumnOrderAndAnomalies:
         # 至少一行是有限数（其他正常行）
         assert np.isfinite(values).any()
 
+    def test_refresh_precomputed_index_discovers_new_group(self, tmp_path):
+        """Lazy build 后写入新 group，refresh_precomputed_index 使其可被发现。"""
+        # 第一次 build 时 group 尚未存在
+        provider = _build_provider(tmp_path)
+        provider.initialize()
+        assert "pe_ratio" not in provider._precomputed_index
+
+        # 之后写入新 group —— 不 refresh 时应当认作 unknown factor
+        _write_precomputed(tmp_path, "fundamental",
+                           ["AAPL"], ["2024-01-02"], {"pe_ratio": [1.0]})
+        with pytest.raises(ValueError, match="Unknown factor"):
+            provider.get_factors(
+                ["AAPL"], ["pe_ratio"],
+                date(2024, 1, 2), date(2024, 1, 2),
+            )
+
+        # 调 refresh 后能找到
+        provider.refresh_precomputed_index()
+        assert "pe_ratio" in provider._precomputed_index
+        result = provider.get_factors(
+            ["AAPL"], ["pe_ratio"],
+            date(2024, 1, 2), date(2024, 1, 2),
+        )
+        assert len(result) == 1
+
+    def test_parquet_atomic_write_tmp_has_unique_suffix(self, tmp_path):
+        """并发写场景：tmp 文件名带 uuid，两次 write 不会互相覆盖 tmp。"""
+        import pyarrow.parquet as pq
+        store = ParquetFactorStore(tmp_path)
+        idx = pd.MultiIndex.from_tuples(
+            [(pd.Timestamp("2024-01-02"), "AAPL")], names=["date", "ticker"],
+        )
+        df1 = pd.DataFrame({"x": [1.0]}, index=idx)
+        df2 = pd.DataFrame({"y": [2.0]}, index=idx)
+        store.write_factors("g1", df1)
+        store.write_factors("g2", df2)
+
+        # 两个目标文件都存在，无 tmp 残留
+        leftover = list(tmp_path.glob("*.tmp*"))
+        assert leftover == []
+        assert (tmp_path / "g1.parquet").exists()
+        assert (tmp_path / "g2.parquet").exists()
+
     def test_empty_date_range_returns_empty_dataframe(self, tmp_path):
         """请求的 date range 完全在数据之外 → 空 MultiIndex DataFrame，不 crash。"""
         ohlcv = _make_ohlcv(["AAPL"], "2024-01-01", n_days=30)

--- a/tests/test_factor_integration.py
+++ b/tests/test_factor_integration.py
@@ -220,6 +220,20 @@ class TestTickerAndIndexIsolation:
         tickers_in_result = set(result.index.get_level_values("ticker").unique())
         assert tickers_in_result == {"AAPL", "TSLA"}
 
+    def test_date_level_normalization_ticker_date_order(self, tmp_path):
+        """MultiIndex names=['ticker','date'] 顺序时，_normalize_date_index 仍按名字定位 level，不崩。"""
+        from stockbee.factor_data.local_provider import _normalize_date_index
+        tuples = [("AAPL", date(2024, 1, d))
+                  for d in range(2, 10) if date(2024, 1, d).weekday() < 5]
+        idx = pd.MultiIndex.from_tuples(tuples, names=["ticker", "date"])
+        df = pd.DataFrame({"x": [1.0] * len(tuples)}, index=idx)
+        # 反序 MultiIndex，date 在位置 1。若实现用 levels[0] 会把 ticker 字符串
+        # 送进 to_datetime → 抛错；本用例保证 name-based 定位。
+        result = _normalize_date_index(df)
+        assert pd.api.types.is_datetime64_any_dtype(
+            result.index.get_level_values("date"),
+        )
+
     def test_date_level_normalization_end_to_end(self, tmp_path):
         """market_data 返回 datetime.date level index（非 Timestamp）→ 合并不 TypeError。"""
         # 构造 object dtype date level


### PR DESCRIPTION
## Summary

Closes Room **04-factor-storage** — 8/8 milestones 全部完成。交付量化因子存储与评估的完整 Feature：
- DSL 表达式引擎（Tokenizer/Parser/AST/Evaluator）+ 22 个函数
- Alpha158 全量 158 因子注册表（YAML 定义 + lazy parse + AST cache）
- ParquetFactorStore 预计算因子存储（merge-write + 原子重命名）
- IC/ICIR 离线评估器（Spearman rank IC + 前向收益 shift）
- LocalFactorProvider 路由层（expression + precomputed + IC 统一接口 + setter 注入 MarketData）
- 集成测试层（单元测试抓不到的跨模块 edge case）

## Milestones

| # | Milestone | 行数 | Tests |
|---|-----------|-----|-------|
| m1a | Tokenizer + Parser + AST | 740 | incl. below |
| m1b | Evaluator + 12 基础函数 | 866 | incl. below |
| m2 | 10 高级函数 (OLS/EMA/CORR/RANK/QUANTILE/IF/IDXMAX/IDXMIN) | 687 | incl. below |
| m3 | Alpha158 全量 158 因子 + TS_RANK/TS_QUANTILE | 516 | 167 |
| m4 | ParquetFactorStore | 315 | 17 |
| m5 | IC/ICIR evaluator | 248 | 19 |
| m6 | LocalFactorProvider + ICUniverse + 模块导出 | 470 | 20 |
| m7 | 集成 edge case 测试（7 组 × 18 cases） | 512 | 18 |

**全量回归：666 passed, 0 failed**

## Review 历程

- m1b–m3 经 ceo/eng review；Alpha158 定义含 8 条决策记录（见 spec.md）
- m5 经 Codex review，修掉 duplicate factor_df index 未校验 bug
- m7 plan 经 Staff Engineer review：删掉与 m6 重复的 3 个 case，强化 IC oracle 测试，新增 7 个 corner case
- m7 post-ship adversarial review 发现 \`_normalize_date_index\` 对 MultiIndex 位置有隐式依赖，已修（本 PR 最后一个 commit）

## Key Contracts 锁定

- \`\$close\` → \`adj_close\`（唯一被复权映射的价格），其他价 + volume 不复权
- IC shift=1 只在 \`ic_evaluator\` 层做，provider 不二次 shift（m7 oracle 因子测试保证）
- \`max_lookback\` 嵌套相加（MA(REF(c,5),20) → 25）
- Parquet group 按数据来源分组（fundamental/sentiment/ml_score）
- Expression 优先级高于 precomputed（同名时 shadow）

## Test plan

- [x] \`pytest tests/\` — 666 passed
- [x] 18 integration edge cases cover 7 组跨模块场景
- [x] m7 oracle 因子测试证明无 lookahead（factor=fwd_ret → IC≈1.0）
- [x] \`_normalize_date_index\` 反序 MultiIndex 回归测试
- [ ] 下游消费方（05-experience-buffer, 03-model-system）后续接入时做 provider 契约集成测试

🤖 Generated with [Claude Code](https://claude.com/claude-code)