### PR TITLE
[02-macro-scoring] feat: macro scoring engine — regime classification + LLM analysis + Provider

### DIFF
--- a/meta/00-project-room/04-macro-analysis/02-macro-scoring/progress.yaml
+++ b/meta/00-project-room/04-macro-analysis/02-macro-scoring/progress.yaml
@@ -1,5 +1,5 @@
 progress:
-  completion: 0.25
+  completion: 0.50
   milestones:
     - id: "m1-macro-scorer"
       name: "MacroScorer 核心 — 经济周期分类 + 日度评分"
@@ -22,8 +22,8 @@ progress:
 
     - id: "m2-llm-analyst"
       name: "LLM 周度宏观分析 — Claude Opus 深度解读"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-15"
       estimated_files:
         - "src/stockbee/macro_scoring/llm_analyst.py"
       estimated_lines: 200
@@ -75,3 +75,4 @@ progress:
         Provider: SQLite CRUD, 回测 vs 实盘模式, get_history 时间范围查询。
   commits:
     - { date: "2026-04-15", message: "[02-macro-scoring] feat: m1 MacroScorer — regime classification + daily scoring + 36 tests" }
+    - { date: "2026-04-15", message: "[02-macro-scoring] feat: m2 LLMMacroAnalyst — weekly LLM analysis + prompt + cache + 24 tests" }

--- a/meta/00-project-room/04-macro-analysis/02-macro-scoring/progress.yaml
+++ b/meta/00-project-room/04-macro-analysis/02-macro-scoring/progress.yaml
@@ -75,6 +75,7 @@ progress:
         LLM analyst: mock LLMRouter 测试 prompt 构建 + 输出解析 + fallback。
         Provider: SQLite CRUD, 回测 vs 实盘模式, get_history 时间范围查询。
   commits:
-    - { date: "2026-04-15", message: "[02-macro-scoring] feat: m1 MacroScorer — regime classification + daily scoring + 36 tests" }
-    - { date: "2026-04-15", message: "[02-macro-scoring] feat: m2 LLMMacroAnalyst — weekly LLM analysis + prompt + cache + 24 tests" }
-    - { date: "2026-04-15", message: "[02-macro-scoring] feat: m3 MacroScoringProvider — Provider interface + SQLite + backtest/live + 14 tests" }
+    - { date: "2026-04-15", hash: "7484f83", message: "[02-macro-scoring] feat: m1 MacroScorer — regime classification + daily scoring + 36 tests", files_changed: 5 }
+    - { date: "2026-04-15", hash: "d1f1dd2", message: "[02-macro-scoring] feat: m2 LLMMacroAnalyst — weekly LLM analysis + prompt + cache + 24 tests", files_changed: 4 }
+    - { date: "2026-04-15", hash: "2df1168", message: "[02-macro-scoring] feat: m3 MacroScoringProvider — Provider interface + SQLite + backtest/live + 14 tests", files_changed: 4 }
+    - { date: "2026-04-15", hash: "4e61c7f", message: "[02-macro-scoring] done: Room completed — 4/4 milestones, 74 tests", files_changed: 2 }

--- a/meta/00-project-room/04-macro-analysis/02-macro-scoring/progress.yaml
+++ b/meta/00-project-room/04-macro-analysis/02-macro-scoring/progress.yaml
@@ -1,20 +1,77 @@
 progress:
-  completion: 0.0
+  completion: 0.25
   milestones:
-    - id: "m1-Z-score-标准化"
-      name: "Z-score 标准化"
+    - id: "m1-macro-scorer"
+      name: "MacroScorer 核心 — 经济周期分类 + 日度评分"
+      status: completed
+      completed_at: "2026-04-15"
+      estimated_files:
+        - "src/stockbee/macro_scoring/scorer.py"
+      estimated_lines: 250
+      depends_on: []
+      complexity_flags: [design_decisions]
+      open_questions: []
+      description: |
+        5 种 regime 规则引擎分类器 (expansion/overheating/stagflation/recession/recovery)。
+        消费 MacroProvider.get_latest_z_scores() 的 19 个 FRED 指标 Z-score，
+        基于阈值规则判断当前经济周期。日度 macro_score: -1.0 (极度看跌) ~ +1.0 (极度看涨)。
+        regime_confidence: 各 regime 的概率分布 dict。
+        消费 PolymarketFetcher cliff 信号调整评分。
+        消费 EconomicCalendar 高波动日标记。
+        预留 propagation_weight 参数（默认 0.0，Phase 2 知识图谱完成后改为 0.4）。
+
+    - id: "m2-llm-analyst"
+      name: "LLM 周度宏观分析 — Claude Opus 深度解读"
       status: pending
       completed_at: null
-    - id: "m2-经济周期分类5种"
-      name: "经济周期分类(5种)"
+      estimated_files:
+        - "src/stockbee/macro_scoring/llm_analyst.py"
+      estimated_lines: 200
+      depends_on: ["m1-macro-scorer"]
+      complexity_flags: [external_api, prompt_engineering, error_handling_heavy]
+      open_questions: []
+      description: |
+        构建 prompt: Z-scores + regime + Polymarket 概率 + 经济日历。
+        调用 LLMRouter.route(TaskType.MACRO_ANALYSIS, prompt)。
+        解析 LLM 输出 → structured MacroInsight (regime_override, risk_factors, outlook)。
+        缓存结果 (每周一次，不重复调用)。
+        LLM 输出可覆盖/调整 rule-based score (加权融合)。
+        错误处理: LLM 超时/失败时 fallback 到纯规则评分。
+
+    - id: "m3-provider"
+      name: "MacroScoringProvider — Provider 接口 + 持久化"
       status: pending
       completed_at: null
-    - id: "m3-日度评分输出"
-      name: "日度评分输出"
-      status: pending
-      completed_at: null
-    - id: "m4-测试"
+      estimated_files:
+        - "src/stockbee/macro_scoring/provider.py"
+        - "src/stockbee/macro_scoring/__init__.py"
+      estimated_lines: 180
+      depends_on: ["m1-macro-scorer", "m2-llm-analyst"]
+      complexity_flags: []
+      open_questions: []
+      description: |
+        统一 Provider 接口: get_macro_score(date) → float, get_regime(date) → str,
+        get_history(start, end) → DataFrame。
+        SQLite 存储: macro_scores 表 (date, score, regime, confidence_json, llm_insight)。
+        回测模式: 从历史 Z-scores 重算 (无 LLM，纯规则)。
+        实盘模式: rule-based + LLM weekly overlay。
+        模块 __init__.py 导出。
+
+    - id: "m4-tests"
       name: "测试"
       status: pending
       completed_at: null
-  commits: []
+      estimated_files:
+        - "tests/test_macro_scoring.py"
+      estimated_lines: 400
+      depends_on: ["m3-provider"]
+      complexity_flags: []
+      open_questions: []
+      description: |
+        Regime 分类: 5 种 regime 的典型 Z-score 输入 → 正确分类。
+        日度评分: 边界值 (-1, 0, +1), 混合信号场景。
+        Polymarket cliff 信号 → score 调整验证。
+        LLM analyst: mock LLMRouter 测试 prompt 构建 + 输出解析 + fallback。
+        Provider: SQLite CRUD, 回测 vs 实盘模式, get_history 时间范围查询。
+  commits:
+    - { date: "2026-04-15", message: "[02-macro-scoring] feat: m1 MacroScorer — regime classification + daily scoring + 36 tests" }

--- a/meta/00-project-room/04-macro-analysis/02-macro-scoring/progress.yaml
+++ b/meta/00-project-room/04-macro-analysis/02-macro-scoring/progress.yaml
@@ -1,5 +1,5 @@
 progress:
-  completion: 0.75
+  completion: 1.0
   milestones:
     - id: "m1-macro-scorer"
       name: "MacroScorer 核心 — 经济周期分类 + 日度评分"
@@ -59,8 +59,9 @@ progress:
 
     - id: "m4-tests"
       name: "测试"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-15"
+      note: "74 tests already written inline with m1-m3, no additional tests needed"
       estimated_files:
         - "tests/test_macro_scoring.py"
       estimated_lines: 400

--- a/meta/00-project-room/04-macro-analysis/02-macro-scoring/progress.yaml
+++ b/meta/00-project-room/04-macro-analysis/02-macro-scoring/progress.yaml
@@ -1,5 +1,5 @@
 progress:
-  completion: 0.50
+  completion: 0.75
   milestones:
     - id: "m1-macro-scorer"
       name: "MacroScorer 核心 — 经济周期分类 + 日度评分"
@@ -40,8 +40,8 @@ progress:
 
     - id: "m3-provider"
       name: "MacroScoringProvider — Provider 接口 + 持久化"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-15"
       estimated_files:
         - "src/stockbee/macro_scoring/provider.py"
         - "src/stockbee/macro_scoring/__init__.py"
@@ -76,3 +76,4 @@ progress:
   commits:
     - { date: "2026-04-15", message: "[02-macro-scoring] feat: m1 MacroScorer — regime classification + daily scoring + 36 tests" }
     - { date: "2026-04-15", message: "[02-macro-scoring] feat: m2 LLMMacroAnalyst — weekly LLM analysis + prompt + cache + 24 tests" }
+    - { date: "2026-04-15", message: "[02-macro-scoring] feat: m3 MacroScoringProvider — Provider interface + SQLite + backtest/live + 14 tests" }

--- a/meta/00-project-room/04-macro-analysis/02-macro-scoring/room.yaml
+++ b/meta/00-project-room/04-macro-analysis/02-macro-scoring/room.yaml
@@ -3,7 +3,7 @@ room:
   name: "宏观评分"
   parent: "04-macro-analysis"
   type: feature
-  lifecycle: planning
+  lifecycle: completed
   priority: P0
   phase: "1"
   created_at: "2026-03-24"

--- a/meta/00-project-room/04-macro-analysis/02-macro-scoring/spec.md
+++ b/meta/00-project-room/04-macro-analysis/02-macro-scoring/spec.md
@@ -7,16 +7,37 @@
 5 种经济制度分类（扩张/过热/滞胀/衰退/复苏）。Z-score 标准化所有指标。与知识图谱传播 Tilt 融合。
 
 来源：Feature Hierarchy §4.2, Tech Design §3.5
-研究状态：待研究
 
 ## Decisions
 
-_暂无决策记录_
+- **Regime 分类方法**: 规则引擎 (Plan A)。Phase 1 用阈值规则，简单可解释可调。Phase 2 可升级为 HMM 统计模型。
+- **LLM 周度分析**: Phase 1 做。LLMRouter 已有 MACRO_ANALYSIS task type ($4/月预算)，早期迭代积累 prompt 经验。
+- **融合权重**: Phase 1 propagation_weight=0.0 (纯规则)。知识图谱 Room 完成后改为 0.6 规则 + 0.4 传播图。1 行改动，完全可逆。
 
 ## Contracts
 
-_暂无接口约定_
+- **MacroScoringProvider**:
+  - `get_macro_score(date) → float` — 日度评分 [-1.0, +1.0]
+  - `get_regime(date) → str` — 经济周期 (expansion/overheating/stagflation/recession/recovery)
+  - `get_history(start, end) → DataFrame` — 历史评分序列
+- **下游消费者**: 03-sector-tilts, 04-style-tilts (用 regime + score 计算 tilt 幅度)
+
+## 当前进度
+
+4 milestones, 0% 完成:
+- m1: MacroScorer 核心 — 经济周期分类 + 日度评分 (~250 行)
+- m2: LLM 周度宏观分析 — Claude Opus 深度解读 (~200 行)
+- m3: MacroScoringProvider — Provider 接口 + 持久化 (~180 行)
+- m4: 测试 (~400 行)
+
+总计: ~1030 行, 4-5 files
+
+## Deferred (Phase 2)
+
+- HMM/统计模型替换规则引擎 (如 regime 分类准确率 < 70%)
+- 知识图谱传播信号融合 (propagation_weight → 0.4)
 
 ---
 _所有 spec 状态: draft（需要 review 后升为 active）_
-_spec.md 由 room-init 自动生成，specs/*.yaml 为源数据_
+_spec.md 由 plan-milestones 更新, 2026-04-15_
+_specs/*.yaml 为源数据_

--- a/meta/00-project-room/04-macro-analysis/02-macro-scoring/spec.md
+++ b/meta/00-project-room/04-macro-analysis/02-macro-scoring/spec.md
@@ -7,30 +7,33 @@
 5 种经济制度分类（扩张/过热/滞胀/衰退/复苏）。Z-score 标准化所有指标。与知识图谱传播 Tilt 融合。
 
 来源：Feature Hierarchy §4.2, Tech Design §3.5
+实现状态：已完成 ✅
 
 ## Decisions
 
 - **Regime 分类方法**: 规则引擎 (Plan A)。Phase 1 用阈值规则，简单可解释可调。Phase 2 可升级为 HMM 统计模型。
 - **LLM 周度分析**: Phase 1 做。LLMRouter 已有 MACRO_ANALYSIS task type ($4/月预算)，早期迭代积累 prompt 经验。
-- **融合权重**: Phase 1 propagation_weight=0.0 (纯规则)。知识图谱 Room 完成后改为 0.6 规则 + 0.4 传播图。1 行改动，完全可逆。
+- **融合权重**: Phase 1 propagation_weight=0.0 (纯规则)。知识图谱 Room 完成后改为 0.6 规则 + 0.4 传播图。
+- **Live 模式融合**: 0.7 rule-based + 0.3 LLM weekly outlook
+- **Polymarket cliff**: 负向调整 (概率上升 → 不确定性 → bearish)，cap ±0.15
+- **HV 日 dampening**: 0.8x 乘数 (FOMC/CPI/NFP 日降低 conviction)
 
 ## Contracts
 
 - **MacroScoringProvider**:
-  - `get_macro_score(date) → float` — 日度评分 [-1.0, +1.0]
-  - `get_regime(date) → str` — 经济周期 (expansion/overheating/stagflation/recession/recovery)
+  - `get_macro_score(date) → float | None` — 日度评分 [-1.0, +1.0]
+  - `get_regime(date) → str | None` — 经济周期 (expansion/overheating/stagflation/recession/recovery)
   - `get_history(start, end) → DataFrame` — 历史评分序列
+  - `score_and_store(date) → MacroScore | None` — 评分并持久化
 - **下游消费者**: 03-sector-tilts, 04-style-tilts (用 regime + score 计算 tilt 幅度)
 
 ## 当前进度
 
-4 milestones, 0% 完成:
-- m1: MacroScorer 核心 — 经济周期分类 + 日度评分 (~250 行)
-- m2: LLM 周度宏观分析 — Claude Opus 深度解读 (~200 行)
-- m3: MacroScoringProvider — Provider 接口 + 持久化 (~180 行)
-- m4: 测试 (~400 行)
-
-总计: ~1030 行, 4-5 files
+4/4 milestones 完成，74 tests:
+- ✅ m1: MacroScorer 核心 — 规则引擎 regime 分类 + 日度评分 (scorer.py)
+- ✅ m2: LLM 周度宏观分析 — Claude Opus 深度解读 (llm_analyst.py)
+- ✅ m3: MacroScoringProvider — Provider 接口 + SQLite 持久化 (provider.py)
+- ✅ m4: 测试 — 74 tests (test_macro_scoring.py)
 
 ## Deferred (Phase 2)
 
@@ -38,6 +41,6 @@
 - 知识图谱传播信号融合 (propagation_weight → 0.4)
 
 ---
-_所有 spec 状态: draft（需要 review 后升为 active）_
-_spec.md 由 plan-milestones 更新, 2026-04-15_
-_specs/*.yaml 为源数据_
+_所有 spec 状态: active_
+_specs 目录: 1 intent + 1 change = 2 个 spec 文件_
+_spec.md 最后更新: 2026-04-16_

--- a/meta/00-project-room/04-macro-analysis/02-macro-scoring/specs/change-2026-04-15-macro-scoring-complete.yaml
+++ b/meta/00-project-room/04-macro-analysis/02-macro-scoring/specs/change-2026-04-15-macro-scoring-complete.yaml
@@ -1,0 +1,35 @@
+spec_id: "change-2026-04-15-macro-scoring-complete"
+type: change
+state: active
+intent:
+  summary: "02-macro-scoring Room 完成 — 4 milestones, 74 tests"
+  detail: |
+    m1: MacroScorer 规则引擎 — 5 regime 分类 + 日度 bull/bear 评分 [-1, +1]
+    m2: LLMMacroAnalyst — Claude Opus 周度深度分析 + 7天 SQLite 缓存
+    m3: MacroScoringProvider — BaseProvider 子类 + SQLite 持久化 + backtest/live 模式
+    m4: 测试 — 74 tests inline with m1-m3
+
+    关键设计决策:
+    - Regime 分类: 规则引擎 (Phase 2 可升级 HMM)
+    - LLM 融合: 0.7 rules + 0.3 LLM weekly outlook (live mode)
+    - 传播权重: propagation_weight=0.0 (Phase 2 知识图谱完成后 → 0.4)
+    - Polymarket cliff: 负向调整 (概率上升 → 不确定性 → bearish)
+    - HV 日: 0.8x dampening (低 conviction)
+constraints: []
+indexing:
+  type: change
+  priority: high
+  layer: feature
+  domain: "quantitative-trading"
+  tags: ["macro-scoring", "regime-classification", "llm-analysis"]
+provenance:
+  source_type: implementation
+  confidence: 1.0
+  source_ref: "feature/macro-scoring branch, commits 7484f83..4e61c7f"
+relations:
+  - { spec_id: "intent-02-macro-scoring-001", relation: "implements" }
+anchors:
+  - file: "src/stockbee/macro_scoring/scorer.py"
+  - file: "src/stockbee/macro_scoring/llm_analyst.py"
+  - file: "src/stockbee/macro_scoring/provider.py"
+  - file: "tests/test_macro_scoring.py"

--- a/meta/00-project-room/04-macro-analysis/02-macro-scoring/specs/intent-02-macro-scoring-001.yaml
+++ b/meta/00-project-room/04-macro-analysis/02-macro-scoring/specs/intent-02-macro-scoring-001.yaml
@@ -1,6 +1,6 @@
 spec_id: "intent-02-macro-scoring-001"
 type: intent
-state: draft
+state: active
 intent:
   summary: "日度看涨/看跌评分，经济周期分类"
   detail: |
@@ -20,4 +20,10 @@ provenance:
   confidence: 0.8
   source_ref: "PRD + Feature Hierarchy + Tech Design"
 relations: []
-anchors: []
+anchors:
+  - file: "src/stockbee/macro_scoring/scorer.py"
+    symbols: ["MacroScorer", "RegimeType", "MacroScore"]
+  - file: "src/stockbee/macro_scoring/llm_analyst.py"
+    symbols: ["LLMMacroAnalyst", "MacroInsight"]
+  - file: "src/stockbee/macro_scoring/provider.py"
+    symbols: ["MacroScoringProvider"]

--- a/meta/00-project-room/04-macro-analysis/progress.yaml
+++ b/meta/00-project-room/04-macro-analysis/progress.yaml
@@ -1,14 +1,14 @@
 progress:
-  completion: 0.0
+  completion: 0.5
   milestones:
     - id: "m1-数据源接入"
       name: "数据源接入"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-06"
     - id: "m2-宏观评分"
       name: "宏观评分"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-15"
     - id: "m3-行业风格-Tilt"
       name: "行业+风格 Tilt"
       status: pending

--- a/meta/00-project-room/_tree.yaml
+++ b/meta/00-project-room/_tree.yaml
@@ -47,7 +47,7 @@ tree:
           phase: 1
           children:
             - { id: "01-macro-sources", type: feature, priority: P0, phase: 1, status: "已完成", note: "Polymarket + 经济日历" }
-            - { id: "02-macro-scoring", type: feature, priority: P0, phase: 1, status: "待研究" }
+            - { id: "02-macro-scoring", type: feature, priority: P0, phase: 1, status: "已完成" }
             - { id: "03-sector-tilts", type: feature, priority: P0, phase: 1, status: "待研究" }
             - { id: "04-style-tilts", type: feature, priority: P0, phase: 1, status: "待研究" }
 

--- a/meta/00-project-room/progress.yaml
+++ b/meta/00-project-room/progress.yaml
@@ -1,5 +1,5 @@
 progress:
-  completion: 0.052
+  completion: 0.077
   milestones:
     - id: "m1-Phase-1-MVP-跑通"
       name: "Phase 1 MVP 跑通"

--- a/meta/00-project-room/timeline.yaml
+++ b/meta/00-project-room/timeline.yaml
@@ -104,10 +104,10 @@ timeline:
           target_start: "2026-04-14"
           target_end: "2026-04-25"
           estimated_days: 9
-          status: implementing
-          completion: 0.75
+          status: completed
+          completion: 1.0
           depends_on: ["01-stock-data", "07-provider-arch"]
-          note: "6/8 milestones done (m1a,m1b,m2,m3,m4,m5). 剩余: m6-provider, m7-integration"
+          note: "已完成 2026-04-13, 8/8 milestones done"
 
         # --- Sprint 2: 模型层 + 宏观 (Week 3-6) ---
         - room: "01-llm-routing"
@@ -160,9 +160,10 @@ timeline:
           target_start: "2026-04-28"
           target_end: "2026-05-09"
           estimated_days: 9
-          status: planning
-          completion: 0.0
+          status: completed
+          completion: 1.0
           depends_on: ["01-macro-sources", "01-llm-routing"]
+          note: "已完成 2026-04-15, 4 milestones, 74 tests"
 
         - room: "03-sector-tilts"
           parent: "04-macro-analysis"
@@ -508,7 +509,7 @@ timeline:
     phase_1_rooms: 26
     phase_2_rooms: 11
     phase_3_rooms: 3
-    completed: 5
+    completed: 6
     in_progress: 0
     planning: 21
     backlog: 14

--- a/src/stockbee/macro_scoring/__init__.py
+++ b/src/stockbee/macro_scoring/__init__.py
@@ -1,0 +1,15 @@
+"""Macro Scoring 模块 — 日度看涨/看跌评分 + 经济周期分类。
+
+5 种经济制度 (expansion/overheating/stagflation/recession/recovery)。
+消费 MacroProvider Z-scores + Polymarket 概率悬崖 + 经济日历高波动日。
+
+来源：Tech Design §3.5 MacroTiltEngine
+"""
+
+from .scorer import MacroScorer, MacroScore, RegimeType
+
+__all__ = [
+    "MacroScorer",
+    "MacroScore",
+    "RegimeType",
+]

--- a/src/stockbee/macro_scoring/__init__.py
+++ b/src/stockbee/macro_scoring/__init__.py
@@ -8,6 +8,7 @@
 
 from .scorer import MacroScorer, MacroScore, RegimeType
 from .llm_analyst import LLMMacroAnalyst, MacroInsight
+from .provider import MacroScoringProvider
 
 __all__ = [
     "MacroScorer",
@@ -15,4 +16,5 @@ __all__ = [
     "RegimeType",
     "LLMMacroAnalyst",
     "MacroInsight",
+    "MacroScoringProvider",
 ]

--- a/src/stockbee/macro_scoring/__init__.py
+++ b/src/stockbee/macro_scoring/__init__.py
@@ -7,9 +7,12 @@
 """
 
 from .scorer import MacroScorer, MacroScore, RegimeType
+from .llm_analyst import LLMMacroAnalyst, MacroInsight
 
 __all__ = [
     "MacroScorer",
     "MacroScore",
     "RegimeType",
+    "LLMMacroAnalyst",
+    "MacroInsight",
 ]

--- a/src/stockbee/macro_scoring/llm_analyst.py
+++ b/src/stockbee/macro_scoring/llm_analyst.py
@@ -1,0 +1,296 @@
+"""LLMMacroAnalyst — 周度 LLM 宏观深度分析。
+
+使用 LLMRouter (TaskType.MACRO_ANALYSIS → Claude Opus) 对当前宏观环境
+做深度解读。结果缓存 7 天，避免重复调用。
+
+来源：Tech Design §3.5, plan-milestones 2026-04-15
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import sqlite3
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+CACHE_TTL_DAYS = 7
+
+
+@dataclass(frozen=True)
+class MacroInsight:
+    """LLM 周度宏观分析结果。"""
+    regime_assessment: str          # LLM 对当前经济周期的判断
+    risk_factors: list[str]         # 主要风险因素
+    outlook_score: float            # LLM 给出的 outlook [-1.0, +1.0]
+    reasoning: str                  # 详细分析推理
+    model_used: str                 # 使用的模型
+    analyzed_at: date               # 分析日期
+
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+_SYSTEM_PROMPT = """\
+You are a senior macro economist analyzing US economic conditions for a \
+quantitative equity trading system. Your analysis directly influences \
+portfolio tilt decisions.
+
+Respond in the following format (plain text, not JSON):
+
+REGIME: <one of: expansion, overheating, stagflation, recession, recovery>
+OUTLOOK_SCORE: <float from -1.0 (very bearish) to +1.0 (very bullish)>
+RISK_FACTORS:
+- <risk factor 1>
+- <risk factor 2>
+- <risk factor 3>
+REASONING:
+<2-3 paragraph analysis of current macro environment, key drivers, and outlook>
+"""
+
+
+class LLMMacroAnalyst:
+    """周度 LLM 宏观分析引擎。
+
+    Args:
+        router: LLMRouter 实例
+        macro_provider: MacroProvider 实例 (get_latest_z_scores)
+        polymarket: PolymarketFetcher 实例 (可选)
+        calendar: EconomicCalendar 实例 (可选)
+        cache_dir: SQLite 缓存目录 (默认 data/)
+    """
+
+    def __init__(
+        self,
+        router,
+        macro_provider,
+        polymarket=None,
+        calendar=None,
+        *,
+        cache_dir: str | Path = "data",
+    ):
+        self._router = router
+        self._macro = macro_provider
+        self._polymarket = polymarket
+        self._calendar = calendar
+        self._cache_dir = Path(cache_dir)
+        self._db: sqlite3.Connection | None = None
+
+    def _ensure_db(self) -> sqlite3.Connection:
+        """Lazy-init SQLite cache."""
+        if self._db is not None:
+            return self._db
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+        db_path = self._cache_dir / "macro_llm_cache.db"
+        self._db = sqlite3.connect(str(db_path))
+        self._db.execute(
+            """CREATE TABLE IF NOT EXISTS macro_insights (
+                analyzed_date TEXT PRIMARY KEY,
+                insight_json  TEXT NOT NULL,
+                model_used    TEXT NOT NULL,
+                created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+            )"""
+        )
+        self._db.commit()
+        return self._db
+
+    def analyze(self, as_of: date | None = None) -> MacroInsight | None:
+        """Run weekly macro analysis.
+
+        Returns cached result if within TTL, otherwise calls LLM.
+        Returns None if z_scores are empty or LLM fails.
+        """
+        as_of = as_of or date.today()
+
+        # Check cache first
+        cached = self._get_cached(as_of)
+        if cached is not None:
+            return cached
+
+        # Get z_scores
+        z_scores = self._macro.get_latest_z_scores()
+        if not z_scores:
+            logger.warning("Empty z_scores, skipping LLM analysis")
+            return None
+
+        # Build prompt
+        prompt = self._build_prompt(z_scores, as_of)
+
+        # Call LLM
+        try:
+            from stockbee.llm_routing import TaskType
+
+            response = self._router.route(
+                TaskType.MACRO_ANALYSIS,
+                prompt,
+                system_prompt=_SYSTEM_PROMPT,
+            )
+        except Exception:
+            logger.warning("LLM macro analysis failed", exc_info=True)
+            return None
+
+        # Parse response
+        insight = self._parse_response(response.content, response.model_used, as_of)
+        if insight is not None:
+            self._save_cache(insight)
+
+        return insight
+
+    def _build_prompt(self, z_scores: dict[str, float], as_of: date) -> str:
+        """Build the analysis prompt with current macro data."""
+        lines = [f"Date: {as_of.isoformat()}", "", "## Current FRED Z-Scores (252-day rolling)", ""]
+
+        # Group z_scores by dimension
+        try:
+            from stockbee.macro_data.indicators import FRED_INDICATORS
+            for code, z in sorted(z_scores.items()):
+                ind = FRED_INDICATORS.get(code)
+                label = f"{ind.name} ({ind.dimension})" if ind else code
+                direction = "↑" if z > 0.5 else "↓" if z < -0.5 else "→"
+                lines.append(f"- {label}: z={z:+.2f} {direction}")
+        except ImportError:
+            for code, z in sorted(z_scores.items()):
+                lines.append(f"- {code}: z={z:+.2f}")
+
+        # Polymarket events
+        if self._polymarket is not None:
+            try:
+                events = self._polymarket.get_latest_events(limit=10)
+                if events:
+                    lines.extend(["", "## Polymarket Macro Events", ""])
+                    for e in events[:10]:
+                        cliff_tag = " ⚠️CLIFF" if e.is_cliff else ""
+                        lines.append(f"- {e.question}: {e.probability:.0%}{cliff_tag}")
+            except Exception:
+                logger.debug("Polymarket events fetch failed for prompt", exc_info=True)
+
+        # Upcoming high-volatility events
+        if self._calendar is not None:
+            try:
+                upcoming = self._calendar.get_events(
+                    start=as_of, end=as_of + timedelta(days=14), high_volatility_only=True
+                )
+                if upcoming:
+                    lines.extend(["", "## Upcoming High-Volatility Events (14 days)", ""])
+                    for ev in upcoming[:5]:
+                        lines.append(f"- {ev.release_name}: {ev.release_date}")
+            except Exception:
+                logger.debug("Calendar events fetch failed for prompt", exc_info=True)
+
+        lines.extend([
+            "",
+            "## Task",
+            "Analyze the current US macro environment. Classify the economic regime, "
+            "identify top risk factors, and provide an outlook score.",
+        ])
+
+        return "\n".join(lines)
+
+    def _parse_response(
+        self, content: str, model_used: str, as_of: date
+    ) -> MacroInsight | None:
+        """Parse LLM text response into MacroInsight."""
+        if not content or not content.strip():
+            logger.warning("Empty LLM response")
+            return None
+
+        # Extract fields
+        regime = self._extract_field(content, "REGIME", "unknown")
+        outlook_str = self._extract_field(content, "OUTLOOK_SCORE", "0.0")
+        reasoning = self._extract_section(content, "REASONING")
+
+        # Parse outlook_score
+        try:
+            outlook_score = float(outlook_str)
+            outlook_score = max(-1.0, min(1.0, outlook_score))
+        except (ValueError, TypeError):
+            logger.warning(f"Could not parse outlook_score: {outlook_str!r}, defaulting to 0.0")
+            outlook_score = 0.0
+
+        # Parse risk factors
+        risk_factors = self._extract_list(content, "RISK_FACTORS")
+
+        return MacroInsight(
+            regime_assessment=regime,
+            risk_factors=risk_factors,
+            outlook_score=outlook_score,
+            reasoning=reasoning,
+            model_used=model_used,
+            analyzed_at=as_of,
+        )
+
+    @staticmethod
+    def _extract_field(text: str, field_name: str, default: str) -> str:
+        """Extract a single-line field value like 'FIELD: value'."""
+        pattern = rf"^{field_name}:\s*(.+)$"
+        match = re.search(pattern, text, re.MULTILINE | re.IGNORECASE)
+        return match.group(1).strip() if match else default
+
+    @staticmethod
+    def _extract_section(text: str, section_name: str) -> str:
+        """Extract a multi-line section after 'SECTION_NAME:'."""
+        pattern = rf"^{section_name}:\s*\n(.*?)(?=\n[A-Z_]+:|\Z)"
+        match = re.search(pattern, text, re.MULTILINE | re.DOTALL | re.IGNORECASE)
+        return match.group(1).strip() if match else ""
+
+    @staticmethod
+    def _extract_list(text: str, section_name: str) -> list[str]:
+        """Extract a bulleted list after 'SECTION_NAME:'."""
+        pattern = rf"^{section_name}:\s*\n((?:- .+\n?)+)"
+        match = re.search(pattern, text, re.MULTILINE | re.IGNORECASE)
+        if not match:
+            return []
+        items = re.findall(r"^- (.+)$", match.group(1), re.MULTILINE)
+        return [item.strip() for item in items]
+
+    # ---------------------------------------------------------------------------
+    # Cache
+    # ---------------------------------------------------------------------------
+
+    def _get_cached(self, as_of: date) -> MacroInsight | None:
+        """Return cached insight if within TTL."""
+        db = self._ensure_db()
+        cutoff = (as_of - timedelta(days=CACHE_TTL_DAYS)).isoformat()
+        row = db.execute(
+            "SELECT insight_json, model_used, analyzed_date FROM macro_insights "
+            "WHERE analyzed_date > ? ORDER BY analyzed_date DESC LIMIT 1",
+            (cutoff,),
+        ).fetchone()
+        if row is None:
+            return None
+        data = json.loads(row[0])
+        return MacroInsight(
+            regime_assessment=data["regime_assessment"],
+            risk_factors=data["risk_factors"],
+            outlook_score=data["outlook_score"],
+            reasoning=data["reasoning"],
+            model_used=row[1],
+            analyzed_at=date.fromisoformat(row[2]),
+        )
+
+    def _save_cache(self, insight: MacroInsight) -> None:
+        """Save insight to cache."""
+        db = self._ensure_db()
+        data = {
+            "regime_assessment": insight.regime_assessment,
+            "risk_factors": insight.risk_factors,
+            "outlook_score": insight.outlook_score,
+            "reasoning": insight.reasoning,
+        }
+        db.execute(
+            "INSERT OR REPLACE INTO macro_insights (analyzed_date, insight_json, model_used) "
+            "VALUES (?, ?, ?)",
+            (insight.analyzed_at.isoformat(), json.dumps(data), insight.model_used),
+        )
+        db.commit()
+
+    def close(self) -> None:
+        """Close the cache database."""
+        if self._db is not None:
+            self._db.close()
+            self._db = None

--- a/src/stockbee/macro_scoring/provider.py
+++ b/src/stockbee/macro_scoring/provider.py
@@ -1,0 +1,185 @@
+"""MacroScoringProvider — 日度宏观评分 Provider + SQLite 持久化。
+
+统一 Provider 接口，供下游 sector/style tilt 消费。
+回测模式: 纯规则引擎 (无 LLM)。
+实盘模式: 规则引擎 + LLM weekly overlay。
+
+来源：Tech Design §3.5, plan-milestones 2026-04-15
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+
+from stockbee.providers.base import BaseProvider, ProviderConfig
+
+from .llm_analyst import LLMMacroAnalyst
+from .scorer import MacroScore, MacroScorer, RegimeType
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA = """\
+CREATE TABLE IF NOT EXISTS macro_scores (
+    scored_date    TEXT PRIMARY KEY,
+    score          REAL NOT NULL,
+    regime         TEXT NOT NULL,
+    confidence_json TEXT NOT NULL,
+    llm_outlook    REAL,
+    llm_insight_json TEXT,
+    signals_json   TEXT,
+    created_at     TEXT NOT NULL DEFAULT (datetime('now'))
+);
+"""
+
+
+class MacroScoringProvider(BaseProvider):
+    """日度宏观评分 Provider。
+
+    Args (via ProviderConfig.params):
+        db_path: SQLite 数据库路径 (默认 data/macro_scores.db)
+        mode: "backtest" | "live" (默认 backtest)
+    """
+
+    def __init__(self, config: ProviderConfig | None = None) -> None:
+        super().__init__(config)
+        params = self._config.params
+        self._db_path = Path(params.get("db_path", "data/macro_scores.db"))
+        self._mode = params.get("mode", "backtest")
+        self._db: sqlite3.Connection | None = None
+        self._scorer: MacroScorer | None = None
+        self._analyst: LLMMacroAnalyst | None = None
+
+    def set_scorer(self, scorer: MacroScorer) -> None:
+        """注入 MacroScorer 实例。"""
+        self._scorer = scorer
+
+    def set_analyst(self, analyst: LLMMacroAnalyst) -> None:
+        """注入 LLMMacroAnalyst 实例 (实盘模式)。"""
+        self._analyst = analyst
+
+    def _do_initialize(self) -> None:
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._db = sqlite3.connect(str(self._db_path))
+        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db.execute(_SCHEMA)
+        self._db.commit()
+
+    def _do_shutdown(self) -> None:
+        if self._analyst is not None:
+            self._analyst.close()
+        if self._db is not None:
+            self._db.close()
+            self._db = None
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def get_macro_score(self, as_of: date) -> float | None:
+        """Get macro score for a given date. Returns None if no data."""
+        row = self._query_row(as_of)
+        return row[0] if row else None
+
+    def get_regime(self, as_of: date) -> str | None:
+        """Get economic regime for a given date. Returns None if no data."""
+        row = self._query_row(as_of)
+        return row[1] if row else None
+
+    def get_history(self, start: date, end: date) -> pd.DataFrame:
+        """Get score history as DataFrame.
+
+        Returns:
+            DataFrame with columns: date, score, regime, llm_outlook
+            Empty DataFrame if no data in range.
+        """
+        assert self._db is not None
+        rows = self._db.execute(
+            "SELECT scored_date, score, regime, llm_outlook "
+            "FROM macro_scores WHERE scored_date >= ? AND scored_date <= ? "
+            "ORDER BY scored_date",
+            (start.isoformat(), end.isoformat()),
+        ).fetchall()
+        if not rows:
+            return pd.DataFrame(columns=["date", "score", "regime", "llm_outlook"])
+        df = pd.DataFrame(rows, columns=["date", "score", "regime", "llm_outlook"])
+        df["date"] = pd.to_datetime(df["date"]).dt.date
+        return df
+
+    def score_and_store(self, as_of: date | None = None) -> MacroScore | None:
+        """Score the given date and persist to SQLite.
+
+        In live mode, also fetches weekly LLM insight and blends outlook.
+        Returns None if scorer is not set.
+        """
+        if self._scorer is None:
+            logger.warning("No scorer set, cannot score")
+            return None
+
+        as_of = as_of or date.today()
+        result = self._scorer.score(as_of)
+
+        # Optional LLM overlay (live mode only)
+        llm_outlook: float | None = None
+        llm_insight_json: str | None = None
+        if self._mode == "live" and self._analyst is not None:
+            insight = self._analyst.analyze(as_of)
+            if insight is not None:
+                llm_outlook = insight.outlook_score
+                llm_insight_json = json.dumps({
+                    "regime_assessment": insight.regime_assessment,
+                    "risk_factors": insight.risk_factors,
+                    "reasoning": insight.reasoning[:500],
+                })
+                # Blend: 0.7 rule-based + 0.3 LLM outlook
+                result = MacroScore(
+                    score=max(-1.0, min(1.0, result.score * 0.7 + llm_outlook * 0.3)),
+                    regime=result.regime,
+                    regime_confidence=result.regime_confidence,
+                    scored_at=result.scored_at,
+                    signals={**result.signals, "llm_blend": 0.3, "llm_outlook": llm_outlook},
+                )
+
+        self._store(result, llm_outlook, llm_insight_json)
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _query_row(self, as_of: date) -> tuple | None:
+        """Query (score, regime) for a date."""
+        assert self._db is not None
+        return self._db.execute(
+            "SELECT score, regime FROM macro_scores WHERE scored_date = ?",
+            (as_of.isoformat(),),
+        ).fetchone()
+
+    def _store(
+        self,
+        result: MacroScore,
+        llm_outlook: float | None,
+        llm_insight_json: str | None,
+    ) -> None:
+        """Persist a MacroScore to SQLite."""
+        assert self._db is not None
+        self._db.execute(
+            "INSERT OR REPLACE INTO macro_scores "
+            "(scored_date, score, regime, confidence_json, llm_outlook, llm_insight_json, signals_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                result.scored_at.isoformat(),
+                result.score,
+                result.regime.value,
+                json.dumps(result.regime_confidence),
+                llm_outlook,
+                llm_insight_json,
+                json.dumps(result.signals),
+            ),
+        )
+        self._db.commit()

--- a/src/stockbee/macro_scoring/scorer.py
+++ b/src/stockbee/macro_scoring/scorer.py
@@ -1,0 +1,297 @@
+"""MacroScorer — 经济周期分类 + 日度 bull/bear 评分。
+
+规则引擎实现（Phase 1）。基于 19 个 FRED 指标 Z-score 判断经济周期，
+输出 macro_score [-1, +1] 供下游 sector/style tilt 使用。
+
+来源：Tech Design §3.5, plan-milestones 2026-04-15
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import date
+from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+class RegimeType(str, Enum):
+    """5 种经济制度。"""
+    EXPANSION = "expansion"
+    OVERHEATING = "overheating"
+    STAGFLATION = "stagflation"
+    RECESSION = "recession"
+    RECOVERY = "recovery"
+
+
+@dataclass(frozen=True)
+class MacroScore:
+    """日度宏观评分结果。"""
+    score: float                          # [-1.0, +1.0]  负=看跌 正=看涨
+    regime: RegimeType
+    regime_confidence: dict[str, float]   # {regime_name: probability}
+    scored_at: date
+    signals: dict[str, float] = field(default_factory=dict)  # 诊断用: 各维度信号
+
+
+# ---------------------------------------------------------------------------
+# Regime classification rules
+# ---------------------------------------------------------------------------
+# 每条规则: (indicator_code, operator, threshold)
+# 满足越多条 → confidence 越高
+
+_REGIME_RULES: dict[RegimeType, list[tuple[str, str, float]]] = {
+    # Expansion: GDP↑ + employment↑ + moderate inflation
+    RegimeType.EXPANSION: [
+        ("GDP", ">", 0.0),
+        ("INDPRO", ">", 0.0),
+        ("PAYEMS", ">", 0.0),
+        ("UNRATE", "<", 0.0),
+        ("CPIAUCSL", "<", 1.0),     # inflation below 1 std
+        ("T10Y2Y", ">", 0.0),       # positive yield curve
+    ],
+    # Overheating: high inflation + rising rates
+    RegimeType.OVERHEATING: [
+        ("CPIAUCSL", ">", 1.0),
+        ("PPIFIS", ">", 1.0),
+        ("DFF", ">", 0.5),
+        ("DGS10", ">", 0.5),
+        ("GDP", ">", 0.0),          # still growing
+        ("UNRATE", "<", 0.0),       # still low unemployment
+    ],
+    # Stagflation: high inflation + declining growth
+    RegimeType.STAGFLATION: [
+        ("CPIAUCSL", ">", 1.0),
+        ("GDP", "<", 0.0),
+        ("INDPRO", "<", 0.0),
+        ("UNRATE", ">", 0.5),
+        ("BAMLH0A0HYM2", ">", 0.5),  # widening credit spread
+    ],
+    # Recession: declining growth + rising unemployment
+    RegimeType.RECESSION: [
+        ("GDP", "<", -0.5),
+        ("INDPRO", "<", -0.5),
+        ("PAYEMS", "<", -0.5),
+        ("UNRATE", ">", 1.0),
+        ("ICSA", ">", 1.0),
+        ("T10Y2Y", "<", 0.0),       # inverted yield curve
+        ("BAMLH0A0HYM2", ">", 1.0), # wide credit spreads
+    ],
+    # Recovery: GDP bottoming + expectations rising
+    RegimeType.RECOVERY: [
+        ("GDP", ">", -0.5),         # GDP recovering (not deeply negative)
+        ("GDP", "<", 0.5),          # but not yet strong
+        ("INDPRO", ">", 0.0),
+        ("UNRATE", ">", 0.0),       # unemployment still elevated
+        ("VIXCLS", "<", 0.0),       # volatility declining
+        ("T10Y2Y", ">", 0.0),       # yield curve normalizing
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Score weights by indicator dimension
+# ---------------------------------------------------------------------------
+# positive z_score on growth/employment → bullish (+)
+# positive z_score on inflation/risk → bearish (-)
+
+_SCORE_WEIGHTS: dict[str, float] = {
+    # Growth (+)
+    "GDP": 0.12,
+    "INDPRO": 0.08,
+    # Employment (+)
+    "PAYEMS": 0.10,
+    "UNRATE": -0.08,    # higher unemployment = bearish
+    "ICSA": -0.05,      # higher claims = bearish
+    # Inflation (-)
+    "CPIAUCSL": -0.08,
+    "PPIFIS": -0.05,
+    # Rates (context-dependent, net negative for equities)
+    "DFF": -0.06,
+    "DGS10": -0.04,
+    "T10Y2Y": 0.06,     # positive curve = healthy
+    # Credit (-)
+    "BAMLH0A0HYM2": -0.08,  # wider spread = risk
+    "DRTSCILM": -0.04,
+    # Liquidity
+    "M2SL": 0.06,
+    "VIXCLS": -0.06,    # higher VIX = bearish
+    # FX / Commodities
+    "DEXUSEU": -0.01,   # weak USD mildly negative
+    "DCOILWTICO": -0.01,
+    "PCOPPUSDM": 0.04,  # copper as growth proxy
+}
+# Weights sum ≈ 0 by design (balanced bull/bear in neutral regime).
+
+
+# ---------------------------------------------------------------------------
+# MacroScorer
+# ---------------------------------------------------------------------------
+
+class MacroScorer:
+    """日度宏观评分引擎（规则引擎版）。
+
+    Args:
+        macro_provider: MacroProvider 实例 (get_latest_z_scores)
+        polymarket: PolymarketFetcher 实例 (可选)
+        calendar: EconomicCalendar 实例 (可选)
+        propagation_weight: 知识图谱传播信号权重 (Phase 1 = 0.0)
+    """
+
+    def __init__(
+        self,
+        macro_provider,
+        polymarket=None,
+        calendar=None,
+        *,
+        propagation_weight: float = 0.0,
+    ):
+        self._macro = macro_provider
+        self._polymarket = polymarket
+        self._calendar = calendar
+        self._propagation_weight = propagation_weight
+
+    def score(self, as_of: date | None = None) -> MacroScore:
+        """计算日度宏观评分。
+
+        Args:
+            as_of: 评分日期, None = today
+
+        Returns:
+            MacroScore with score, regime, confidence
+        """
+        scored_at = as_of or date.today()
+
+        # 1. Get Z-scores from macro provider
+        z_scores = self._macro.get_latest_z_scores()
+        if not z_scores:
+            logger.warning("Empty z_scores from macro_provider, returning neutral")
+            return MacroScore(
+                score=0.0,
+                regime=RegimeType.EXPANSION,
+                regime_confidence={r.value: 0.2 for r in RegimeType},
+                scored_at=scored_at,
+                signals={},
+            )
+
+        # 2. Classify regime
+        regime, confidence = self._classify_regime(z_scores)
+
+        # 3. Compute base score
+        base_score = self._compute_base_score(z_scores)
+
+        # 4. Apply optional adjustments
+        score = base_score
+        signals = {"base_score": base_score}
+
+        poly_adj = self._apply_polymarket_adjustment()
+        if poly_adj != 0.0:
+            score += poly_adj
+            signals["polymarket_adj"] = poly_adj
+
+        # Clip to [-1, +1]
+        score = max(-1.0, min(1.0, score))
+
+        # 5. Dampen on high-volatility calendar days (less conviction)
+        if self._is_high_volatility_day(scored_at):
+            score *= 0.8
+            signals["hv_dampening"] = 0.8
+
+        return MacroScore(
+            score=score,
+            regime=regime,
+            regime_confidence=confidence,
+            scored_at=scored_at,
+            signals=signals,
+        )
+
+    def _classify_regime(
+        self, z_scores: dict[str, float]
+    ) -> tuple[RegimeType, dict[str, float]]:
+        """Classify economic regime based on Z-score rules.
+
+        Returns:
+            (best_regime, {regime_name: match_ratio})
+        """
+        match_counts: dict[RegimeType, float] = {}
+
+        for regime, rules in _REGIME_RULES.items():
+            matched = 0
+            applicable = 0
+            for code, op, threshold in rules:
+                if code not in z_scores:
+                    continue
+                applicable += 1
+                z = z_scores[code]
+                if op == ">" and z > threshold:
+                    matched += 1
+                elif op == "<" and z < threshold:
+                    matched += 1
+            match_counts[regime] = matched / applicable if applicable > 0 else 0.0
+
+        # Normalize to probabilities
+        total = sum(match_counts.values())
+        if total == 0:
+            confidence = {r.value: 0.2 for r in RegimeType}
+            return RegimeType.EXPANSION, confidence
+
+        confidence = {r.value: v / total for r, v in match_counts.items()}
+        best = max(match_counts, key=match_counts.get)  # type: ignore[arg-type]
+        return best, confidence
+
+    def _compute_base_score(self, z_scores: dict[str, float]) -> float:
+        """Weighted aggregation of Z-scores into [-1, +1] score."""
+        score = 0.0
+        for code, weight in _SCORE_WEIGHTS.items():
+            if code in z_scores:
+                score += weight * z_scores[code]
+        # Clip to [-1, +1]
+        return max(-1.0, min(1.0, score))
+
+    def _apply_polymarket_adjustment(self) -> float:
+        """Adjust score based on Polymarket probability cliffs.
+
+        Large probability swings on macro events signal market consensus shift.
+        """
+        if self._polymarket is None:
+            return 0.0
+
+        try:
+            cliffs = self._polymarket.detect_cliffs()
+        except Exception:
+            logger.warning("Polymarket cliff detection failed, skipping", exc_info=True)
+            return 0.0
+
+        if not cliffs:
+            return 0.0
+
+        # Average cliff magnitude, capped at ±0.15 adjustment
+        total_shift = 0.0
+        valid_count = 0
+        for event in cliffs:
+            if event.previous_probability is None:
+                continue
+            shift = event.probability - event.previous_probability
+            total_shift += shift
+            valid_count += 1
+
+        avg_shift = total_shift / valid_count if valid_count > 0 else 0.0
+        # Positive cliff (probabilities rising) could be bearish (policy tightening)
+        # or bullish — we use negative sign as heuristic (higher event probability = uncertainty)
+        adjustment = -avg_shift * 0.3  # scale factor
+        return max(-0.15, min(0.15, adjustment))
+
+    def _is_high_volatility_day(self, d: date) -> bool:
+        """Check if date is a high-volatility calendar day."""
+        if self._calendar is None:
+            return False
+        try:
+            return self._calendar.is_high_volatility_day(d)
+        except Exception:
+            logger.warning("Calendar check failed, skipping", exc_info=True)
+            return False

--- a/tests/test_macro_scoring.py
+++ b/tests/test_macro_scoring.py
@@ -1,0 +1,431 @@
+"""Tests for macro_scoring module — m1 MacroScorer.
+
+Covers:
+- Regime classification for all 5 regimes
+- Base score computation + clipping
+- Polymarket cliff adjustment
+- Calendar high-volatility dampening
+- Edge cases: empty z_scores, partial indicators, extreme values
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from unittest.mock import MagicMock
+
+import pytest
+
+from stockbee.macro_scoring.scorer import (
+    MacroScore,
+    MacroScorer,
+    RegimeType,
+    _REGIME_RULES,
+    _SCORE_WEIGHTS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: mock providers
+# ---------------------------------------------------------------------------
+
+def _make_macro_provider(z_scores: dict[str, float]):
+    """Create a mock MacroProvider with given z_scores."""
+    provider = MagicMock()
+    provider.get_latest_z_scores.return_value = z_scores
+    return provider
+
+
+@dataclass
+class FakeMarketEvent:
+    """Minimal MarketEvent for testing."""
+    event_id: str = "test"
+    question: str = "test"
+    slug: str = "test"
+    probability: float = 0.5
+    previous_probability: float | None = 0.3
+    volume: float = 0.0
+    liquidity: float = 0.0
+    is_cliff: bool = True
+    fetched_at: str = "2026-04-15"
+
+
+def _make_polymarket(cliffs: list[FakeMarketEvent] | None = None):
+    """Create a mock PolymarketFetcher."""
+    fetcher = MagicMock()
+    fetcher.detect_cliffs.return_value = cliffs or []
+    return fetcher
+
+
+def _make_calendar(hv_days: set[date] | None = None):
+    """Create a mock EconomicCalendar."""
+    cal = MagicMock()
+    hv = hv_days or set()
+    cal.is_high_volatility_day.side_effect = lambda d: d in hv
+    return cal
+
+
+# ---------------------------------------------------------------------------
+# Z-score profiles for each regime
+# ---------------------------------------------------------------------------
+
+EXPANSION_ZSCORES = {
+    "GDP": 1.0, "INDPRO": 0.8, "PAYEMS": 1.0, "UNRATE": -0.5,
+    "CPIAUCSL": 0.3, "T10Y2Y": 0.5, "DFF": 0.0, "DGS10": 0.0,
+    "PPIFIS": 0.2, "ICSA": -0.3, "BAMLH0A0HYM2": -0.3,
+    "DRTSCILM": -0.2, "M2SL": 0.5, "VIXCLS": -0.5,
+    "DEXUSEU": 0.0, "DCOILWTICO": 0.0, "PCOPPUSDM": 0.5,
+}
+
+OVERHEATING_ZSCORES = {
+    "GDP": 0.5, "INDPRO": 0.3, "PAYEMS": 0.5, "UNRATE": -0.5,
+    "CPIAUCSL": 2.0, "PPIFIS": 1.5, "DFF": 1.5, "DGS10": 1.0,
+    "T10Y2Y": -0.3, "ICSA": -0.2, "BAMLH0A0HYM2": 0.3,
+    "DRTSCILM": 0.2, "M2SL": -0.3, "VIXCLS": 0.5,
+    "DEXUSEU": 0.0, "DCOILWTICO": 1.0, "PCOPPUSDM": 0.5,
+}
+
+STAGFLATION_ZSCORES = {
+    "GDP": -1.0, "INDPRO": -0.8, "PAYEMS": -0.3, "UNRATE": 1.0,
+    "CPIAUCSL": 2.0, "PPIFIS": 1.5, "DFF": 0.5, "DGS10": 0.5,
+    "T10Y2Y": -0.5, "ICSA": 0.8, "BAMLH0A0HYM2": 1.0,
+    "DRTSCILM": 0.5, "M2SL": -0.5, "VIXCLS": 1.0,
+    "DEXUSEU": 0.5, "DCOILWTICO": 1.5, "PCOPPUSDM": -0.5,
+}
+
+RECESSION_ZSCORES = {
+    "GDP": -2.0, "INDPRO": -1.5, "PAYEMS": -1.5, "UNRATE": 2.0,
+    "CPIAUCSL": -0.5, "PPIFIS": -0.5, "DFF": -1.0, "DGS10": -0.5,
+    "T10Y2Y": -0.5, "ICSA": 2.0, "BAMLH0A0HYM2": 2.0,
+    "DRTSCILM": 1.0, "M2SL": -1.0, "VIXCLS": 2.5,
+    "DEXUSEU": -0.5, "DCOILWTICO": -1.0, "PCOPPUSDM": -1.0,
+}
+
+RECOVERY_ZSCORES = {
+    "GDP": 0.2, "INDPRO": 0.3, "PAYEMS": 0.1, "UNRATE": 0.5,
+    "CPIAUCSL": 0.0, "PPIFIS": 0.0, "DFF": -0.5, "DGS10": -0.3,
+    "T10Y2Y": 0.5, "ICSA": 0.0, "BAMLH0A0HYM2": -0.3,
+    "DRTSCILM": 0.0, "M2SL": 0.5, "VIXCLS": -0.5,
+    "DEXUSEU": 0.0, "DCOILWTICO": 0.0, "PCOPPUSDM": 0.3,
+}
+
+
+# ===================================================================
+# Regime classification tests
+# ===================================================================
+
+class TestRegimeClassification:
+    """Test _classify_regime for all 5 regimes."""
+
+    def test_expansion(self):
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES))
+        regime, conf = scorer._classify_regime(EXPANSION_ZSCORES)
+        assert regime == RegimeType.EXPANSION
+        assert conf["expansion"] == max(conf.values())
+
+    def test_overheating(self):
+        scorer = MacroScorer(_make_macro_provider(OVERHEATING_ZSCORES))
+        regime, conf = scorer._classify_regime(OVERHEATING_ZSCORES)
+        assert regime == RegimeType.OVERHEATING
+        assert conf["overheating"] == max(conf.values())
+
+    def test_stagflation(self):
+        scorer = MacroScorer(_make_macro_provider(STAGFLATION_ZSCORES))
+        regime, conf = scorer._classify_regime(STAGFLATION_ZSCORES)
+        assert regime == RegimeType.STAGFLATION
+        assert conf["stagflation"] == max(conf.values())
+
+    def test_recession(self):
+        scorer = MacroScorer(_make_macro_provider(RECESSION_ZSCORES))
+        regime, conf = scorer._classify_regime(RECESSION_ZSCORES)
+        assert regime == RegimeType.RECESSION
+        assert conf["recession"] == max(conf.values())
+
+    def test_recovery(self):
+        scorer = MacroScorer(_make_macro_provider(RECOVERY_ZSCORES))
+        regime, conf = scorer._classify_regime(RECOVERY_ZSCORES)
+        assert regime == RegimeType.RECOVERY
+        assert conf["recovery"] == max(conf.values())
+
+    def test_confidence_sums_to_one(self):
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES))
+        _, conf = scorer._classify_regime(EXPANSION_ZSCORES)
+        assert abs(sum(conf.values()) - 1.0) < 1e-9
+
+    def test_all_regimes_present_in_confidence(self):
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES))
+        _, conf = scorer._classify_regime(EXPANSION_ZSCORES)
+        for regime in RegimeType:
+            assert regime.value in conf
+
+
+# ===================================================================
+# Base score tests
+# ===================================================================
+
+class TestBaseScore:
+    """Test _compute_base_score."""
+
+    def test_expansion_positive_score(self):
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES))
+        score = scorer._compute_base_score(EXPANSION_ZSCORES)
+        assert score > 0.0, "Expansion should produce positive score"
+
+    def test_recession_negative_score(self):
+        scorer = MacroScorer(_make_macro_provider(RECESSION_ZSCORES))
+        score = scorer._compute_base_score(RECESSION_ZSCORES)
+        assert score < 0.0, "Recession should produce negative score"
+
+    def test_score_clipped_to_range(self):
+        # Extreme z-scores should still produce [-1, +1]
+        extreme = {code: 3.0 for code in _SCORE_WEIGHTS}
+        scorer = MacroScorer(_make_macro_provider(extreme))
+        score = scorer._compute_base_score(extreme)
+        assert -1.0 <= score <= 1.0
+
+    def test_all_zero_zscores(self):
+        zeros = {code: 0.0 for code in _SCORE_WEIGHTS}
+        scorer = MacroScorer(_make_macro_provider(zeros))
+        score = scorer._compute_base_score(zeros)
+        assert score == 0.0, "All-zero z_scores should give 0.0 score"
+
+    def test_partial_indicators(self):
+        """Only a few indicators available — should still compute."""
+        partial = {"GDP": 1.0, "UNRATE": -1.0}
+        scorer = MacroScorer(_make_macro_provider(partial))
+        score = scorer._compute_base_score(partial)
+        expected = 0.12 * 1.0 + (-0.08) * (-1.0)  # GDP + UNRATE
+        assert abs(score - expected) < 1e-9
+
+
+# ===================================================================
+# Full score() integration tests
+# ===================================================================
+
+class TestScoreIntegration:
+    """Test the full score() pipeline."""
+
+    def test_basic_scoring(self):
+        provider = _make_macro_provider(EXPANSION_ZSCORES)
+        scorer = MacroScorer(provider)
+        result = scorer.score(as_of=date(2026, 4, 15))
+        assert isinstance(result, MacroScore)
+        assert -1.0 <= result.score <= 1.0
+        assert result.regime in RegimeType
+        assert result.scored_at == date(2026, 4, 15)
+        assert "base_score" in result.signals
+
+    def test_empty_zscores_returns_neutral(self):
+        provider = _make_macro_provider({})
+        scorer = MacroScorer(provider)
+        result = scorer.score(as_of=date(2026, 4, 15))
+        assert result.score == 0.0
+        assert result.regime == RegimeType.EXPANSION
+        # All regimes should have equal confidence
+        for val in result.regime_confidence.values():
+            assert abs(val - 0.2) < 1e-9
+
+    def test_no_optional_providers(self):
+        """Works fine without polymarket/calendar."""
+        provider = _make_macro_provider(RECESSION_ZSCORES)
+        scorer = MacroScorer(provider)
+        result = scorer.score()
+        assert result.score < 0.0
+        assert "polymarket_adj" not in result.signals
+
+    def test_score_uses_today_when_no_date(self):
+        provider = _make_macro_provider(EXPANSION_ZSCORES)
+        scorer = MacroScorer(provider)
+        result = scorer.score()
+        assert result.scored_at == date.today()
+
+
+# ===================================================================
+# Polymarket adjustment tests
+# ===================================================================
+
+class TestPolymarketAdjustment:
+    """Test _apply_polymarket_adjustment."""
+
+    def test_no_cliffs_no_adjustment(self):
+        poly = _make_polymarket([])
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES), polymarket=poly)
+        adj = scorer._apply_polymarket_adjustment()
+        assert adj == 0.0
+
+    def test_positive_cliff_negative_adjustment(self):
+        """Rising probability → uncertainty → slightly bearish."""
+        cliff = FakeMarketEvent(probability=0.8, previous_probability=0.3)
+        poly = _make_polymarket([cliff])
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES), polymarket=poly)
+        adj = scorer._apply_polymarket_adjustment()
+        assert adj < 0.0
+
+    def test_negative_cliff_positive_adjustment(self):
+        """Falling probability → reduced uncertainty → slightly bullish."""
+        cliff = FakeMarketEvent(probability=0.2, previous_probability=0.8)
+        poly = _make_polymarket([cliff])
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES), polymarket=poly)
+        adj = scorer._apply_polymarket_adjustment()
+        assert adj > 0.0
+
+    def test_adjustment_capped_at_015(self):
+        """Adjustment should not exceed ±0.15."""
+        cliff = FakeMarketEvent(probability=1.0, previous_probability=0.0)
+        poly = _make_polymarket([cliff])
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES), polymarket=poly)
+        adj = scorer._apply_polymarket_adjustment()
+        assert -0.15 <= adj <= 0.15
+
+    def test_none_previous_probability_skipped(self):
+        """First-ever fetch has no previous — should not crash."""
+        cliff = FakeMarketEvent(probability=0.5, previous_probability=None)
+        poly = _make_polymarket([cliff])
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES), polymarket=poly)
+        adj = scorer._apply_polymarket_adjustment()
+        assert adj == 0.0  # no valid shifts
+
+    def test_polymarket_exception_returns_zero(self):
+        """If polymarket raises, gracefully return 0."""
+        poly = MagicMock()
+        poly.detect_cliffs.side_effect = RuntimeError("API down")
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES), polymarket=poly)
+        adj = scorer._apply_polymarket_adjustment()
+        assert adj == 0.0
+
+    def test_mixed_none_and_valid_cliffs(self):
+        """Mix of valid and None previous_probability cliffs."""
+        cliffs = [
+            FakeMarketEvent(probability=0.8, previous_probability=0.3),  # valid: +0.5
+            FakeMarketEvent(probability=0.5, previous_probability=None),  # skipped
+            FakeMarketEvent(probability=0.2, previous_probability=0.6),  # valid: -0.4
+        ]
+        poly = _make_polymarket(cliffs)
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES), polymarket=poly)
+        adj = scorer._apply_polymarket_adjustment()
+        # avg_shift = (0.5 + (-0.4)) / 2 = 0.05, adjustment = -0.05 * 0.3 = -0.015
+        expected = -(0.05) * 0.3
+        assert abs(adj - expected) < 1e-9
+
+    def test_polymarket_adjustment_in_full_score(self):
+        """Verify polymarket_adj appears in signals when active."""
+        cliff = FakeMarketEvent(probability=0.8, previous_probability=0.3)
+        poly = _make_polymarket([cliff])
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES), polymarket=poly)
+        result = scorer.score(as_of=date(2026, 4, 15))
+        assert "polymarket_adj" in result.signals
+
+
+# ===================================================================
+# Calendar dampening tests
+# ===================================================================
+
+class TestCalendarDampening:
+    """Test high-volatility day dampening."""
+
+    def test_hv_day_dampens_score(self):
+        hv_date = date(2026, 4, 15)
+        cal = _make_calendar({hv_date})
+        provider = _make_macro_provider(EXPANSION_ZSCORES)
+        scorer = MacroScorer(provider, calendar=cal)
+
+        # Score without calendar
+        scorer_no_cal = MacroScorer(provider)
+        base_result = scorer_no_cal.score(as_of=hv_date)
+
+        # Score with calendar on HV day
+        result = scorer.score(as_of=hv_date)
+        assert abs(result.score) < abs(base_result.score) or base_result.score == 0.0
+        if base_result.score != 0.0:
+            assert abs(result.score - base_result.score * 0.8) < 1e-9
+
+    def test_non_hv_day_no_dampening(self):
+        hv_date = date(2026, 4, 15)
+        normal_date = date(2026, 4, 16)
+        cal = _make_calendar({hv_date})
+        provider = _make_macro_provider(EXPANSION_ZSCORES)
+
+        scorer = MacroScorer(provider, calendar=cal)
+        scorer_no_cal = MacroScorer(provider)
+
+        result = scorer.score(as_of=normal_date)
+        base_result = scorer_no_cal.score(as_of=normal_date)
+        assert abs(result.score - base_result.score) < 1e-9
+
+    def test_calendar_exception_no_dampening(self):
+        cal = MagicMock()
+        cal.is_high_volatility_day.side_effect = RuntimeError("DB error")
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES), calendar=cal)
+        result = scorer.score(as_of=date(2026, 4, 15))
+        # Should succeed without dampening
+        assert isinstance(result, MacroScore)
+
+    def test_hv_dampening_signal_in_result(self):
+        hv_date = date(2026, 4, 15)
+        cal = _make_calendar({hv_date})
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES), calendar=cal)
+        result = scorer.score(as_of=hv_date)
+        assert "hv_dampening" in result.signals
+
+
+# ===================================================================
+# Edge cases
+# ===================================================================
+
+class TestEdgeCases:
+    """Edge cases and boundary conditions."""
+
+    def test_all_extreme_positive_zscores(self):
+        extreme = {code: 3.0 for code in _SCORE_WEIGHTS}
+        scorer = MacroScorer(_make_macro_provider(extreme))
+        result = scorer.score(as_of=date(2026, 4, 15))
+        assert -1.0 <= result.score <= 1.0
+
+    def test_all_extreme_negative_zscores(self):
+        extreme = {code: -3.0 for code in _SCORE_WEIGHTS}
+        scorer = MacroScorer(_make_macro_provider(extreme))
+        result = scorer.score(as_of=date(2026, 4, 15))
+        assert -1.0 <= result.score <= 1.0
+
+    def test_single_indicator(self):
+        """Only one indicator available."""
+        single = {"GDP": 2.0}
+        scorer = MacroScorer(_make_macro_provider(single))
+        result = scorer.score(as_of=date(2026, 4, 15))
+        assert isinstance(result, MacroScore)
+        assert result.score > 0.0  # GDP positive → bullish
+
+    def test_unknown_indicator_ignored(self):
+        """Z-scores with unknown codes should not crash."""
+        z = {"GDP": 1.0, "UNKNOWN_CODE": 5.0}
+        scorer = MacroScorer(_make_macro_provider(z))
+        result = scorer.score(as_of=date(2026, 4, 15))
+        assert isinstance(result, MacroScore)
+
+    def test_regime_rules_cover_all_types(self):
+        """All RegimeType values should have rules."""
+        for regime in RegimeType:
+            assert regime in _REGIME_RULES, f"Missing rules for {regime}"
+
+    def test_propagation_weight_stored(self):
+        """propagation_weight should be stored for Phase 2."""
+        scorer = MacroScorer(
+            _make_macro_provider({}), propagation_weight=0.4
+        )
+        assert scorer._propagation_weight == 0.4
+
+    def test_score_weights_roughly_balanced(self):
+        """Weights should approximately sum to 0 (balanced bull/bear)."""
+        total = sum(_SCORE_WEIGHTS.values())
+        assert abs(total) < 0.15, f"Weights sum to {total}, should be ~0"
+
+    def test_frozen_macro_score(self):
+        """MacroScore is immutable."""
+        result = MacroScore(
+            score=0.5,
+            regime=RegimeType.EXPANSION,
+            regime_confidence={"expansion": 1.0},
+            scored_at=date(2026, 4, 15),
+        )
+        with pytest.raises(AttributeError):
+            result.score = 0.0  # type: ignore[misc]

--- a/tests/test_macro_scoring.py
+++ b/tests/test_macro_scoring.py
@@ -1,11 +1,12 @@
-"""Tests for macro_scoring module — m1 MacroScorer.
+"""Tests for macro_scoring module — m1 MacroScorer + m2 LLMMacroAnalyst.
 
 Covers:
-- Regime classification for all 5 regimes
-- Base score computation + clipping
-- Polymarket cliff adjustment
-- Calendar high-volatility dampening
-- Edge cases: empty z_scores, partial indicators, extreme values
+- m1: Regime classification for all 5 regimes
+- m1: Base score computation + clipping
+- m1: Polymarket cliff adjustment
+- m1: Calendar high-volatility dampening
+- m1: Edge cases: empty z_scores, partial indicators, extreme values
+- m2: Prompt building, LLM response parsing, SQLite caching, error handling
 """
 
 from __future__ import annotations
@@ -22,6 +23,11 @@ from stockbee.macro_scoring.scorer import (
     RegimeType,
     _REGIME_RULES,
     _SCORE_WEIGHTS,
+)
+from stockbee.macro_scoring.llm_analyst import (
+    LLMMacroAnalyst,
+    MacroInsight,
+    _SYSTEM_PROMPT,
 )
 
 
@@ -429,3 +435,283 @@ class TestEdgeCases:
         )
         with pytest.raises(AttributeError):
             result.score = 0.0  # type: ignore[misc]
+
+
+# ===================================================================
+# m2: LLMMacroAnalyst tests
+# ===================================================================
+
+SAMPLE_LLM_RESPONSE = """\
+REGIME: expansion
+OUTLOOK_SCORE: 0.65
+RISK_FACTORS:
+- Rising inflation expectations could force Fed to hold rates longer
+- Credit spreads widening modestly signals caution
+- Geopolitical tensions in trade policy
+REASONING:
+The US economy remains in an expansion phase with solid GDP growth and improving \
+employment metrics. The labor market is tight with unemployment below the historical average.
+
+However, inflation remains sticky above the Fed's 2% target, which may delay rate cuts. \
+Credit conditions are tightening modestly but not at alarming levels. Overall, the macro \
+environment supports a mildly bullish equity stance with sector rotation toward cyclicals.
+"""
+
+
+@dataclass
+class FakeReleaseEvent:
+    """Minimal ReleaseEvent for testing."""
+    release_id: int = 1
+    release_name: str = "CPI"
+    release_date: str = "2026-04-20"
+    high_volatility: bool = True
+
+
+def _make_router(content: str = SAMPLE_LLM_RESPONSE, raise_error: bool = False):
+    """Create a mock LLMRouter."""
+    router = MagicMock()
+    if raise_error:
+        router.route.side_effect = RuntimeError("LLM unavailable")
+    else:
+        resp = MagicMock()
+        resp.content = content
+        resp.model_used = "anthropic/claude-opus-4-6"
+        router.route.return_value = resp
+    return router
+
+
+class TestPromptBuilding:
+    """Test _build_prompt."""
+
+    def test_basic_prompt_has_zscores(self):
+        analyst = LLMMacroAnalyst(
+            _make_router(), _make_macro_provider(EXPANSION_ZSCORES)
+        )
+        prompt = analyst._build_prompt(EXPANSION_ZSCORES, date(2026, 4, 15))
+        assert "2026-04-15" in prompt
+        assert "Z-Scores" in prompt
+        assert "GDP" in prompt
+
+    def test_prompt_with_polymarket(self):
+        events = [FakeMarketEvent(
+            question="Fed rate cut in May?", probability=0.35,
+            previous_probability=0.2, is_cliff=True
+        )]
+        poly = MagicMock()
+        poly.get_latest_events.return_value = events
+        analyst = LLMMacroAnalyst(
+            _make_router(), _make_macro_provider(EXPANSION_ZSCORES), polymarket=poly
+        )
+        prompt = analyst._build_prompt(EXPANSION_ZSCORES, date(2026, 4, 15))
+        assert "Polymarket" in prompt
+        assert "Fed rate cut" in prompt
+        assert "CLIFF" in prompt
+
+    def test_prompt_with_calendar(self):
+        cal = MagicMock()
+        cal.get_events.return_value = [
+            FakeReleaseEvent(release_name="CPI", release_date="2026-04-20"),
+        ]
+        analyst = LLMMacroAnalyst(
+            _make_router(), _make_macro_provider(EXPANSION_ZSCORES), calendar=cal
+        )
+        prompt = analyst._build_prompt(EXPANSION_ZSCORES, date(2026, 4, 15))
+        assert "High-Volatility" in prompt
+        assert "CPI" in prompt
+
+    def test_prompt_without_optional_sources(self):
+        analyst = LLMMacroAnalyst(
+            _make_router(), _make_macro_provider(EXPANSION_ZSCORES)
+        )
+        prompt = analyst._build_prompt(EXPANSION_ZSCORES, date(2026, 4, 15))
+        assert "Polymarket" not in prompt
+        assert "High-Volatility" not in prompt
+
+    def test_prompt_polymarket_exception_graceful(self):
+        poly = MagicMock()
+        poly.get_latest_events.side_effect = RuntimeError("API down")
+        analyst = LLMMacroAnalyst(
+            _make_router(), _make_macro_provider(EXPANSION_ZSCORES), polymarket=poly
+        )
+        prompt = analyst._build_prompt(EXPANSION_ZSCORES, date(2026, 4, 15))
+        # Should not crash, polymarket section omitted
+        assert "Z-Scores" in prompt
+
+    def test_prompt_calendar_exception_graceful(self):
+        cal = MagicMock()
+        cal.get_events.side_effect = RuntimeError("DB error")
+        analyst = LLMMacroAnalyst(
+            _make_router(), _make_macro_provider(EXPANSION_ZSCORES), calendar=cal
+        )
+        prompt = analyst._build_prompt(EXPANSION_ZSCORES, date(2026, 4, 15))
+        assert "Z-Scores" in prompt
+
+
+class TestResponseParsing:
+    """Test _parse_response."""
+
+    def test_parse_full_response(self):
+        analyst = LLMMacroAnalyst(
+            _make_router(), _make_macro_provider(EXPANSION_ZSCORES)
+        )
+        insight = analyst._parse_response(
+            SAMPLE_LLM_RESPONSE, "claude-opus-4-6", date(2026, 4, 15)
+        )
+        assert insight is not None
+        assert insight.regime_assessment == "expansion"
+        assert abs(insight.outlook_score - 0.65) < 1e-9
+        assert len(insight.risk_factors) == 3
+        assert "inflation" in insight.risk_factors[0].lower()
+        assert "expansion" in insight.reasoning.lower()
+        assert insight.model_used == "claude-opus-4-6"
+        assert insight.analyzed_at == date(2026, 4, 15)
+
+    def test_parse_empty_response(self):
+        analyst = LLMMacroAnalyst(
+            _make_router(), _make_macro_provider(EXPANSION_ZSCORES)
+        )
+        assert analyst._parse_response("", "test", date(2026, 4, 15)) is None
+        assert analyst._parse_response("   ", "test", date(2026, 4, 15)) is None
+
+    def test_parse_malformed_outlook_defaults_to_zero(self):
+        bad_response = "REGIME: expansion\nOUTLOOK_SCORE: not-a-number\nRISK_FACTORS:\n- test\nREASONING:\ntest"
+        analyst = LLMMacroAnalyst(
+            _make_router(), _make_macro_provider(EXPANSION_ZSCORES)
+        )
+        insight = analyst._parse_response(bad_response, "test", date(2026, 4, 15))
+        assert insight is not None
+        assert insight.outlook_score == 0.0
+
+    def test_parse_outlook_clipped(self):
+        response = "REGIME: recession\nOUTLOOK_SCORE: -5.0\nRISK_FACTORS:\n- doom\nREASONING:\nbad"
+        analyst = LLMMacroAnalyst(
+            _make_router(), _make_macro_provider(EXPANSION_ZSCORES)
+        )
+        insight = analyst._parse_response(response, "test", date(2026, 4, 15))
+        assert insight is not None
+        assert insight.outlook_score == -1.0
+
+    def test_parse_missing_risk_factors(self):
+        response = "REGIME: expansion\nOUTLOOK_SCORE: 0.5\nREASONING:\nall good"
+        analyst = LLMMacroAnalyst(
+            _make_router(), _make_macro_provider(EXPANSION_ZSCORES)
+        )
+        insight = analyst._parse_response(response, "test", date(2026, 4, 15))
+        assert insight is not None
+        assert insight.risk_factors == []
+
+    def test_parse_missing_reasoning(self):
+        response = "REGIME: expansion\nOUTLOOK_SCORE: 0.5\nRISK_FACTORS:\n- test"
+        analyst = LLMMacroAnalyst(
+            _make_router(), _make_macro_provider(EXPANSION_ZSCORES)
+        )
+        insight = analyst._parse_response(response, "test", date(2026, 4, 15))
+        assert insight is not None
+        assert insight.reasoning == ""
+
+
+class TestLLMAnalystIntegration:
+    """Test full analyze() flow with mock LLM."""
+
+    def test_analyze_calls_router(self, tmp_path):
+        router = _make_router()
+        analyst = LLMMacroAnalyst(
+            router, _make_macro_provider(EXPANSION_ZSCORES), cache_dir=tmp_path
+        )
+        insight = analyst.analyze(as_of=date(2026, 4, 15))
+        assert insight is not None
+        assert insight.regime_assessment == "expansion"
+        router.route.assert_called_once()
+
+    def test_analyze_empty_zscores_returns_none(self, tmp_path):
+        router = _make_router()
+        analyst = LLMMacroAnalyst(
+            router, _make_macro_provider({}), cache_dir=tmp_path
+        )
+        result = analyst.analyze(as_of=date(2026, 4, 15))
+        assert result is None
+        router.route.assert_not_called()
+
+    def test_analyze_llm_failure_returns_none(self, tmp_path):
+        router = _make_router(raise_error=True)
+        analyst = LLMMacroAnalyst(
+            router, _make_macro_provider(EXPANSION_ZSCORES), cache_dir=tmp_path
+        )
+        result = analyst.analyze(as_of=date(2026, 4, 15))
+        assert result is None
+
+    def test_analyze_caches_result(self, tmp_path):
+        router = _make_router()
+        analyst = LLMMacroAnalyst(
+            router, _make_macro_provider(EXPANSION_ZSCORES), cache_dir=tmp_path
+        )
+        # First call → LLM
+        insight1 = analyst.analyze(as_of=date(2026, 4, 15))
+        assert insight1 is not None
+        assert router.route.call_count == 1
+
+        # Second call same week → cache
+        insight2 = analyst.analyze(as_of=date(2026, 4, 18))
+        assert insight2 is not None
+        assert router.route.call_count == 1  # not called again
+        assert insight2.regime_assessment == insight1.regime_assessment
+
+    def test_analyze_cache_expired(self, tmp_path):
+        router = _make_router()
+        analyst = LLMMacroAnalyst(
+            router, _make_macro_provider(EXPANSION_ZSCORES), cache_dir=tmp_path
+        )
+        # First call
+        analyst.analyze(as_of=date(2026, 4, 8))
+        assert router.route.call_count == 1
+
+        # 8 days later → cache expired → new LLM call
+        analyst.analyze(as_of=date(2026, 4, 16))
+        assert router.route.call_count == 2
+
+    def test_close_db(self, tmp_path):
+        analyst = LLMMacroAnalyst(
+            _make_router(), _make_macro_provider(EXPANSION_ZSCORES), cache_dir=tmp_path
+        )
+        analyst.analyze(as_of=date(2026, 4, 15))
+        analyst.close()
+        assert analyst._db is None
+
+    def test_frozen_macro_insight(self):
+        insight = MacroInsight(
+            regime_assessment="expansion",
+            risk_factors=["test"],
+            outlook_score=0.5,
+            reasoning="test",
+            model_used="test",
+            analyzed_at=date(2026, 4, 15),
+        )
+        with pytest.raises(AttributeError):
+            insight.outlook_score = 0.0  # type: ignore[misc]
+
+
+class TestExtractHelpers:
+    """Test static parsing helpers."""
+
+    def test_extract_field(self):
+        text = "REGIME: expansion\nOUTLOOK_SCORE: 0.5"
+        assert LLMMacroAnalyst._extract_field(text, "REGIME", "x") == "expansion"
+        assert LLMMacroAnalyst._extract_field(text, "OUTLOOK_SCORE", "0") == "0.5"
+        assert LLMMacroAnalyst._extract_field(text, "MISSING", "default") == "default"
+
+    def test_extract_list(self):
+        text = "RISK_FACTORS:\n- item one\n- item two\n- item three\nREASONING:\nfoo"
+        items = LLMMacroAnalyst._extract_list(text, "RISK_FACTORS")
+        assert items == ["item one", "item two", "item three"]
+
+    def test_extract_list_missing(self):
+        assert LLMMacroAnalyst._extract_list("no list here", "RISK_FACTORS") == []
+
+    def test_extract_section(self):
+        text = "REASONING:\nline one\nline two\n\nline three"
+        result = LLMMacroAnalyst._extract_section(text, "REASONING")
+        assert "line one" in result
+        assert "line three" in result
+
+    def test_extract_section_missing(self):
+        assert LLMMacroAnalyst._extract_section("no section", "REASONING") == ""

--- a/tests/test_macro_scoring.py
+++ b/tests/test_macro_scoring.py
@@ -29,6 +29,8 @@ from stockbee.macro_scoring.llm_analyst import (
     MacroInsight,
     _SYSTEM_PROMPT,
 )
+from stockbee.macro_scoring.provider import MacroScoringProvider
+from stockbee.providers.base import ProviderConfig
 
 
 # ---------------------------------------------------------------------------
@@ -715,3 +717,172 @@ class TestExtractHelpers:
 
     def test_extract_section_missing(self):
         assert LLMMacroAnalyst._extract_section("no section", "REASONING") == ""
+
+
+# ===================================================================
+# m3: MacroScoringProvider tests
+# ===================================================================
+
+def _make_provider(tmp_path, mode="backtest") -> MacroScoringProvider:
+    """Create a MacroScoringProvider with tmp SQLite."""
+    config = ProviderConfig(
+        implementation="MacroScoringProvider",
+        params={"db_path": str(tmp_path / "macro_scores.db"), "mode": mode},
+    )
+    provider = MacroScoringProvider(config)
+    provider.initialize()
+    return provider
+
+
+class TestProviderLifecycle:
+    """Test initialize / shutdown / health_check."""
+
+    def test_initialize_creates_db(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        assert provider.is_initialized
+        assert provider.health_check()
+        assert (tmp_path / "macro_scores.db").exists()
+
+    def test_shutdown(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        provider.shutdown()
+        assert not provider.is_initialized
+
+    def test_double_initialize(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        provider.initialize()  # should be idempotent
+        assert provider.is_initialized
+
+
+class TestScoreAndStore:
+    """Test score_and_store + retrieval."""
+
+    def test_score_and_store_backtest(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES))
+        provider.set_scorer(scorer)
+
+        result = provider.score_and_store(as_of=date(2026, 4, 15))
+        assert result is not None
+        assert result.score > 0.0
+        assert result.regime == RegimeType.EXPANSION
+
+        # Verify persisted
+        score = provider.get_macro_score(date(2026, 4, 15))
+        assert score is not None
+        assert abs(score - result.score) < 1e-9
+
+        regime = provider.get_regime(date(2026, 4, 15))
+        assert regime == "expansion"
+
+    def test_score_and_store_no_scorer(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        result = provider.score_and_store(as_of=date(2026, 4, 15))
+        assert result is None
+
+    def test_score_and_store_replaces_existing(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES))
+        provider.set_scorer(scorer)
+
+        provider.score_and_store(as_of=date(2026, 4, 15))
+        # Score again same date — should replace, not error
+        result2 = provider.score_and_store(as_of=date(2026, 4, 15))
+        assert result2 is not None
+
+    def test_score_and_store_live_with_llm(self, tmp_path):
+        provider = _make_provider(tmp_path, mode="live")
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES))
+        provider.set_scorer(scorer)
+
+        router = _make_router()
+        analyst = LLMMacroAnalyst(
+            router, _make_macro_provider(EXPANSION_ZSCORES),
+            cache_dir=tmp_path / "llm_cache",
+        )
+        provider.set_analyst(analyst)
+
+        result = provider.score_and_store(as_of=date(2026, 4, 15))
+        assert result is not None
+        assert "llm_blend" in result.signals
+        assert "llm_outlook" in result.signals
+        router.route.assert_called_once()
+
+    def test_score_and_store_live_llm_failure(self, tmp_path):
+        provider = _make_provider(tmp_path, mode="live")
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES))
+        provider.set_scorer(scorer)
+
+        router = _make_router(raise_error=True)
+        analyst = LLMMacroAnalyst(
+            router, _make_macro_provider(EXPANSION_ZSCORES),
+            cache_dir=tmp_path / "llm_cache",
+        )
+        provider.set_analyst(analyst)
+
+        # Should fallback to pure rule-based score
+        result = provider.score_and_store(as_of=date(2026, 4, 15))
+        assert result is not None
+        assert "llm_blend" not in result.signals
+
+
+class TestGetHistory:
+    """Test get_history."""
+
+    def test_history_multiple_dates(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES))
+        provider.set_scorer(scorer)
+
+        for day in range(10, 16):
+            provider.score_and_store(as_of=date(2026, 4, day))
+
+        df = provider.get_history(date(2026, 4, 10), date(2026, 4, 15))
+        assert len(df) == 6
+        assert list(df.columns) == ["date", "score", "regime", "llm_outlook"]
+        assert all(df["regime"] == "expansion")
+
+    def test_history_empty_range(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        df = provider.get_history(date(2026, 1, 1), date(2026, 1, 31))
+        assert len(df) == 0
+        assert list(df.columns) == ["date", "score", "regime", "llm_outlook"]
+
+    def test_history_partial_range(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES))
+        provider.set_scorer(scorer)
+
+        provider.score_and_store(as_of=date(2026, 4, 12))
+        provider.score_and_store(as_of=date(2026, 4, 14))
+
+        df = provider.get_history(date(2026, 4, 10), date(2026, 4, 15))
+        assert len(df) == 2
+
+
+class TestProviderQuery:
+    """Test get_macro_score / get_regime edge cases."""
+
+    def test_query_missing_date(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        assert provider.get_macro_score(date(2026, 4, 15)) is None
+        assert provider.get_regime(date(2026, 4, 15)) is None
+
+    def test_query_after_shutdown_and_reinit(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        scorer = MacroScorer(_make_macro_provider(EXPANSION_ZSCORES))
+        provider.set_scorer(scorer)
+        provider.score_and_store(as_of=date(2026, 4, 15))
+        provider.shutdown()
+
+        # Re-initialize — data should persist
+        provider.initialize()
+        score = provider.get_macro_score(date(2026, 4, 15))
+        assert score is not None
+
+    def test_recession_regime_stored(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        scorer = MacroScorer(_make_macro_provider(RECESSION_ZSCORES))
+        provider.set_scorer(scorer)
+        provider.score_and_store(as_of=date(2026, 4, 15))
+        assert provider.get_regime(date(2026, 4, 15)) == "recession"


### PR DESCRIPTION
## Summary
- **MacroScorer** — rule-based economic regime classifier (5 regimes) with daily macro_score [-1, +1], consuming 17 FRED Z-scores + Polymarket cliff signals + calendar HV-day dampening
- **LLMMacroAnalyst** — weekly Claude Opus macro analysis, structured text parsing, SQLite 7-day cache
- **MacroScoringProvider** — BaseProvider subclass, SQLite persistence, backtest (pure rules) / live (0.7 rules + 0.3 LLM blend)
- **74 tests**, 853 all pass

## Test plan
- [x] 5 regime classification + confidence distribution
- [x] Score computation: clipping, partial data, edge cases
- [x] Polymarket cliff adjustment + exception fallback
- [x] Calendar HV-day dampening
- [x] LLM prompt/parse/cache lifecycle
- [x] Provider: backtest/live, persistence, get_history
- [x] Full suite: 853 pass (74 new + 779 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)