### PR TITLE
feat: 04-factor-storage + 02-small-models (15 milestones, Phase 1)

### DIFF
--- a/claude-skills/dev/SKILL.md
+++ b/claude-skills/dev/SKILL.md
@@ -156,7 +156,10 @@ description: >
       LOW（要 defer？）: · [L1] list_factors schema 不统一 → TypedDict / ...
     修复并重跑测试？(y/n/选择性)
     ```
-
+   修复展示格式:
+  每条: "[级别] [文件:行号] — 改了什么（一句话）— 为什么（一句话）"
+  如需看完整改动: 用户说 "展开 C1" 才展示那一段 diff
+  禁止: 用自然语言段落描述修改过程
 16. 修复后重跑全量测试，必须全绿才进 Phase 4。
 
 ### Phase 4: Commit-Sync（内置 commit-sync 逻辑）

--- a/meta/00-project-room/03-model-system/02-small-models/progress.yaml
+++ b/meta/00-project-room/03-model-system/02-small-models/progress.yaml
@@ -1,24 +1,433 @@
 progress:
-  completion: 0.0
+  completion: 0.143  # 1/7 milestones
+  # 7 milestones，参考 04-factor-storage 的 8-milestone 分法（m1a/m1b 拆、m7 集成测试独立）
+  # 设计原则：
+  #   - 每个 milestone 自带单元测试，可独立验收，不依赖下一个 milestone
+  #   - 非测试代码目标 ~250 行/milestone（少数略超至 280-300，权衡分拆成本）
+  #   - 最后一个 milestone 做跨模块集成测试（参考 04-factor-storage m7 模式）
+  #   - 依赖拓扑：m1 (含 model_io) → {m2a → m2b, m3 → m4, m5} 可并行 → m6
+  # 关键决策（见 spec.md Decisions 表）：
+  #   - XGBoost 因子融合推迟到 04-alpha-mining
+  #   - 周度 refit 推迟到 Phase 2（本 room 不做 CLI / APScheduler 调度）
+  #   - FinBERT / Fin-E5 用预训练，不做 fine-tune
+  #   - Fin-E5 重要性降级为 embedding infra + rule baseline
+  #   - P3: g2_classifier 从私有 FinBERT 实例重构为复用 m2a FinBERTScorer singleton
+  #         新 schema 列 finbert_negative/neutral/confidence + fine5_importance
+  #   - D2: m4 独立新增 evaluate_ml_score(shift=5)，不破坏已稳定的 get_ic_report
   milestones:
-    - id: "m1-FinBERT-部署"
-      name: "FinBERT 部署"
+    - id: "m1-contracts-fixtures-io"
+      name: "Contracts + Fixtures + model_io + DB Migration"
+      status: completed
+      completed_at: "2026-04-13"
+      estimated_files:
+        - "src/stockbee/small_models/__init__.py"
+        - "src/stockbee/small_models/paths.py"
+        - "src/stockbee/small_models/model_io.py"           # 从 m2a 上移：通用 artifact IO
+        - "src/stockbee/news_data/news_store.py"            # schema 扩 4 列
+        - "tests/small_models/__init__.py"                  # 空，pytest 扫描 conftest 用
+        - "tests/small_models/conftest.py"                  # OQ2 锁定：子目录 conftest 自动发现
+        - "tests/small_models/test_contracts.py"
+        - "meta/00-project-room/03-model-system/02-small-models/spec.md"
+      estimated_lines: 300   # non-test ~140 (paths 20 + model_io 80 + schema ALTER 40) + tests/fixtures ~160
+      depends_on: []
+      complexity_flags: [first_of_kind, contract_locking, shared_infra]
+      description: |
+        锁定跨模块契约 + 通用 artifact IO + shared fixtures + SQLite schema 扩列。
+        契约锁定教训来自 04-factor-storage：m1 时未锁 RANK/QUANTILE 横截面/时序 → m2 返工。
+        model_io 上移到 m1（review v2 第 1 轮 blocker）：m2a/m3/m4/m5 都用 save_pickle/load_pickle，
+        若放 m2a 会导致 m3/m4/m5 反向依赖 m2a，违反 "m2a/m3/m5 可并行" 原则。
+
+        非测试代码 (~140 行):
+          - src/stockbee/small_models/paths.py (~20 行)：路径常量
+              MODEL_ROOT = Path("data/models")
+              ML_SCORE_PARQUET = Path("data/factors/ml_score.parquet")
+          - src/stockbee/small_models/model_io.py (~80 行)：通用 artifact IO
+              def artifact_path(name: str, version: str = "current") -> Path
+              def save_pickle(obj, name, version=None, overwrite=False) -> Path  # OQ1：默认拒绝覆盖
+              def load_pickle(name: str, version: str = "current") -> object
+              def update_symlink(name: str, version: str) -> None    # POSIX symlink, Windows fallback = current.txt (OQ3)
+              def list_versions(name: str) -> list[str]               # descending date
+              NotFoundError / InvalidArtifactError 分级 raise
+              # OQ4：save_pickle 不自动 update_symlink，训练完显式调用
+          - src/stockbee/small_models/__init__.py：占位 re-export paths + model_io
+          - news_store.py 扩 schema (~40 行 diff)：
+              新增 finbert_negative REAL   (FinBERT negative softmax 概率)
+              新增 finbert_neutral REAL    (FinBERT neutral softmax 概率)
+              新增 finbert_confidence REAL (= max(sentiment_score, finbert_negative, finbert_neutral)，缓存)
+              新增 fine5_importance REAL   (Fin-E5 + rule baseline，m5 回写)
+              sentiment_score 列保留，按 P3 语义 = FinBERT positive softmax（g2 原有写法一致）
+              实现：_do_initialize() 末尾 PRAGMA table_info 探测后条件执行 ALTER TABLE ADD COLUMN
+              （SQLite 不支持 ADD COLUMN IF NOT EXISTS，必须探测）
+
+        Fixtures (~160 行)：tests/conftest_small_models.py
+          - ohlcv_fixture: 2 tickers × 60 天 adj_close/open/high/low/close/volume
+          - alpha158_fixture: 5 因子 × 50 天 × 2 tickers 的 MultiIndex DataFrame
+          - news_fixture: 20 条假新闻 (含 ticker 关联 + timestamp)
+          - embeddings_fixture: 假 embedding matrix (N, D)，D 参数化（e5-large-v2=1024, base=768）
+          - finbert_golden: 10 条已知情感的金融新闻（正向 4 / 负向 4 / 中性 2）
+          - tmp_artifact_dir: pytest tmp_path 隔离 data/models/
+
+        测试 (本 milestone 约 25 case, ~160 行):
+          - paths 路径格式
+          - model_io: save/load roundtrip；current symlink 覆盖；versions 排序；NotFoundError；损坏 pickle 拒绝
+          - 各 fixture shape / dtype / index 断言
+          - ALTER TABLE idempotency (重复 _do_initialize 不报错)
+          - 老库（无新列）打开后自动扩列，数据不丢
+
+        验收门槛：本 milestone 单独 pytest 通过；fixtures 在 m2-m5 中被复用无需修改。
+
+    - id: "m2a-finbert-scorer"
+      name: "FinBERT Scorer (纯推理 + 性能 gate)"
       status: pending
       completed_at: null
-    - id: "m2-Fin-E5-部署"
-      name: "Fin-E5 部署"
+      estimated_files:
+        - "src/stockbee/small_models/finbert_scorer.py"
+        - "src/stockbee/small_models/__init__.py"
+        - "tests/test_small_models_finbert_scorer.py"
+      estimated_lines: 450   # non-test ~200 (scorer) + tests ~250
+      depends_on: [m1-contracts-fixtures-io]
+      complexity_flags: [first_of_kind, external_model, performance_gate]
+      description: |
+        纯推理层：加载 ProsusAI/finbert，batch tokenize + forward，
+        <100ms 性能基准 hard gate（PRD §3.3 硬约束）。无 DB 副作用，无 g2 改动。
+
+        非测试代码 (~200 行):
+          - finbert_scorer.py：
+              class FinBERTScorer:
+                __init__(device: str | None = None, model_name: str = "ProsusAI/finbert")
+                  auto-detect cuda / cpu / mps；mock 友好（device="mock" 接口）
+                score_texts(texts: list[str], batch_size: int = 32) -> list[dict]
+                  返回 [{positive, negative, neutral, confidence}]
+                  三项 softmax + confidence = max(3)
+                  max_length=128 (Tech Design 约束)，truncation=True
+                __repr__, __len__
+              _SINGLETON: FinBERTScorer | None = None
+              def get_default_scorer() -> FinBERTScorer   # singleton lazy init, g2/m2b 共享
+              def reset_default_scorer() -> None          # test hook
+          - __init__.py 增量导出 FinBERTScorer + get_default_scorer
+
+        测试 (~250 行, 约 18 case):
+          - m1 golden 10 条 → argmax label 正确率 ≥ 8/10
+          - batch_size = 1 / 4 / 32 结果一致 (tol 1e-5)
+          - softmax 三项 sum ≈ 1.0, confidence = max
+          - 空列表 / 超长文本 (> 128 token) 截断不报错
+          - 全空白字符串 → neutral ≈ 1.0 或明确处理
+          - 性能 gate: batch=32, len=128, GPU <100ms / CPU <300ms (@pytest.mark.perf 隔离)
+          - CPU fallback (torch.cuda.is_available mock=False)
+          - get_default_scorer singleton（两次 get 返回同一实例）
+          - reset_default_scorer 清理
+          - HF 加载失败 → 明确错误信息（mock transformers raise）
+
+        验收：独立 pytest，性能 gate 在 @pytest.mark.perf 默认 skip，CI opt-in；功能 case 必过。
+
+    - id: "m2b-local-sentiment-provider"
+      name: "LocalSentimentProvider + g2 重构 + DB 回写"
       status: pending
       completed_at: null
-    - id: "m3-LightGBM-训练推理"
-      name: "LightGBM 训练+推理"
+      estimated_files:
+        - "src/stockbee/small_models/local_sentiment_provider.py"
+        - "src/stockbee/news_data/g2_classifier.py"           # P3 重构：复用 m2a scorer singleton
+        - "src/stockbee/news_data/news_store.py"              # 扩 insert/update 写新列
+        - "src/stockbee/small_models/__init__.py"
+        - "tests/test_small_models_sentiment_provider.py"
+      estimated_lines: 550   # non-test ~280 (provider 180 + g2 diff 50 + news_store diff 50) + tests ~270
+      depends_on: [m2a-finbert-scorer]
+      complexity_flags: [integration, refactor]
+      description: |
+        三件事：
+        (1) 实现 providers/interfaces.py:281 的 SentimentProvider
+        (2) P3 重构：g2_classifier 从私有 FinBERT 实例切到 m2a FinBERTScorer singleton
+            → 消除重复推理（同一条新闻不再跑两遍 ProsusAI/finbert）
+        (3) 扩 news_store insert/update 写 finbert_negative/neutral/confidence
+            （sentiment_score = positive 保持 g2 原语义，向后兼容）
+
+        非测试代码 (~280 行):
+          - local_sentiment_provider.py (~180 行):
+              class LocalSentimentProvider(BaseProvider, SentimentProvider):
+                __init__(scorer: FinBERTScorer | None = None, news_store: NewsStore | None = None)
+                  scorer 默认 = get_default_scorer() (m2a singleton)
+                score_texts(texts) -> list[dict]         # 透传 m2a scorer
+                get_ticker_sentiment(ticker, lookback_days=7) -> dict
+                  SELECT news_events JOIN news_tickers WHERE ticker, ts >= now - lookback
+                  加权公式：Σ(conf_i × prob_i) / Σ conf_i，conf = finbert_confidence
+                  返回 {positive, negative, neutral, confidence, count}
+                  无匹配 → 全 0 + count=0
+                backfill(since: date | None = None, limit: int = 1000) -> int
+                  查 WHERE finbert_confidence IS NULL [AND timestamp >= since] LIMIT
+                  批量 scorer.score_texts → 写 finbert_negative/neutral/confidence
+                  不覆盖 sentiment_score（g2 已写）
+                register_default()  # class method, 在 __init__.py 或显式触发注册到 PROVIDER_REGISTRY
+          - g2_classifier.py (~50 行 diff):
+              self._scorer = get_default_scorer()  # 替代原私有 pipeline
+              _classify_sentiment_batch 改调 self._scorer.score_texts
+              G2Result 新增可选 finbert_negative/finbert_neutral 字段
+              classify_batch 返回 3-way softmax，供 news_store 持久化
+              保留 use_finbert=False fallback 到规则引擎（接口无变化）
+          - news_store.py (~50 行 diff):
+              insert/update 接受 finbert_negative, finbert_neutral, finbert_confidence 参数
+              g2 sync 管道在 save_event / bulk_insert 时带入三值（None 兼容老代码路径）
+
+        测试 (~270 行, 约 22 case):
+          - score_texts 透传一致性（和 m2a 直接调用同结果）
+          - get_ticker_sentiment:
+              * 空结果 → zeros + count=0（不 raise）
+              * 加权均值公式断言（手算 golden）
+              * lookback_days 过滤
+              * 多 ticker 共享新闻
+              * NaN confidence 跳过
+          - backfill:
+              * 只更新 finbert_confidence IS NULL 的行
+              * 不覆盖 sentiment_score（g2 所写）
+              * since 过滤
+              * limit 分页
+              * 空 DB → 返回 0
+              * 1K rows chunked commit 不 OOM（performance smoke）
+          - g2 重构回归:
+              * 相同 headline 新旧路径 sentiment / score 一致 (tol 1e-4)
+              * use_finbert=False 规则降级仍工作
+              * classify_batch 写入 finbert_negative/neutral/confidence 到 DB
+              * g2 和 m2b 共享同一 FinBERTScorer 实例（get_default_scorer identity 断言）
+          - PROVIDER_REGISTRY 注册验证
+
+        验收：mock FinBERTScorer 避免测试加载 HF；real SQLite temp DB。
+
+    - id: "m3-lightgbm-trainer"
+      name: "LightGBM Trainer + label_utils"
       status: pending
       completed_at: null
-    - id: "m4-周度-refit-调度"
-      name: "周度 refit 调度"
+      estimated_files:
+        - "src/stockbee/small_models/label_utils.py"
+        - "src/stockbee/small_models/lightgbm_trainer.py"
+        - "src/stockbee/small_models/__init__.py"
+        - "tests/test_small_models_lightgbm_train.py"
+      estimated_lines: 560   # non-test ~280 (label 80 + trainer 200) + tests ~280
+      depends_on: [m1-contracts-fixtures-io]   # 用 m1 model_io.save_pickle
+      complexity_flags: [first_of_kind, ml_training]
+      description: |
+        训练路径：Alpha158 × 5日前瞻 return label (决策 B3) → LightGBM booster → pickle 落盘。
+        与 m2a/m2b/m5 可并行开发（只依赖 m1）。
+
+        非测试代码 (~280 行):
+          - label_utils.py (~80 行):
+              def forward_return_5d(prices_df: MultiIndex (date, ticker) x adj_close,
+                                    horizon: int = 5) -> Series
+                决策 B3: mean(daily_returns[t+1 .. t+horizon])
+                实现:
+                  daily_ret = prices.groupby(level="ticker").pct_change()
+                  fwd = daily_ret.groupby(level="ticker").shift(-1).rolling(horizon).mean().shift(-(horizon-1))
+                  （等价 [t+1, t+horizon] 5 天日收益率的均值）
+                尾部最后 horizon 天 NaN（预期行为，训练时 drop）
+                NaN 传播 / 停牌 / adj_close 缺失端到端处理
+          - lightgbm_trainer.py (~200 行):
+              def walk_forward_splits(dates, train_size=252, test_size=21, step=21) -> Iter[(train_idx, test_idx)]
+                严格无前看（train.max < test.min）
+              DEFAULT_PARAMS = {objective: regression, learning_rate: 0.05, ...}
+              def train_lightgbm(factor_df, label_sr, params=None, num_rounds=500, early_stop=50) -> lgb.Booster
+                seed 固定；valid set = last train_size*0.2
+              def train_and_save(factor_provider, market_data_provider,
+                                 tickers, start, end, version: str | None = None) -> Path
+                组装 Alpha158 + label（forward_return_5d）+ 训 + model_io.save_pickle
+                version 默认 = today().strftime("%Y%m%d")
+                训练完自动 update_symlink("lightgbm", version)
+              if __name__ == "__main__": argparse CLI
+
+        测试 (~280 行, 约 20 case):
+          - label_utils:
+              * 常数价 → label = 0
+              * 线性上升 → label > 0 monotonic
+              * 尾部 horizon 天 NaN 位置正确
+              * 停牌（中间 NaN 价）传播正确
+              * ticker 隔离（A 的尾部 NaN 不影响 B）
+              * B3 公式手算 golden
+          - walk_forward_splits:
+              * 无前看断言 (all train.max < test.min)
+              * step 滑动正确
+              * 最后一窗 fit 不出界
+              * train_size / test_size 边界
+          - train_lightgbm:
+              * 造假 factor + 线性 label (label = 0.5*f1 - 0.3*f2) → 训练后 IC > 0.5
+              * NaN row 自动 drop（不引入 bias）
+              * seed 固定 → 结果复现
+              * early stop 触发（noisy label）
+              * artifact pickle roundtrip (m1 model_io)
+              * update_symlink("lightgbm", version) 正确覆盖
+          - train_and_save E2E (m1 fixtures)
+
+        验收：独立 pytest，不依赖 m4。
+
+    - id: "m4-lightgbm-inference"
+      name: "LightGBM 推理 → ml_score precomputed + evaluate_ml_score"
       status: pending
       completed_at: null
-    - id: "m5-测试"
-      name: "测试"
+      estimated_files:
+        - "src/stockbee/small_models/lightgbm_scorer.py"
+        - "src/stockbee/small_models/__init__.py"
+        - "tests/test_small_models_lightgbm_infer.py"
+      estimated_lines: 470   # non-test ~200 (scorer 150 + evaluate 50) + tests ~270
+      depends_on: [m3-lightgbm-trainer]
+      complexity_flags: [integration, performance_gate]
+      description: |
+        推理路径：加载 current.pkl → 批预测 → 写 data/factors/ml_score.parquet。
+        依赖 LocalFactorProvider 的 precomputed 路由（已验证自动发现 parquet 文件，0 行 diff 到 factor-storage 代码）。
+        决策 D2：新增独立 evaluate_ml_score(shift=5)，不破坏已稳定的 get_ic_report。
+
+        非测试代码 (~200 行):
+          - lightgbm_scorer.py (~150 行):
+              class LightGBMScorer:
+                __init__(version: str = "current")  # m1 model_io.load_pickle("lightgbm", version)
+                predict(factor_df: MultiIndex x 158 cols) -> Series
+                  NaN row 自动 drop 或填充（按训练时策略）
+                predict_and_save(factor_provider, tickers, start, end) -> Path
+                  结果 MultiIndex (date, ticker) → ParquetFactorStore merge-write ml_score 分组
+                  落盘路径 = paths.ML_SCORE_PARQUET
+                <50ms hard gate (1000 rows × 158 cols)
+          - evaluate_ml_score (~50 行) in lightgbm_scorer.py 或同模块:
+              def evaluate_ml_score(
+                  factor_provider: FactorProvider,
+                  market_data_provider: MarketDataProvider,
+                  universe: list[str],
+                  start: date, end: date,
+                  shift: int = 5,
+                  window: int = 252
+              ) -> dict[str, float]:
+                # D2: 独立于 get_ic_report，直接调 ic_evaluator.compute(shift=5)
+                factor_df = factor_provider.get_factors(universe, ["ml_score"], start, end)
+                prices = market_data_provider.get_ohlcv(universe, start, end + shift*CALENDAR_MULTIPLIER)
+                return compute_ic(factor_df["ml_score"], prices["adj_close"], shift=shift, window=window)
+
+          显式交付（progress.yaml 原未列）:
+          - list_factors() 应返回包含 {"name": "ml_score", "type": "precomputed"}
+            （LocalFactorProvider 自动发现，m4 只做断言验证）
+
+        测试 (~270 行, 约 20 case):
+          - predict shape / MultiIndex (date, ticker) 保持
+          - <50ms gate (1000 × 158, GPU <50ms / CPU <150ms, @pytest.mark.perf)
+          - predict_and_save 幂等（同日重跑 merge-write 不爆）
+          - ParquetFactorStore 读写 round-trip
+          - 混合路由: FactorProvider.get_factors(["MA5", "ml_score", "RESI60"]) 列序正确，expression + precomputed 合并
+          - list_factors() 返回中包含 ml_score (type=precomputed) 断言
+          - evaluate_ml_score:
+              * 造假线性 factor → linear label → IC ≈ 1 (shift=5)
+              * shift=5 传递到 compute_ic 验证
+              * universe 为空 → raise 明确
+              * 日期范围外 → NaN 报告
+          - 空 factor df → raise
+          - artifact 不存在 → raise
+          - mock booster (np.array linear regression) 避免单测重训
+
+        验收：独立 pytest；性能 gate @pytest.mark.perf 隔离。
+
+    - id: "m5-fine5-embedding-infra"
+      name: "Fin-E5 Embedding + Rule Baseline Importance"
       status: pending
       completed_at: null
+      estimated_files:
+        - "src/stockbee/small_models/fine5_scorer.py"
+        - "src/stockbee/small_models/importance_baseline.py"
+        - "src/stockbee/small_models/__init__.py"
+        - "tests/test_small_models_fine5.py"
+      estimated_lines: 530   # non-test ~260 (scorer 180 + baseline 80) + tests ~270
+      depends_on: [m1-contracts-fixtures-io]   # 用 m1 model_io（若后续缓存 embedding）
+      complexity_flags: [scope_downgrade, external_model]
+      description: |
+        Fin-E5 降级 scope（见 spec.md 决策）：
+          - 纯 embedding infra (加载 + batch encode + cosine 相似度 + 去重)
+          - importance_score 用 rule baseline：count × |sentiment - 0.5| × reliability
+          - 精确 importance fine-tune 推迟至 04-alpha-mining
+        与 m2a/m3 可并行。
+
+        非测试代码 (~260 行):
+          - fine5_scorer.py (~180 行):
+              class FinE5Scorer:
+                __init__(device: str | None = None, model_name: str = "intfloat/e5-large-v2")
+                  HF 无 canonical fin-e5，用 e5-large-v2 fallback（spec.md 锁定）
+                  embedding_dim 参数化（通过 model.config.hidden_size 动态取，避免硬编码 1024）
+                encode(texts: list[str], batch_size: int = 16, max_length: int = 512) -> np.ndarray
+                cosine_sim(a: np.ndarray, b: np.ndarray | None = None) -> np.ndarray
+                  b=None 时返回对称矩阵
+                cosine_dedup(embeds: np.ndarray, threshold: float = 0.95) -> list[int]
+                  union-find 聚类；对称但非传递相似度下的行为：
+                  决策 → "同一 cluster" 语义 = 传递闭包（A~B, B~C, A 与 C 无视直接距离都归一组）
+                  spec.md 显式锁定该语义
+          - importance_baseline.py (~80 行):
+              def baseline_importance(news_df: DataFrame) -> Series
+                要求列：count_30d, sentiment_score (FinBERT positive), reliability_score
+                公式: min(count_30d/10, 1.0) × |sentiment_score - 0.5| × 2 × clip(reliability_score, 0, 1)
+                值域 [0, 1]
+              def backfill_importance(news_store: NewsStore, batch: int = 1000) -> int
+                读需要列 → 计算 baseline → 回写 fine5_importance（不覆盖已有非空值）
+
+        测试 (~270 行, 约 19 case):
+          - encode shape (N, hidden_size)（参数化 fixture：hidden_size 从 scorer 读）
+          - batch 一致性（batch=1 vs batch=16 tol 1e-5）
+          - 对称 cosine_sim 矩阵 diag ≈ 1，对称
+          - cosine_dedup:
+              * 2 条近似文本 → 同 cluster
+              * 无关文本 → 不同 cluster
+              * 传递闭包语义断言（A-B 相似，B-C 相似，A-C 不直接相似 → 三者同组）
+              * 空输入
+          - baseline_importance:
+              * 值域 [0, 1]
+              * 高 count + 极端 sentiment + 高 reliability → 接近 1
+              * 低 count OR 中性 sentiment → 接近 0
+              * 手算 golden
+          - backfill:
+              * 只写 NULL 行
+              * 批次分页
+              * 空 DB
+          - mock model 加载（torch.nn.Linear dummy 避免下 HF ~400MB）
+
+        验收：独立 pytest；importance 弱 baseline 不设硬门槛。
+
+    - id: "m6-integration-tests"
+      name: "跨模块集成测试"
+      status: pending
+      completed_at: null
+      estimated_files:
+        - "tests/test_small_models_integration.py"
+      estimated_lines: 520   # 纯集成测试，非测试代码 = 0
+      depends_on: [m2b-local-sentiment-provider, m4-lightgbm-inference, m5-fine5-embedding-infra]
+      complexity_flags: [cross_module_integration]
+      description: |
+        参考 04-factor-storage m7 模式（18 cases, 512 行）。
+        单元测试已覆盖单模块正确性；本 milestone 只做组合/边界/冲突验证。
+
+        集成测试分组（7 组约 16-18 case）：
+          A. Contracts + artifact 流转 (2):
+            - model_io 在 m2a / m3 / m4 / m5 间共享 (并发读/写 current symlink)
+            - artifact 版本 list → 跨模型列出（finbert / lightgbm / fine5）
+
+          B. FinBERT 端到端 (3):
+            - news → g2_classifier (复用 m2a singleton) → DB (finbert_negative/neutral/confidence) → LocalSentimentProvider.backfill（空操作，因 g2 已写）
+            - LocalSentimentProvider.get_ticker_sentiment 加权公式手算一致
+            - g2 和 m2b 共享 FinBERTScorer 同一实例（identity 断言）
+
+          C. LightGBM 端到端 (3):
+            - Alpha158 → train_lightgbm → artifact → LightGBMScorer → ml_score.parquet
+            - FactorProvider.get_factors(["ml_score"]) 读取通
+            - 混合请求 get_factors(["MA5", "ml_score", "RESI60"]) 列序 + 路由正确
+            - LocalFactorProvider.list_factors() 含 ml_score (type=precomputed)
+
+          D. evaluate_ml_score wire (2):
+            - oracle 因子验证无前看泄漏 (ml_score = fwd_ret_5d shift-6 → IC ≈ 1)
+            - shift=5 传递断言（vs get_ic_report 的硬编码 shift=1 不冲突）
+
+          E. 列冲突并存策略 (2):
+            - sentiment_score (= finbert positive, g2 写) + finbert_negative/neutral/confidence (g2 写) 一致
+            - fine5_importance 与 g2 写的 importance_score 并存、可独立查询
+            - 重构前后旧数据：老新闻只有 sentiment_score，无 finbert_negative → backfill 补齐
+
+          F. 性能回归 (2, @pytest.mark.perf 隔离，默认 CI skip):
+            - FinBERT 批推理 32 条，P95 延迟 < tolerance（GPU 100ms / CPU 300ms）
+            - LightGBM 推理 1000 条，P95 < tolerance（GPU 50ms / CPU 150ms）
+            - 3 次 warm-up + 10 次采样中位数（避免冷启动噪声）
+
+          G. Edge cases (3):
+            - universe 尾部 5 天 label 缺失 → train 不爆（自动 drop）
+            - FinBERT GPU OOM → CPU fallback 路径 invoked (仅断言 fallback_invoked=True；不验证 CPU 推理正确性等价，因 mock 不可信)
+            - 空新闻 DB → backfill 返回 0，不 raise
+            - LocalSentimentProvider.backfill 在 100K news 下 chunked commit 不 OOM（performance smoke）
+
+        验收：所有 case pass + 全量回归 (m1-m6 + factor-storage 基线 665) 全绿。
+
   commits: []

--- a/meta/00-project-room/03-model-system/02-small-models/progress.yaml
+++ b/meta/00-project-room/03-model-system/02-small-models/progress.yaml
@@ -1,5 +1,5 @@
 progress:
-  completion: 0.143  # 1/7 milestones
+  completion: 0.286  # 2/7 milestones
   # 7 milestones，参考 04-factor-storage 的 8-milestone 分法（m1a/m1b 拆、m7 集成测试独立）
   # 设计原则：
   #   - 每个 milestone 自带单元测试，可独立验收，不依赖下一个 milestone
@@ -78,8 +78,8 @@ progress:
 
     - id: "m2a-finbert-scorer"
       name: "FinBERT Scorer (纯推理 + 性能 gate)"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-20"
       estimated_files:
         - "src/stockbee/small_models/finbert_scorer.py"
         - "src/stockbee/small_models/__init__.py"
@@ -430,4 +430,10 @@ progress:
 
         验收：所有 case pass + 全量回归 (m1-m6 + factor-storage 基线 665) 全绿。
 
-  commits: []
+  commits:
+    - hash: "83ed83d"
+      date: "2026-04-20"
+      message: "[02-small-models] feat: m2a FinBERTScorer (纯推理 + mock + singleton)"
+      files_changed: 5
+      milestones_affected:
+        - "m2a-finbert-scorer (→ completed)"

--- a/meta/00-project-room/03-model-system/02-small-models/progress.yaml
+++ b/meta/00-project-room/03-model-system/02-small-models/progress.yaml
@@ -1,5 +1,5 @@
 progress:
-  completion: 0.571  # 4/7 milestones
+  completion: 0.714  # 5/7 milestones
   # 7 milestones，参考 04-factor-storage 的 8-milestone 分法（m1a/m1b 拆、m7 集成测试独立）
   # 设计原则：
   #   - 每个 milestone 自带单元测试，可独立验收，不依赖下一个 milestone
@@ -122,8 +122,8 @@ progress:
 
     - id: "m2b-local-sentiment-provider"
       name: "LocalSentimentProvider + g2 重构 + DB 回写"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-20"
       estimated_files:
         - "src/stockbee/small_models/local_sentiment_provider.py"
         - "src/stockbee/news_data/g2_classifier.py"           # P3 重构：复用 m2a scorer singleton
@@ -443,9 +443,15 @@ progress:
       files_changed: 6
       milestones_affected:
         - "m3-lightgbm-trainer (→ completed)"
-    - hash: "4fd670f"
+    - hash: "c2c96f4"
       date: "2026-04-20"
       message: "[02-small-models] feat: m5 Fin-E5 embedding + baseline importance"
       files_changed: 5
       milestones_affected:
         - "m5-fine5-embedding-infra (→ completed)"
+    - hash: "8b63beb"
+      date: "2026-04-20"
+      message: "[02-small-models] feat: m2b LocalSentimentProvider + g2 P3 refactor"
+      files_changed: 8
+      milestones_affected:
+        - "m2b-local-sentiment-provider (→ completed)"

--- a/meta/00-project-room/03-model-system/02-small-models/progress.yaml
+++ b/meta/00-project-room/03-model-system/02-small-models/progress.yaml
@@ -1,5 +1,5 @@
 progress:
-  completion: 0.857  # 6/7 milestones
+  completion: 1.000  # 7/7 milestones 全部完成
   # 7 milestones，参考 04-factor-storage 的 8-milestone 分法（m1a/m1b 拆、m7 集成测试独立）
   # 设计原则：
   #   - 每个 milestone 自带单元测试，可独立验收，不依赖下一个 milestone
@@ -381,8 +381,8 @@ progress:
 
     - id: "m6-integration-tests"
       name: "跨模块集成测试"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-20"
       estimated_files:
         - "tests/test_small_models_integration.py"
       estimated_lines: 520   # 纯集成测试，非测试代码 = 0
@@ -461,3 +461,9 @@ progress:
       files_changed: 4
       milestones_affected:
         - "m4-lightgbm-inference (→ completed)"
+    - hash: "b89fd05"
+      date: "2026-04-20"
+      message: "[02-small-models] test: m6 跨模块集成测试 (room 完成 7/7)"
+      files_changed: 2
+      milestones_affected:
+        - "m6-integration-tests (→ completed)"

--- a/meta/00-project-room/03-model-system/02-small-models/progress.yaml
+++ b/meta/00-project-room/03-model-system/02-small-models/progress.yaml
@@ -467,3 +467,10 @@ progress:
       files_changed: 2
       milestones_affected:
         - "m6-integration-tests (→ completed)"
+    - hash: "92b9f55"
+      date: "2026-04-20"
+      message: "[02-small-models] fix: PR #33 review 三处修复"
+      files_changed: 3
+      specs_affected:
+        - "change-2026-04-20-pr33-review-fixes (created)"
+      milestones_affected: []   # post-completion fix,不动 milestone 状态

--- a/meta/00-project-room/03-model-system/02-small-models/progress.yaml
+++ b/meta/00-project-room/03-model-system/02-small-models/progress.yaml
@@ -1,5 +1,5 @@
 progress:
-  completion: 0.286  # 2/7 milestones
+  completion: 0.429  # 3/7 milestones
   # 7 milestones，参考 04-factor-storage 的 8-milestone 分法（m1a/m1b 拆、m7 集成测试独立）
   # 设计原则：
   #   - 每个 milestone 自带单元测试，可独立验收，不依赖下一个 milestone
@@ -193,8 +193,8 @@ progress:
 
     - id: "m3-lightgbm-trainer"
       name: "LightGBM Trainer + label_utils"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-20"
       estimated_files:
         - "src/stockbee/small_models/label_utils.py"
         - "src/stockbee/small_models/lightgbm_trainer.py"
@@ -437,3 +437,9 @@ progress:
       files_changed: 5
       milestones_affected:
         - "m2a-finbert-scorer (→ completed)"
+    - hash: "780ea5a"
+      date: "2026-04-20"
+      message: "[02-small-models] feat: m3 LightGBM trainer + B3 label + walk-forward"
+      files_changed: 6
+      milestones_affected:
+        - "m3-lightgbm-trainer (→ completed)"

--- a/meta/00-project-room/03-model-system/02-small-models/progress.yaml
+++ b/meta/00-project-room/03-model-system/02-small-models/progress.yaml
@@ -1,5 +1,5 @@
 progress:
-  completion: 0.429  # 3/7 milestones
+  completion: 0.571  # 4/7 milestones
   # 7 milestones，参考 04-factor-storage 的 8-milestone 分法（m1a/m1b 拆、m7 集成测试独立）
   # 设计原则：
   #   - 每个 milestone 自带单元测试，可独立验收，不依赖下一个 milestone
@@ -319,8 +319,8 @@ progress:
 
     - id: "m5-fine5-embedding-infra"
       name: "Fin-E5 Embedding + Rule Baseline Importance"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-20"
       estimated_files:
         - "src/stockbee/small_models/fine5_scorer.py"
         - "src/stockbee/small_models/importance_baseline.py"
@@ -431,15 +431,21 @@ progress:
         验收：所有 case pass + 全量回归 (m1-m6 + factor-storage 基线 665) 全绿。
 
   commits:
-    - hash: "83ed83d"
+    - hash: "7d506ac"
       date: "2026-04-20"
       message: "[02-small-models] feat: m2a FinBERTScorer (纯推理 + mock + singleton)"
       files_changed: 5
       milestones_affected:
         - "m2a-finbert-scorer (→ completed)"
-    - hash: "780ea5a"
+    - hash: "894a1c9"
       date: "2026-04-20"
       message: "[02-small-models] feat: m3 LightGBM trainer + B3 label + walk-forward"
       files_changed: 6
       milestones_affected:
         - "m3-lightgbm-trainer (→ completed)"
+    - hash: "4fd670f"
+      date: "2026-04-20"
+      message: "[02-small-models] feat: m5 Fin-E5 embedding + baseline importance"
+      files_changed: 5
+      milestones_affected:
+        - "m5-fine5-embedding-infra (→ completed)"

--- a/meta/00-project-room/03-model-system/02-small-models/progress.yaml
+++ b/meta/00-project-room/03-model-system/02-small-models/progress.yaml
@@ -1,5 +1,5 @@
 progress:
-  completion: 0.714  # 5/7 milestones
+  completion: 0.857  # 6/7 milestones
   # 7 milestones，参考 04-factor-storage 的 8-milestone 分法（m1a/m1b 拆、m7 集成测试独立）
   # 设计原则：
   #   - 每个 milestone 自带单元测试，可独立验收，不依赖下一个 milestone
@@ -257,8 +257,8 @@ progress:
 
     - id: "m4-lightgbm-inference"
       name: "LightGBM 推理 → ml_score precomputed + evaluate_ml_score"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-20"
       estimated_files:
         - "src/stockbee/small_models/lightgbm_scorer.py"
         - "src/stockbee/small_models/__init__.py"
@@ -455,3 +455,9 @@ progress:
       files_changed: 8
       milestones_affected:
         - "m2b-local-sentiment-provider (→ completed)"
+    - hash: "a5ba4d6"
+      date: "2026-04-20"
+      message: "[02-small-models] feat: m4 LightGBM inference + ml_score + evaluate_ml_score"
+      files_changed: 4
+      milestones_affected:
+        - "m4-lightgbm-inference (→ completed)"

--- a/meta/00-project-room/03-model-system/02-small-models/room.yaml
+++ b/meta/00-project-room/03-model-system/02-small-models/room.yaml
@@ -7,9 +7,12 @@ room:
   priority: P0
   phase: "1"
   created_at: "2026-03-24"
-  updated_at: "2026-03-24"
+  updated_at: "2026-04-13"
   prompt_test:
     passable: false
     last_tested: null
     token_count: null
-  depends_on: ['02-data-architecture/04-factor-storage']
+  depends_on:
+    - '02-data-architecture/01-stock-data'    # OHLCV 供 LightGBM label (5日前瞻 return)
+    - '02-data-architecture/02-news-data'     # 新闻文本 + news_events 表 (FinBERT/Fin-E5 输入 + 回写)
+    - '02-data-architecture/04-factor-storage' # Alpha158 因子 (LightGBM 输入) + FactorProvider precomputed 路由 (ml_score 落盘)

--- a/meta/00-project-room/03-model-system/02-small-models/room.yaml
+++ b/meta/00-project-room/03-model-system/02-small-models/room.yaml
@@ -3,11 +3,12 @@ room:
   name: "小模型体系"
   parent: "03-model-system"
   type: feature
-  lifecycle: planning
+  lifecycle: completed
   priority: P0
   phase: "1"
   created_at: "2026-03-24"
-  updated_at: "2026-04-13"
+  updated_at: "2026-04-20"
+  completed_at: "2026-04-20"
   prompt_test:
     passable: false
     last_tested: null

--- a/meta/00-project-room/03-model-system/02-small-models/spec.md
+++ b/meta/00-project-room/03-model-system/02-small-models/spec.md
@@ -4,23 +4,154 @@
 
 **FinBERT 情绪 + Fin-E5 重要性 + LightGBM 收益预测**
 
-所有模型本地部署，GPU 加速推理。FinBERT <100ms，LightGBM <50ms。每周 refit 适应市场变化。
+所有模型本地部署，GPU 加速推理（CPU fallback 必须可跑通测试）。
+FinBERT <100ms / LightGBM <50ms 为 PRD 硬约束。
 
-来源：Tech Design §3.3
+来源：PRD §3.3, Tech Design §3.3
 研究状态：研究完成 (新闻小模型.md, 量化小模型.md)
+
+**Scope 决策（见 Decisions）**：本 room 只做推理 + 预训练集成，不做 fine-tune / 周度 refit / XGBoost 因子融合。
+**架构决策（见 Decisions）**：P3 复用 FinBERTScorer singleton（消除 g2 重复推理）；D2 独立 evaluate_ml_score（不破坏 factor-storage 已稳定的 get_ic_report）。
 
 ## Constraints
 
-- **FinBERT 情绪准确率 > 80%** — 来源: PRD §3.3
+- **FinBERT 情绪准确率 > 80%** — 来源: PRD §3.3（预训练 ProsusAI/finbert 基线 ~87%）
 - **LightGBM 预测 IC > 0.03** — 来源: PRD §3.3
+- **FinBERT 推理 < 100ms**（batch=32, len=128）— 来源: Tech Design §3.3
+- **LightGBM 推理 < 50ms**（1000 rows × 158 cols）— 来源: Tech Design §3.3
 
 ## Decisions
 
-_暂无决策记录_
+| 决策 | 结论 | 日期 |
+|------|------|------|
+| **A1→P3** FinBERT 部署策略 | g2_classifier 从私有 FinBERT 实例重构为复用 m2a `FinBERTScorer` singleton（消除重复推理）。新列 `finbert_negative` / `finbert_neutral` / `finbert_confidence` 由 g2 写；`sentiment_score` 保留 = FinBERT positive softmax（g2 原语义）| 2026-04-13 |
+| **B3** LightGBM label 公式 | `mean(next_5_days_daily_returns)`，基于 `adj_close` 日收益率均值（贴 PRD 原文"未来 5 日平均收益率"）| 2026-04-13 |
+| **D2** m4 IC 评估策略 | 新增独立函数 `evaluate_ml_score(shift=5)`，**不修改** `LocalFactorProvider.get_ic_report`（后者 factor-storage 已 freeze，`_IC_SHIFT=1` 硬编码不动）| 2026-04-13 |
+| model_io 归属 | m1 交付，供 m2a / m3 / m4 / m5 共用；不放 m2a（否则违反并行开发拓扑）| 2026-04-13 |
+| Fin-E5 scope | 降级为 embedding infra + cosine 去重 + rule baseline importance；精准 importance fine-tune 推迟到 `04-alpha-mining` | 2026-04-13 |
+| Fin-E5 fallback 模型 | `intfloat/e5-large-v2`（HF 无 canonical `fin-e5`）| 2026-04-13 |
+| Fin-E5 embedding dim 参数化 | 从 `scorer.model.config.hidden_size` 动态取（e5-large-v2=1024, base=768），**不硬编码**；测试 fixture 参数化 | 2026-04-13 |
+| cosine_dedup 语义 | union-find 传递闭包（A~B, B~C → A/B/C 同 cluster，即使 A-C 直接距离超过 threshold）| 2026-04-13 |
+| XGBoost 因子融合 | 推迟到 `04-alpha-mining`，本 room 不做 | 2026-04-13 |
+| 周度 refit | 推迟到 Phase 2；本 room 不做 CLI / APScheduler 调度 | 2026-04-13 |
+| FinBERT/Fin-E5 fine-tune | 推迟到 Phase 2；本 room 仅加载预训练权重 | 2026-04-13 |
+| 模型 artifact 路径 | `data/models/{name}/{YYYYMMDD}.pkl` + `data/models/{name}/current.pkl` (POSIX symlink，Windows fallback = copy) | 2026-04-13 |
+| ml_score 落盘 | 单 Parquet 文件 `data/factors/ml_score.parquet`（group 名 = `ml_score`，走 ParquetFactorStore merge-write）| 2026-04-13 |
+| ml_score 自动发现 | `LocalFactorProvider._build_precomputed_index` 已泛化读 parquet schema（line 324-358），**无需白名单注册**；m4 非测试代码对 factor-storage 零改动 | 2026-04-13 |
+| `list_factors()` 对 `ml_score` 交付 | m4 显式断言 `list_factors()` 返回中包含 `{name: "ml_score", type: "precomputed"}` | 2026-04-13 |
+| 预训练模型版本 | FinBERT: `ProsusAI/finbert`；Fin-E5: `intfloat/e5-large-v2` | 2026-04-13 |
+| GPU 可选 | `torch.cuda.is_available()` 自动选择；CPU fallback 必须可跑测试（CI 环境无 GPU） | 2026-04-13 |
+| 性能基准 tolerance | FinBERT: GPU <100ms / CPU <300ms；LightGBM: GPU <50ms / CPU <150ms | 2026-04-13 |
+| 性能测试隔离 | `@pytest.mark.perf` marker，默认 CI skip；本地/夜间手动跑；采样 3 warm-up + 10 中位数 | 2026-04-13 |
+| GPU OOM fallback 测试策略 | 仅断言 fallback path invoked；**不验证** CPU 推理等价性（mock `torch.cuda.OutOfMemoryError` 不可信）| 2026-04-13 |
+| SentimentProvider 归属 | `LocalSentimentProvider` 放 `small_models/`（与 scorer 共位，不放 `news_data/`）| 2026-04-13 |
+| Fin-E5 无 Provider | Fin-E5 不建 Provider 接口，作 `small_models/` 内部模块，下游直接 import | 2026-04-13 |
+| `get_ticker_sentiment` 加权公式 | `Σ(conf_i × prob_i) / Σ conf_i`，权重 = `finbert_confidence`（max softmax）；Σconf=0 → 返回 zeros + count=0 | 2026-04-13 |
+| `__init__.py` 增量导出约定 | 每个 milestone 向 `src/stockbee/small_models/__init__.py` 增量 re-export 本 milestone 对外符号（参考 factor-storage）| 2026-04-13 |
+| Provider Registry 注册位置 | m2b 交付时由 `LocalSentimentProvider.register_default()` 注册到 `PROVIDER_REGISTRY`（触发点在 `__init__.py` 或显式 setup）| 2026-04-13 |
+| 测试 mock 策略 | 单元测试 mock HF 模型加载（避免每次 pytest 下 ~500MB 权重）；只在本地手动验收 + m6 F 组性能测试加载真实权重 | 2026-04-13 |
+| Milestone 方案 | 7 milestones（m1 含 model_io、m2a/m2b FinBERT 分层、m3/m4 训推分拆、m5 Fin-E5、m6 集成测试）；经两轮 plan-eng subagent review 定稿 | 2026-04-13 |
+| **OQ1** `save_pickle` 同版本重复写入 | 默认 raise `FileExistsError`，参数 `overwrite: bool = False` 显式允许覆盖 | 2026-04-13 |
+| **OQ2** fixtures 导入方式 | `tests/small_models/conftest.py`（pytest 自动发现子目录 conftest），m2-m6 测试文件落在 `tests/small_models/` 下零样板。progress.yaml 原 `tests/conftest_small_models.py` 同步调整 | 2026-04-13 |
+| **OQ3** `update_symlink` Windows fallback | 写 `data/models/{name}/current.txt` 明文记录版本号；`load_pickle("current")` 先查 symlink，若缺再读 `current.txt` → 版本文件。POSIX 下 symlink 为准，切换版本时清理旧 `current.txt` | 2026-04-13 |
+| **OQ4** `save_pickle` 是否自动 update_symlink | **否**。训练完显式 `update_symlink(name, version)`，保留"先保存再评审再上线"流程 | 2026-04-13 |
 
 ## Contracts
 
-_暂无接口约定_
+### SentimentProvider 实现 (`providers/interfaces.py:281`)
+- `LocalSentimentProvider.score_texts(texts) → list[dict]`
+  - 返回 `[{"positive", "negative", "neutral", "confidence"}]`
+  - 三项 softmax，sum ≈ 1；confidence = max(三项)
+- `LocalSentimentProvider.get_ticker_sentiment(ticker, lookback_days=7) → dict`
+  - JOIN `news_events` × `news_tickers`，窗口 = `[now - lookback_days, now]`
+  - 权重 = `finbert_confidence`；公式 `Σ(conf × prob) / Σconf`
+  - 返回 `{"positive", "negative", "neutral", "confidence", "count"}`
+  - 无匹配 / Σconf=0 → 全 0 + count=0（不 raise）
+- `LocalSentimentProvider.backfill(since: date | None = None, limit: int = 1000) → int`
+  - 只更新 `finbert_confidence IS NULL` 的行
+  - 写 `finbert_negative` / `finbert_neutral` / `finbert_confidence`；**不触** `sentiment_score`
+- `LocalSentimentProvider.register_default()` → 注册到 `PROVIDER_REGISTRY`
+
+### FactorProvider 扩展：`ml_score` 作 precomputed factor
+- 请求：`FactorProvider.get_factors(tickers, ["ml_score"], start, end)` → MultiIndex (date, ticker) × [ml_score]
+- 落盘：`data/factors/ml_score.parquet`，主键 `(date, ticker)`，merge-write 幂等
+- 混合：`get_factors(tickers, ["MA5", "ml_score", "RESI60"])` 由 `LocalFactorProvider` 路由，expression + precomputed 合并，列序按请求保留
+- `list_factors()` 返回中包含 `{"name": "ml_score", "type": "precomputed"}`（m4 断言交付）
+- **自动发现**：`LocalFactorProvider._build_precomputed_index` 已泛化，m4 对 factor-storage 代码零改动
+
+### 独立 IC 评估 (D2)
+```python
+def evaluate_ml_score(
+    factor_provider, market_data_provider,
+    universe, start, end,
+    shift: int = 5, window: int = 252,
+) -> dict[str, float]:
+    """m4 独立交付，不改 get_ic_report。
+    走 ic_evaluator.compute(ml_score, prices, shift=5, window=window)
+    返回 {ic_mean, ic_std, icir}
+    """
+```
+
+### LightGBM Label 公式（B3）
+```python
+daily_ret = adj_close.groupby(level="ticker").pct_change()
+label = (
+    daily_ret.groupby(level="ticker")
+    .shift(-1)
+    .rolling(5).mean()
+    .shift(-(5 - 1))
+)
+# 等价：取 [t+1, t+5] 五天日收益率的均值
+# 尾部最后 5 天 NaN，训练时 drop
+```
+
+### FinBERT Scorer (m2a)
+- `FinBERTScorer(device=None, model_name="ProsusAI/finbert")`
+- `FinBERTScorer.score_texts(texts, batch_size=32) → list[dict]`
+- max_length=128, truncation=True
+- 输出 key：`positive`, `negative`, `neutral`, `confidence`（= max 三项）
+- `get_default_scorer()` → singleton，供 g2 + m2b 共享
+
+### Fin-E5 Scorer (m5)
+- `FinE5Scorer(device=None, model_name="intfloat/e5-large-v2")`
+- `encode(texts, batch_size=16, max_length=512) → np.ndarray (N, hidden_size)`
+- `cosine_sim(a, b=None) → np.ndarray`
+- `cosine_dedup(embeds, threshold=0.95) → list[int]`（union-find，传递闭包）
+
+### Importance Baseline (m5)
+- `baseline_importance(news_df) → Series`，值域 `[0, 1]`
+- 公式：`min(count_30d/10, 1.0) × |sentiment_score - 0.5| × 2 × clip(reliability_score, 0, 1)`
+- 写列：`fine5_importance`（保留 g2 写的 `importance_score` 并存）
+
+### Model Artifact IO (m1)
+- `artifact_path(name, version="current") → Path`
+- `save_pickle(obj, name, version=None) → Path`（version 默认 = today）
+- `load_pickle(name, version="current") → object`
+- `update_symlink(name, version) → None`
+- `list_versions(name) → list[str]`（descending date）
+
+### SQLite Schema 扩展（m1 交付）
+```sql
+-- 老库自动升级：_do_initialize 用 PRAGMA table_info 探测 + 条件 ALTER
+ALTER TABLE news_events ADD COLUMN finbert_negative REAL;
+ALTER TABLE news_events ADD COLUMN finbert_neutral REAL;
+ALTER TABLE news_events ADD COLUMN finbert_confidence REAL;
+ALTER TABLE news_events ADD COLUMN fine5_importance REAL;
+-- sentiment_score 保留 = FinBERT positive softmax (g2 已写)
+-- importance_score 保留 = g2 规则评分（与 fine5_importance 并存，下游自选）
+```
+
+### 依赖拓扑
+```
+m1 (contracts + fixtures + model_io + schema migration)
+ ├─→ m2a (FinBERT scorer + <100ms gate) ──→ m2b (Provider + g2 refactor + DB 回写)
+ ├─→ m3 (label_utils + LightGBM trainer) ────→ m4 (推理 + ml_score + evaluate_ml_score)
+ └─→ m5 (Fin-E5 + baseline importance)
+       ↓ (m2b / m4 / m5 全完成后)
+      m6 (跨模块集成测试 + 性能回归)
+```
+
+m2a / m3 / m5 在 m1 完成后可**并行**开发。
 
 ---
 _所有 spec 状态: draft（需要 review 后升为 active）_

--- a/meta/00-project-room/03-model-system/02-small-models/spec.md
+++ b/meta/00-project-room/03-model-system/02-small-models/spec.md
@@ -154,5 +154,5 @@ m1 (contracts + fixtures + model_io + schema migration)
 m2a / m3 / m5 在 m1 完成后可**并行**开发。
 
 ---
-_所有 spec 状态: draft（需要 review 后升为 active）_
+_所有 spec 状态: active (room 完成后升级, 2026-04-20)_
 _spec.md 由 room-init 自动生成，specs/*.yaml 为源数据_

--- a/meta/00-project-room/03-model-system/02-small-models/specs/change-2026-04-13-small-models-plan.yaml
+++ b/meta/00-project-room/03-model-system/02-small-models/specs/change-2026-04-13-small-models-plan.yaml
@@ -1,0 +1,118 @@
+spec_id: "change-2026-04-13-small-models-plan"
+type: change
+state: active
+intent:
+  summary: "02-small-models milestone 首次规划：7 milestone，契约提前锁定 + 训推分拆 + 独立 unit test + 末段集成测试（经两轮 plan-eng review 定稿）"
+  detail: |
+    为 02-small-models Room 完成首次 milestone 拆分与跨模块契约锁定。
+    计划经两轮独立 plan-eng subagent review 迭代定稿。
+
+    === 7 个 milestones（参考 04-factor-storage 的 8-milestone 模式）===
+
+    - m1-contracts-fixtures-io: Contract 锁定 + shared fixtures + model_io + SQLite 扩列 (non-test ~140)
+    - m2a-finbert-scorer: FinBERT 纯推理 + <100ms 性能 gate (non-test ~200)
+    - m2b-local-sentiment-provider: 实现 SentimentProvider + P3 g2 重构 + DB 回写 (non-test ~280)
+    - m3-lightgbm-trainer: label_utils (B3) + walk-forward 训练 CLI (non-test ~280)
+    - m4-lightgbm-inference: 批推理 → ml_score Parquet + 独立 evaluate_ml_score (D2) (non-test ~200)
+    - m5-fine5-embedding-infra: Fin-E5 embedding + cosine 去重 + rule baseline importance (non-test ~260)
+    - m6-integration-tests: 7 组 16-18 跨模块 case (纯测试 ~520)
+
+    === 设计原则 ===
+      - 每个 milestone 非测试代码目标 ~250 行（m2b/m3/m5 略超至 260-280，权衡分拆成本）
+      - 每个 milestone 自带单元测试，独立可验收
+      - 末段 m6 做跨模块集成测试（参考 factor-storage m7 模式，18 cases 512 行）
+      - 拓扑：m1 → {m2a→m2b, m3→m4, m5} 可并行 → m6
+
+    === 关键决策 ===
+
+    **A1→P3 (FinBERT 部署策略)**：
+      发现 g2_classifier 已在用 ProsusAI/finbert（第二轮 review blocker）。
+      A1 "新列并存 + g2 保留" 会导致同一条新闻跑两遍 FinBERT。
+      最终 P3：g2 重构为复用 m2a FinBERTScorer singleton (get_default_scorer)；
+      新列 `finbert_negative / finbert_neutral / finbert_confidence` 由 g2 写；
+      `sentiment_score` 保留 = FinBERT positive softmax (g2 原语义)。
+
+    **B3 (LightGBM label 公式)**：
+      `mean(next_5_days_daily_returns)` 基于 adj_close。
+      原因：贴 PRD §3.3 原文"未来 5 日平均收益率"；均值比端点 return 噪声小。
+
+    **D2 (m4 IC 评估策略)**：
+      第二轮 review 发现 `LocalFactorProvider.get_ic_report` 硬编码 `_IC_SHIFT=1`（line 32）。
+      C1 原方案"重用 get_ic_report 传 shift=5"不可行。
+      最终 D2：m4 新增独立 `evaluate_ml_score(shift=5)`，直接调 `ic_evaluator.compute(shift=5)`，
+      不修改 factor-storage 已 freeze 的 `get_ic_report`（避免破坏回归测试）。
+
+    **Model IO 归属**：
+      第二轮 review 发现 m2a 吞 model_io 导致 m3/m4/m5 反向依赖 m2a，违反并行声明。
+      最终：model_io 上移到 m1，作为跨模块基础设施。
+
+    === Scope 推迟（防 scope creep）===
+      - XGBoost 因子融合 → 04-alpha-mining
+      - 周度 refit CLI / APScheduler → Phase 2
+      - FinBERT / Fin-E5 fine-tune → Phase 2（只用预训练，ProsusAI/finbert ≥85% 已过 PRD 80% gate）
+      - Fin-E5 精准 importance → 04-alpha-mining（本 room 用 rule baseline 占位）
+
+    === 估算修正历程 ===
+      - v1 (6 milestone, 2200 行): 第一轮 review 判定 SPLIT+REWORK
+      - v2 (7 milestone, ~3100 行): 第二轮 review 判定 CONDITIONAL GO
+      - v3 (最终，7 milestone, ~3380 行):
+          m1: 180 → 300 行（加 model_io + 4 列 schema ALTER）
+          m2a: 550 → 450 行（移除 model_io）
+          m2b: 380 → 550 行（吸收 P3 g2 重构 + news_store 扩写）
+          m3: 560 (不变)
+          m4: 450 → 470 行（加 evaluate_ml_score）
+          m5: 530 (不变)
+          m6: 450 → 520 行（对齐 factor-storage m7 的 512/18 比例 + G/F 组精度调整）
+          总计：3380 行（non-test ~1260 + test ~2120）
+      - 参考基线：04-factor-storage 实际 4400 行 / 8 milestone ≈ 550 行/milestone
+
+    === Review 历史 ===
+
+    **第一轮 plan-eng review (判定 SPLIT+REWORK)**：
+      - m1 被指为 kitchen sink → 改 m1 = 纯契约+fixtures
+      - m5 "embedding × 5日涨幅相似度" 无法离线 validate → 降级为 embedding infra + rule baseline
+      - m2 FinBERT 需拆 scorer vs provider → 拆 m2a/m2b
+      - 缺失性能基准 → 加 m2a/m4 单元测试 hard gate
+      - 缺失跨模块 contract 锁定 → 集中到 m1
+      - 列冲突（g2 已写 sentiment_score/importance_score）未解决 → 原定 A1
+
+    **第二轮 plan-eng review (判定 CONDITIONAL GO, 3 blockers)**：
+      Blocker 1: model_io 归属错位
+        fix: model_io 上移到 m1（+80 非测试 + 100 测试到 m1）
+      Blocker 2: C1 决策与 LocalFactorProvider `_IC_SHIFT=1` 硬编码矛盾
+        fix: D2 方案，m4 独立 evaluate_ml_score，不改 get_ic_report
+      Blocker 3: g2 已跑 FinBERT，A1 会导致重复推理
+        fix: P3 方案，g2 重构为复用 m2a FinBERTScorer singleton
+      Nice-to-have (全部采纳):
+        - m1 估算 180→300 行；m6 450→520 行
+        - 新增 Decisions: get_ticker_sentiment 加权公式 / Fin-E5 embedding dim 参数化 /
+          `__init__.py` 增量导出约定 / LocalSentimentProvider Registry 注册位置 /
+          cosine_dedup 传递闭包语义 / GPU OOM fallback 测试策略
+        - m4 显式交付 list_factors() 返回 ml_score 断言
+        - m6 G 组 GPU OOM 降级为 "assert fallback path invoked"（mock 无法验 CPU 等价）
+        - m6 F 组性能测试 @pytest.mark.perf 隔离（CI skip 避免 flakiness）
+        - m6 新增 m2b backfill chunked commit performance smoke case
+
+constraints: []
+indexing:
+  type: change
+  priority: high
+  layer: feature
+  domain: "quantitative-trading"
+  tags: ["planning", "small-models", "finbert", "fine5", "lightgbm", "milestone-plan", "contracts", "two-round-review"]
+provenance:
+  source_type: planning_session
+  confidence: 1.0
+  source_ref: "planning session 2026-04-13 with two rounds of plan-eng-review subagent"
+relations:
+  - { type: refines, target: "intent-02-small-models-001", reason: "将 Room epic intent 拆分为可执行 milestones + 锁跨模块 contract" }
+anchors:
+  - { file: "meta/00-project-room/03-model-system/02-small-models/progress.yaml", type: planning }
+  - { file: "meta/00-project-room/03-model-system/02-small-models/spec.md", type: docs }
+  - { file: "meta/00-project-room/03-model-system/02-small-models/room.yaml", type: config }
+  - { file: "src/stockbee/providers/interfaces.py", type: contract, reason: "SentimentProvider 接口，m2b 实现" }
+  - { file: "src/stockbee/factor_data/local_provider.py", type: contract, reason: "m4 ml_score 走 precomputed 自动发现；_IC_SHIFT 硬编码触发 D2 决策" }
+  - { file: "src/stockbee/factor_data/parquet_factor.py", type: contract, reason: "ml_score.parquet 复用 ParquetFactorStore merge-write" }
+  - { file: "src/stockbee/factor_data/ic_evaluator.py", type: contract, reason: "m4 evaluate_ml_score 直接调 compute_ic(shift=5)" }
+  - { file: "src/stockbee/news_data/news_store.py", type: migration, reason: "m1 扩 schema: +finbert_negative/neutral/confidence + fine5_importance" }
+  - { file: "src/stockbee/news_data/g2_classifier.py", type: refactor, reason: "P3 重构：私有 FinBERT → 共享 m2a FinBERTScorer singleton" }

--- a/meta/00-project-room/03-model-system/02-small-models/specs/change-2026-04-20-pr33-review-fixes.yaml
+++ b/meta/00-project-room/03-model-system/02-small-models/specs/change-2026-04-20-pr33-review-fixes.yaml
@@ -1,0 +1,71 @@
+spec_id: "change-2026-04-20-pr33-review-fixes"
+type: change
+state: active
+intent:
+  summary: "PR #33 post-merge review 三处修复:lazy import / backfill COALESCE / encode([]) 形状"
+  detail: |
+    PR #33 (feature/factor-storage, 含 04-factor-storage + 02-small-models)
+    merge 后 review 发现三处问题,针对 02-small-models 的已完成代码做修复。
+    Room 已 100% completion,本次为 post-completion patch,不新增 milestone。
+
+    === 修复 1 (high): small_models/__init__.py lazy import ===
+      问题:`from stockbee.small_models.fine5_scorer import FinE5Scorer` 会触发
+           package 级 __init__.py 的全量 re-export,其中 `from .lightgbm_scorer`
+           会经 `from stockbee.factor_data.ic_evaluator import ...` 拉起
+           `stockbee/factor_data/__init__.py`,后者 eager import local_provider
+           → pyarrow 变成无关 scorer 的硬依赖。
+      复现:PYTHONPATH=src python3 -c "from stockbee.small_models.fine5_scorer
+           import FinE5Scorer" → ModuleNotFoundError: No module named 'pyarrow'
+      修复:__init__.py 改 PEP 562 __getattr__ lazy loading。`_LAZY_MAP` 声明
+           每个 re-export 符号对应的子模块,首次访问时 importlib 按需加载。
+           `TYPE_CHECKING` 块保留类型提示。
+      验证:import fine5_scorer 后 sys.modules 中只有 stockbee.small_models
+           + stockbee.small_models.fine5_scorer,无 lightgbm_scorer / factor_data。
+
+    === 修复 2 (medium): LocalSentimentProvider.backfill 部分 NULL 行冻结 ===
+      问题:backfill WHERE 只认 `finbert_confidence IS NULL`,且仅 UPDATE
+           finbert_negative/neutral/confidence。
+           get_ticker_sentiment 跳过任一字段 NULL 的行。
+           → "G1 写 sentiment_score 但 finbert_* NULL" 的行,backfill 补全
+           finbert_* 后,若 sentiment_score 本身为 NULL 就再也不会被处理:
+           aggregation 跳过 + backfill WHERE 也不命中 → 永久冻结。
+      修复:
+        a. WHERE 改为任一情绪字段 NULL 即候选 (sentiment_score /
+           finbert_negative / finbert_neutral / finbert_confidence)
+        b. UPDATE 用 COALESCE(col, ?) 逐列 guard,写入仅在列当前为 NULL 时生效
+        c. 新增 scorer sc["positive"] → sentiment_score 的填充(仅当 NULL)
+      语义变化:
+        - 旧:backfill 绝不触碰 sentiment_score(g2 所有)
+        - 新:backfill 仅在 sentiment_score 为 NULL 时填入 FinBERT positive 概率;
+             g2 已写入的值仍不被覆盖(COALESCE 保证)
+        - progress.yaml 中 "不覆盖 sentiment_score" 的约束依然满足,只是
+          "不写 sentiment_score" 被放松为 "不覆盖已有 sentiment_score"
+      回归:test_does_not_touch_sentiment_score 继续绿 (预置 0.42 保留)。
+           test_only_writes_null_rows 继续绿 (COALESCE 对已有值 no-op)。
+
+    === 修复 3 (low): FinE5Scorer.encode([]) 形状依赖调用顺序 ===
+      问题:`if not texts: dim = embedding_dim if self._mock or self._model else 1`
+           真实 scorer 未加载时返回 (0, 1);首次真实 encode 触发 load 后返回
+           (0, hidden_size)。同一 scorer 对空输入的列数依赖调用顺序。
+      修复:`dim = self._hidden_size if self._hidden_size is not None else 1024`
+           未加载时用 e5-large-v2 默认 hidden_size (1024),与 mock 路径一致;
+           加载后用真实 hidden_size。仍不触发 load (保留既有短路性能)。
+      测试:test_encode_empty_returns_empty_no_load (模型未加载断言) 仍绿。
+
+constraints: []
+indexing:
+  type: change
+  priority: medium
+  layer: feature
+  domain: "quantitative-trading"
+  tags: ["pr-review", "post-merge-fix", "lazy-import", "backfill", "pep-562"]
+provenance:
+  source_type: code_review
+  confidence: 1.0
+  source_ref: "PR #33 feature/factor-storage review (three findings: high / medium / low)"
+relations:
+  - { type: refines, target: "change-2026-04-13-small-models-plan", reason: "修订 m2b backfill 对部分 NULL 行的处理语义 + __init__.py 增量导出约定改为 lazy" }
+anchors:
+  - { file: "src/stockbee/small_models/__init__.py", type: refactor, reason: "PEP 562 lazy __getattr__ re-export" }
+  - { file: "src/stockbee/small_models/local_sentiment_provider.py", type: fix, reason: "backfill WHERE 放宽 + COALESCE 填列" }
+  - { file: "src/stockbee/small_models/fine5_scorer.py", type: fix, reason: "encode([]) 形状稳定 = (0, hidden_size or 1024)" }

--- a/meta/00-project-room/03-model-system/02-small-models/specs/constraint-02-small-models-001.yaml
+++ b/meta/00-project-room/03-model-system/02-small-models/specs/constraint-02-small-models-001.yaml
@@ -1,6 +1,6 @@
 spec_id: "constraint-02-small-models-001"
 type: constraint
-state: draft
+state: active
 intent:
   summary: "FinBERT 情绪准确率 > 80%"
   detail: ""

--- a/meta/00-project-room/03-model-system/02-small-models/specs/constraint-02-small-models-002.yaml
+++ b/meta/00-project-room/03-model-system/02-small-models/specs/constraint-02-small-models-002.yaml
@@ -1,6 +1,6 @@
 spec_id: "constraint-02-small-models-002"
 type: constraint
-state: draft
+state: active
 intent:
   summary: "LightGBM 预测 IC > 0.03"
   detail: ""

--- a/meta/00-project-room/03-model-system/02-small-models/specs/intent-02-small-models-001.yaml
+++ b/meta/00-project-room/03-model-system/02-small-models/specs/intent-02-small-models-001.yaml
@@ -1,6 +1,6 @@
 spec_id: "intent-02-small-models-001"
 type: intent
-state: draft
+state: active
 intent:
   summary: "FinBERT 情绪 + Fin-E5 重要性 + LightGBM 收益预测"
   detail: |

--- a/meta/00-project-room/03-model-system/progress.yaml
+++ b/meta/00-project-room/03-model-system/progress.yaml
@@ -1,5 +1,6 @@
 progress:
-  completion: 0.0
+  # 父 epic 进度按子 feature room 平均: 02-small-models 100% / 其余 3 个 0% → 25%
+  completion: 0.25
   milestones:
     - id: "m1-LLM-路由"
       name: "LLM 路由"
@@ -7,8 +8,9 @@ progress:
       completed_at: null
     - id: "m2-小模型部署"
       name: "小模型部署"
-      status: pending
-      completed_at: null
+      status: completed
+      completed_at: "2026-04-20"
+      note: "02-small-models 7/7 milestone 全部完成 (2026-04-13 → 2026-04-20)"
     - id: "m3-RL-训练"
       name: "RL 训练"
       status: pending

--- a/meta/00-project-room/_tree.yaml
+++ b/meta/00-project-room/_tree.yaml
@@ -37,7 +37,7 @@ tree:
           phase: "1-2"
           children:
             - { id: "01-llm-routing", type: feature, priority: P0, phase: 1, status: "研究完成" }
-            - { id: "02-small-models", type: feature, priority: P0, phase: 1, status: "研究完成" }
+            - { id: "02-small-models", type: feature, priority: P0, phase: 1, status: "已完成" }
             - { id: "03-rl-algorithms", type: feature, priority: P0, phase: 2, status: "待研究" }
             - { id: "04-alpha-mining", type: feature, priority: P0, phase: 1, status: "研究完成" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [tool.pytest.ini_options]
 pythonpath = ["src"]
+markers = [
+    "perf: performance benchmark tests (opt-in; set RUN_PERF_TESTS=1 to enable)",
+]

--- a/src/stockbee/news_data/g2_classifier.py
+++ b/src/stockbee/news_data/g2_classifier.py
@@ -26,6 +26,21 @@ def _build_keyword_patterns(keywords: list[str]) -> list[re.Pattern]:
     return [re.compile(r"\b" + re.escape(kw) + r"\b") for kw in keywords]
 
 
+def _label_from_softmax(
+    row: dict[str, float],
+) -> tuple[str, float, float, float, float]:
+    """从 FinBERTScorer 3-way softmax dict 取 (label, positive, negative, neutral, conf)。
+
+    argmax 决定 sentiment 标签;conf = row["confidence"] = max 三项。
+    """
+    pos = float(row["positive"])
+    neg = float(row["negative"])
+    neu = float(row["neutral"])
+    conf = float(row.get("confidence", max(pos, neg, neu)))
+    pair = max(("positive", pos), ("negative", neg), ("neutral", neu), key=lambda x: x[1])
+    return pair[0], pos, neg, neu, conf
+
+
 def _count_keyword_hits(text_lower: str, patterns: list[re.Pattern]) -> int:
     """统计文本中匹配的关键词数量。"""
     return sum(1 for p in patterns if p.search(text_lower))
@@ -116,22 +131,34 @@ _URGENCY_MEDIUM_PATTERNS = _build_keyword_patterns(_URGENCY_MEDIUM_KEYWORDS)
 
 @dataclass
 class G2Result:
-    """G2 分类结果。"""
+    """G2 分类结果。
+
+    P3 重构 (m2b): sentiment_score 语义切换为 FinBERT positive softmax 概率 (0-1)。
+    新增 finbert_negative / finbert_neutral 两列,方便下游直接读到 3-way softmax
+    而无需再跑一次推理。规则引擎降级路径保留旧语义 (0-1 线性 score),
+    finbert_negative / finbert_neutral 在规则降级路径为 None。
+    """
     sentiment: str = "neutral"       # positive / neutral / negative
-    sentiment_score: float = 0.5     # 0.0 (most negative) to 1.0 (most positive)
-    confidence: float = 0.0          # FinBERT 置信度 0-1
+    sentiment_score: float = 0.5     # FinBERT positive softmax (used_finbert=True) 或 规则 score (False)
+    confidence: float = 0.0          # max 三项 softmax (FinBERT) / heuristic conf (rules)
     topic: str = "other"             # earnings / regulatory / merger / litigation / policy / product / other
     importance_score: float = 0.5    # 0.0 to 1.0
     urgency: str = "low"             # high / medium / low
     used_finbert: bool = False       # 是否使用了 FinBERT（vs 降级为规则）
+    finbert_negative: float | None = None  # P3: FinBERT negative softmax,规则降级为 None
+    finbert_neutral: float | None = None   # P3: FinBERT neutral softmax
 
 
 @dataclass
 class G2Config:
-    """G2 分类器配置。"""
+    """G2 分类器配置。
+
+    P3 重构后,FinBERT 推理经 m2a `FinBERTScorer` singleton,不再在 g2 本地加载;
+    finbert_model / device 字段保留兼容老调用方,但实际推理由 singleton 管理。
+    """
     use_finbert: bool = True         # 是否使用 FinBERT（False 时纯规则引擎）
     finbert_model: str = FINBERT_MODEL
-    device: str = "auto"             # auto / cpu / cuda / mps
+    device: str = "auto"             # 保留兼容,实际 device 由 FinBERTScorer singleton 决定
     batch_size: int = 16
 
 
@@ -148,8 +175,9 @@ class G2Classifier:
 
     def __init__(self, config: G2Config | None = None) -> None:
         self._config = config or G2Config()
-        self._pipeline: Any = None
-        self._finbert_available: bool | None = None  # None = 未检测
+        # P3: 复用 m2a FinBERTScorer singleton,消除同一进程多次加载 ProsusAI/finbert
+        self._scorer: Any = None
+        self._scorer_available: bool | None = None
 
     def classify(self, headline: str, snippet: str | None = None) -> G2Result:
         """对单条新闻进行 G2 分类。"""
@@ -158,7 +186,14 @@ class G2Classifier:
             return G2Result()
 
         # 1. 情绪分类
-        sentiment, score, confidence, used_finbert = self._classify_sentiment(text)
+        (
+            sentiment,
+            score,
+            confidence,
+            used_finbert,
+            fb_neg,
+            fb_neu,
+        ) = self._classify_sentiment(text)
 
         # 2. 主题分类
         topic = self._classify_topic(text)
@@ -177,6 +212,8 @@ class G2Classifier:
             importance_score=round(importance, 3),
             urgency=urgency,
             used_finbert=used_finbert,
+            finbert_negative=fb_neg,
+            finbert_neutral=fb_neu,
         )
 
     def classify_batch(self, items: list[dict[str, str]]) -> list[G2Result]:
@@ -193,7 +230,8 @@ class G2Classifier:
         sentiments = self._classify_sentiment_batch(texts)
 
         results = []
-        for text, (sentiment, score, confidence, used_finbert) in zip(texts, sentiments):
+        for text, sent_tuple in zip(texts, sentiments):
+            sentiment, score, confidence, used_finbert, fb_neg, fb_neu = sent_tuple
             if not text:
                 results.append(G2Result())
                 continue
@@ -208,6 +246,12 @@ class G2Classifier:
                 importance_score=round(importance, 3),
                 urgency=urgency,
                 used_finbert=used_finbert,
+                finbert_negative=(
+                    round(fb_neg, 3) if fb_neg is not None else None
+                ),
+                finbert_neutral=(
+                    round(fb_neu, 3) if fb_neu is not None else None
+                ),
             ))
         return results
 
@@ -243,121 +287,130 @@ class G2Classifier:
 
     # ------ 情绪分类 ------
 
-    def _classify_sentiment(self, text: str) -> tuple[str, float, float, bool]:
-        """单条情绪分类。返回 (sentiment, score, confidence, used_finbert)。"""
-        if not text:
-            return ("neutral", 0.5, 0.0, False)
+    # P3 重构: 复用 m2a FinBERTScorer singleton。返回 tuple 扩展为 6 元素:
+    # (sentiment, score, confidence, used_finbert, finbert_negative, finbert_neutral)
+    #   - used_finbert=True 时: score = FinBERT positive softmax, fb_neg/fb_neu 有值
+    #   - used_finbert=False 时 (规则降级或不可分类): fb_neg/fb_neu = None
 
+    _NEUTRAL_TUPLE = ("neutral", 0.5, 0.0, False, None, None)
+    _NEUTRAL_LOWCONF = ("neutral", 0.5, 0.1, False, None, None)
+
+    def _classify_sentiment(
+        self, text: str
+    ) -> tuple[str, float, float, bool, float | None, float | None]:
+        """单条情绪分类。"""
+        if not text:
+            return self._NEUTRAL_TUPLE
         if not self._is_classifiable(text):
-            return ("neutral", 0.5, 0.1, False)
+            return self._NEUTRAL_LOWCONF
 
         if self._config.use_finbert:
-            result = self._finbert_classify(text)
-            if result is not None:
-                return result
+            result = self._scorer_classify([text])
+            if result:
+                return result[0]
 
-        # 降级：规则引擎
-        return self._rule_sentiment(text)
+        rule = self._rule_sentiment(text)
+        # 扩展旧 4 元组到新 6 元组
+        return (rule[0], rule[1], rule[2], rule[3], None, None)
 
     def _classify_sentiment_batch(
         self, texts: list[str]
-    ) -> list[tuple[str, float, float, bool]]:
+    ) -> list[tuple[str, float, float, bool, float | None, float | None]]:
         """批量情绪分类。"""
         if not texts:
             return []
 
-        if self._config.use_finbert and self._ensure_finbert():
+        if self._config.use_finbert and self._ensure_scorer():
+            valid_pairs = [
+                (i, t) for i, t in enumerate(texts) if t and self._is_classifiable(t)
+            ]
+            results: list[
+                tuple[str, float, float, bool, float | None, float | None]
+            ] = [self._NEUTRAL_TUPLE] * len(texts)
+            if not valid_pairs:
+                # 全部不可分类,填 low-conf neutral
+                return [
+                    self._NEUTRAL_LOWCONF if t else self._NEUTRAL_TUPLE
+                    for t in texts
+                ]
+            valid_texts = [t for _, t in valid_pairs]
             try:
-                valid = [(i, t) for i, t in enumerate(texts) if t and self._is_classifiable(t)]
-                if not valid:
-                    return [("neutral", 0.5, 0.0, False)] * len(texts)
-
-                valid_texts = [t for _, t in valid]
-                pipe_results = self._pipeline(
-                    valid_texts,
-                    batch_size=self._config.batch_size,
-                    truncation=True,
-                    max_length=FINBERT_MAX_LENGTH,
+                scored = self._scorer.score_texts(
+                    valid_texts, batch_size=self._config.batch_size
                 )
-
-                results: list[tuple[str, float, float, bool]] = [
-                    ("neutral", 0.5, 0.0, False)
-                ] * len(texts)
-
-                for (orig_idx, _), pipe_res in zip(valid, pipe_results):
-                    label = pipe_res["label"].lower()
-                    conf = pipe_res["score"]
-                    score = {"positive": 0.5 + conf / 2, "negative": 0.5 - conf / 2}.get(label, 0.5)
-                    results[orig_idx] = (label, score, conf, True)
-
-                return results
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 logger.warning("FinBERT batch failed, falling back to rules: %s", e)
+                return self._rule_batch(texts)
 
-        return [
-            ("neutral", 0.5, 0.1, False) if not self._is_classifiable(t)
-            else self._rule_sentiment(t)
-            for t in texts
-        ]
+            # 把 valid 结果填回原位置
+            for (orig_idx, _text), score in zip(valid_pairs, scored):
+                label, pos, neg, neu, conf = _label_from_softmax(score)
+                results[orig_idx] = (label, pos, conf, True, neg, neu)
+            # 其余非 valid 位置按文本状态填 neutral 或 low-conf
+            for i, t in enumerate(texts):
+                if results[i] is self._NEUTRAL_TUPLE:
+                    if not t:
+                        results[i] = self._NEUTRAL_TUPLE
+                    elif not self._is_classifiable(t):
+                        results[i] = self._NEUTRAL_LOWCONF
+            return results
 
-    def _finbert_classify(self, text: str) -> tuple[str, float, float, bool] | None:
-        """FinBERT 单条推理。失败返回 None。"""
-        if not self._ensure_finbert():
+        return self._rule_batch(texts)
+
+    def _rule_batch(
+        self, texts: list[str]
+    ) -> list[tuple[str, float, float, bool, float | None, float | None]]:
+        out: list[tuple[str, float, float, bool, float | None, float | None]] = []
+        for t in texts:
+            if not t:
+                out.append(self._NEUTRAL_TUPLE)
+            elif not self._is_classifiable(t):
+                out.append(self._NEUTRAL_LOWCONF)
+            else:
+                r = self._rule_sentiment(t)
+                out.append((r[0], r[1], r[2], r[3], None, None))
+        return out
+
+    def _scorer_classify(
+        self, texts: list[str]
+    ) -> list[tuple[str, float, float, bool, float | None, float | None]] | None:
+        """使用 m2a singleton 推理;失败返回 None 以触发规则降级。"""
+        if not self._ensure_scorer():
             return None
         try:
-            result = self._pipeline(
-                text, truncation=True, max_length=FINBERT_MAX_LENGTH
+            scored = self._scorer.score_texts(
+                texts, batch_size=self._config.batch_size
             )
-            label = result[0]["label"].lower()
-            conf = result[0]["score"]
-            score = {"positive": 0.5 + conf / 2, "negative": 0.5 - conf / 2}.get(label, 0.5)
-            return (label, score, conf, True)
-        except Exception as e:
-            logger.warning("FinBERT inference failed: %s", e)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("FinBERTScorer inference failed: %s", e)
             return None
+        out: list[tuple[str, float, float, bool, float | None, float | None]] = []
+        for row in scored:
+            label, pos, neg, neu, conf = _label_from_softmax(row)
+            out.append((label, pos, conf, True, neg, neu))
+        return out
 
-    def _ensure_finbert(self) -> bool:
-        """Lazy init FinBERT pipeline。返回是否可用。"""
-        if self._finbert_available is False:
+    def _ensure_scorer(self) -> bool:
+        """Lazy 取 m2a FinBERTScorer singleton。"""
+        if self._scorer_available is False:
             return False
-        if self._pipeline is not None:
+        if self._scorer is not None:
             return True
         try:
-            from transformers import pipeline as hf_pipeline
-            import torch
+            from stockbee.small_models.finbert_scorer import get_default_scorer
 
-            if self._config.device == "auto":
-                if torch.cuda.is_available():
-                    device = 0
-                elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-                    device = "mps"
-                else:
-                    device = -1  # CPU
-            elif self._config.device == "cpu":
-                device = -1
-            elif self._config.device == "cuda":
-                device = 0
-            elif self._config.device == "mps":
-                device = "mps"
-            else:
-                device = -1
-
-            logger.info("Loading FinBERT model: %s (device=%s)", self._config.finbert_model, device)
-            self._pipeline = hf_pipeline(
-                "sentiment-analysis",
-                model=self._config.finbert_model,
-                device=device,
-            )
-            self._finbert_available = True
-            logger.info("FinBERT loaded successfully")
+            self._scorer = get_default_scorer()
+            self._scorer_available = True
             return True
         except ImportError:
-            logger.info("transformers/torch not installed, using rule-based sentiment")
-            self._finbert_available = False
+            logger.info(
+                "stockbee.small_models not available, using rule-based sentiment"
+            )
+            self._scorer_available = False
             return False
-        except Exception as e:
-            logger.warning("FinBERT load failed: %s, using rule-based sentiment", e)
-            self._finbert_available = False
+        except Exception as e:  # noqa: BLE001
+            logger.warning("FinBERTScorer init failed: %s, using rule-based", e)
+            self._scorer_available = False
             return False
 
     # 预编译情绪关键词（类级别，所有实例共享）

--- a/src/stockbee/news_data/news_store.py
+++ b/src/stockbee/news_data/news_store.py
@@ -333,6 +333,9 @@ class SqliteNewsProvider(NewsProvider):
         reliability_score: float | None = None,
         g_level: int = 0,
         analysis: str | None = None,
+        finbert_negative: float | None = None,
+        finbert_neutral: float | None = None,
+        finbert_confidence: float | None = None,
     ) -> int | None:
         """插入一条新闻事件，自动去重。
 
@@ -361,12 +364,14 @@ class SqliteNewsProvider(NewsProvider):
                     """INSERT INTO news_events
                        (timestamp, source, source_url, headline, snippet,
                         sentiment_score, importance_score, reliability_score,
-                        g_level, analysis, created_at)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                        g_level, analysis, created_at,
+                        finbert_negative, finbert_neutral, finbert_confidence)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (
                         ts_normalized, source, source_url,
                         headline, snippet, sentiment_score, importance_score,
                         reliability_score, g_level, analysis, now,
+                        finbert_negative, finbert_neutral, finbert_confidence,
                     ),
                 )
             except sqlite3.IntegrityError:
@@ -414,13 +419,17 @@ class SqliteNewsProvider(NewsProvider):
                         """INSERT INTO news_events
                            (timestamp, source, source_url, headline, snippet,
                             sentiment_score, importance_score, reliability_score,
-                            g_level, analysis, created_at)
-                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                            g_level, analysis, created_at,
+                            finbert_negative, finbert_neutral, finbert_confidence)
+                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                         (
                             ts, source, event.get("source_url"),
                             headline, snippet, event.get("sentiment_score"),
                             event.get("importance_score"), event.get("reliability_score"),
                             event.get("g_level", 0), event.get("analysis"), now,
+                            event.get("finbert_negative"),
+                            event.get("finbert_neutral"),
+                            event.get("finbert_confidence"),
                         ),
                     )
                     row_id = cur.lastrowid
@@ -464,13 +473,17 @@ class SqliteNewsProvider(NewsProvider):
                         """INSERT INTO news_events
                            (timestamp, source, source_url, headline, snippet,
                             sentiment_score, importance_score, reliability_score,
-                            g_level, analysis, created_at)
-                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                            g_level, analysis, created_at,
+                            finbert_negative, finbert_neutral, finbert_confidence)
+                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                         (
                             ts, source, event.get("source_url"),
                             headline, snippet, event.get("sentiment_score"),
                             event.get("importance_score"), event.get("reliability_score"),
                             event.get("g_level", 0), event.get("analysis"), now,
+                            event.get("finbert_negative"),
+                            event.get("finbert_neutral"),
+                            event.get("finbert_confidence"),
                         ),
                     )
                     row_id = cur.lastrowid
@@ -498,8 +511,15 @@ class SqliteNewsProvider(NewsProvider):
         importance_score: float | None = None,
         reliability_score: float | None = None,
         analysis: str | None = None,
+        finbert_negative: float | None = None,
+        finbert_neutral: float | None = None,
+        finbert_confidence: float | None = None,
     ) -> bool:
-        """更新新闻的 G 级别和评分（G2/G3 处理后回写）。"""
+        """更新新闻的 G 级别和评分（G2/G3 处理后回写）。
+
+        m2b 扩展: g2_classifier 重构后同时写入 3-way FinBERT softmax
+        (finbert_negative / finbert_neutral / finbert_confidence)。
+        """
         sets: list[str] = ["g_level = ?"]
         params: list[Any] = [g_level]
 
@@ -515,6 +535,15 @@ class SqliteNewsProvider(NewsProvider):
         if analysis is not None:
             sets.append("analysis = ?")
             params.append(analysis)
+        if finbert_negative is not None:
+            sets.append("finbert_negative = ?")
+            params.append(finbert_negative)
+        if finbert_neutral is not None:
+            sets.append("finbert_neutral = ?")
+            params.append(finbert_neutral)
+        if finbert_confidence is not None:
+            sets.append("finbert_confidence = ?")
+            params.append(finbert_confidence)
 
         params.append(news_id)
 

--- a/src/stockbee/news_data/news_store.py
+++ b/src/stockbee/news_data/news_store.py
@@ -76,6 +76,22 @@ CREATE TABLE IF NOT EXISTS g3_daily_counts (
 );
 """
 
+# 02-small-models m1 扩列迁移。
+# SQLite 不支持 ADD COLUMN IF NOT EXISTS,_migrate_schema 先 PRAGMA 探测再条件 ALTER。
+# 语义 (见 02-small-models spec.md Decisions 表):
+#   - finbert_negative REAL   FinBERT negative softmax (g2 写)
+#   - finbert_neutral  REAL   FinBERT neutral softmax (g2 写)
+#   - finbert_confidence REAL max(positive, negative, neutral) (g2 写,m2b 查询加权用)
+#   - fine5_importance REAL   Fin-E5 + rule baseline importance (m5 回写)
+# sentiment_score 保留 = FinBERT positive softmax (g2 原语义)。
+# importance_score 保留 = g2 规则评分,与 fine5_importance 并存。
+_SMALL_MODELS_NEW_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("finbert_negative", "REAL"),
+    ("finbert_neutral", "REAL"),
+    ("finbert_confidence", "REAL"),
+    ("fine5_importance", "REAL"),
+)
+
 
 def _normalize_timestamp(ts: str | datetime) -> str | None:
     """归一化时间戳为 UTC ISO 8601 字符串。无法解析时返回 None。"""
@@ -145,9 +161,47 @@ class SqliteNewsProvider(NewsProvider):
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA foreign_keys=ON")
         self._conn.executescript(_SCHEMA_SQL)
+        self._migrate_schema()
         self._conn.commit()
         count = self._count_all()
         logger.info("SqliteNewsProvider ready: %s (%d events)", self._db_path, count)
+
+    def _migrate_schema(self) -> None:
+        """老库自动升级:PRAGMA 探测缺失列后条件 ALTER TABLE ADD COLUMN。
+
+        幂等:重复调用不报错。老数据 NULL,不丢。
+
+        并发安全:两进程首次同时开库时,双方都会检测到列缺失并尝试 ALTER;
+        第二次 ALTER 会抛 `sqlite3.OperationalError: duplicate column name`,
+        此时重新 PRAGMA 探测,若列已被另一进程添加则视为成功。
+        """
+        if not self._conn:
+            raise RuntimeError("Provider not initialized")
+        for col_name, col_type in _SMALL_MODELS_NEW_COLUMNS:
+            existing = self._columns()
+            if col_name in existing:
+                continue
+            try:
+                self._conn.execute(
+                    f"ALTER TABLE news_events ADD COLUMN {col_name} {col_type}"
+                )
+                logger.info("news_events: added column %s %s", col_name, col_type)
+            except sqlite3.OperationalError as exc:
+                # 另一进程赢得了 ALTER;重新探测确认列确实已到位。
+                if col_name in self._columns():
+                    logger.debug("%s already added by peer", col_name)
+                    continue
+                raise RuntimeError(
+                    f"schema migration failed for {col_name}: {exc}"
+                ) from exc
+
+    def _columns(self) -> set[str]:
+        """返回 news_events 当前所有列名。"""
+        assert self._conn is not None
+        return {
+            row[1]
+            for row in self._conn.execute("PRAGMA table_info(news_events)").fetchall()
+        }
 
     def _do_shutdown(self) -> None:
         if self._conn:

--- a/src/stockbee/news_data/sync.py
+++ b/src/stockbee/news_data/sync.py
@@ -205,10 +205,16 @@ class NewsDataSyncer:
         g2_results = self._g2.classify_batch(batch_input)
 
         for (event, news_id), g2r in zip(items, g2_results):
+            # P3 (m2b): g2 同时写 3-way FinBERT softmax,供 LocalSentimentProvider
+            # get_ticker_sentiment 加权聚合 + backfill 填缺。规则降级路径 fb_neg/neu
+            # 为 None,update_g_level 内部会跳过对应列。
             self._store.update_g_level(
                 news_id, g_level=2,
                 sentiment_score=g2r.sentiment_score,
                 importance_score=g2r.importance_score,
+                finbert_negative=g2r.finbert_negative,
+                finbert_neutral=g2r.finbert_neutral,
+                finbert_confidence=(g2r.confidence if g2r.used_finbert else None),
             )
             results.append((event, news_id, g2r))
         return results

--- a/src/stockbee/small_models/__init__.py
+++ b/src/stockbee/small_models/__init__.py
@@ -4,8 +4,14 @@
 
 当前:
 - m1: paths, model_io (artifact 版本管理 + save/load pickle)
+- m2a: FinBERTScorer, get_default_scorer, reset_default_scorer (纯推理 + singleton)
 """
 
+from .finbert_scorer import (
+    FinBERTScorer,
+    get_default_scorer,
+    reset_default_scorer,
+)
 from .model_io import (
     InvalidArtifactError,
     NotFoundError,
@@ -18,13 +24,16 @@ from .model_io import (
 from .paths import ML_SCORE_PARQUET, MODEL_ROOT
 
 __all__ = [
+    "FinBERTScorer",
     "InvalidArtifactError",
     "ML_SCORE_PARQUET",
     "MODEL_ROOT",
     "NotFoundError",
     "artifact_path",
+    "get_default_scorer",
     "list_versions",
     "load_pickle",
+    "reset_default_scorer",
     "save_pickle",
     "update_symlink",
 ]

--- a/src/stockbee/small_models/__init__.py
+++ b/src/stockbee/small_models/__init__.py
@@ -8,6 +8,7 @@
 - m3: forward_return_5d (B3 label) + train_lightgbm + train_and_save + walk_forward_splits
 - m5: FinE5Scorer (encode + cosine_sim + cosine_dedup) + baseline_importance + backfill_importance
 - m2b: LocalSentimentProvider (SentimentProvider 实现 + g2 P3 重构)
+- m4: LightGBMScorer (推理 + ml_score.parquet 落盘) + evaluate_ml_score(shift=5)
 """
 
 from .fine5_scorer import FinE5Scorer
@@ -19,6 +20,12 @@ from .finbert_scorer import (
 from .importance_baseline import backfill_importance, baseline_importance
 from .local_sentiment_provider import LocalSentimentProvider
 from .label_utils import LABEL_NAME, forward_return_5d
+from .lightgbm_scorer import (
+    LightGBMScorer,
+    ML_SCORE_COLUMN,
+    ML_SCORE_GROUP,
+    evaluate_ml_score,
+)
 from .lightgbm_trainer import (
     DEFAULT_PARAMS,
     train_and_save,
@@ -42,13 +49,17 @@ __all__ = [
     "FinE5Scorer",
     "InvalidArtifactError",
     "LABEL_NAME",
+    "LightGBMScorer",
     "LocalSentimentProvider",
+    "ML_SCORE_COLUMN",
+    "ML_SCORE_GROUP",
     "ML_SCORE_PARQUET",
     "MODEL_ROOT",
     "NotFoundError",
     "artifact_path",
     "backfill_importance",
     "baseline_importance",
+    "evaluate_ml_score",
     "forward_return_5d",
     "get_default_scorer",
     "list_versions",

--- a/src/stockbee/small_models/__init__.py
+++ b/src/stockbee/small_models/__init__.py
@@ -5,12 +5,20 @@
 当前:
 - m1: paths, model_io (artifact 版本管理 + save/load pickle)
 - m2a: FinBERTScorer, get_default_scorer, reset_default_scorer (纯推理 + singleton)
+- m3: forward_return_5d (B3 label) + train_lightgbm + train_and_save + walk_forward_splits
 """
 
 from .finbert_scorer import (
     FinBERTScorer,
     get_default_scorer,
     reset_default_scorer,
+)
+from .label_utils import LABEL_NAME, forward_return_5d
+from .lightgbm_trainer import (
+    DEFAULT_PARAMS,
+    train_and_save,
+    train_lightgbm,
+    walk_forward_splits,
 )
 from .model_io import (
     InvalidArtifactError,
@@ -24,16 +32,22 @@ from .model_io import (
 from .paths import ML_SCORE_PARQUET, MODEL_ROOT
 
 __all__ = [
+    "DEFAULT_PARAMS",
     "FinBERTScorer",
     "InvalidArtifactError",
+    "LABEL_NAME",
     "ML_SCORE_PARQUET",
     "MODEL_ROOT",
     "NotFoundError",
     "artifact_path",
+    "forward_return_5d",
     "get_default_scorer",
     "list_versions",
     "load_pickle",
     "reset_default_scorer",
     "save_pickle",
+    "train_and_save",
+    "train_lightgbm",
     "update_symlink",
+    "walk_forward_splits",
 ]

--- a/src/stockbee/small_models/__init__.py
+++ b/src/stockbee/small_models/__init__.py
@@ -9,39 +9,94 @@
 - m5: FinE5Scorer (encode + cosine_sim + cosine_dedup) + baseline_importance + backfill_importance
 - m2b: LocalSentimentProvider (SentimentProvider 实现 + g2 P3 重构)
 - m4: LightGBMScorer (推理 + ml_score.parquet 落盘) + evaluate_ml_score(shift=5)
+
+为避免 `from stockbee.small_models.finbert_scorer import ...` 这类直接导入
+把 lightgbm_scorer → factor_data → pyarrow 的重依赖全量拉起,此处使用 PEP 562
+lazy __getattr__: 仅当访问 `stockbee.small_models.<Name>` 时才触发对应子模块加载。
 """
 
-from .fine5_scorer import FinE5Scorer
-from .finbert_scorer import (
-    FinBERTScorer,
-    get_default_scorer,
-    reset_default_scorer,
-)
-from .importance_baseline import backfill_importance, baseline_importance
-from .local_sentiment_provider import LocalSentimentProvider
-from .label_utils import LABEL_NAME, forward_return_5d
-from .lightgbm_scorer import (
-    LightGBMScorer,
-    ML_SCORE_COLUMN,
-    ML_SCORE_GROUP,
-    evaluate_ml_score,
-)
-from .lightgbm_trainer import (
-    DEFAULT_PARAMS,
-    train_and_save,
-    train_lightgbm,
-    walk_forward_splits,
-)
-from .model_io import (
-    InvalidArtifactError,
-    NotFoundError,
-    artifact_path,
-    list_versions,
-    load_pickle,
-    save_pickle,
-    update_symlink,
-)
-from .paths import ML_SCORE_PARQUET, MODEL_ROOT
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .fine5_scorer import FinE5Scorer
+    from .finbert_scorer import (
+        FinBERTScorer,
+        get_default_scorer,
+        reset_default_scorer,
+    )
+    from .importance_baseline import backfill_importance, baseline_importance
+    from .label_utils import LABEL_NAME, forward_return_5d
+    from .lightgbm_scorer import (
+        ML_SCORE_COLUMN,
+        ML_SCORE_GROUP,
+        LightGBMScorer,
+        evaluate_ml_score,
+    )
+    from .lightgbm_trainer import (
+        DEFAULT_PARAMS,
+        train_and_save,
+        train_lightgbm,
+        walk_forward_splits,
+    )
+    from .local_sentiment_provider import LocalSentimentProvider
+    from .model_io import (
+        InvalidArtifactError,
+        NotFoundError,
+        artifact_path,
+        list_versions,
+        load_pickle,
+        save_pickle,
+        update_symlink,
+    )
+    from .paths import ML_SCORE_PARQUET, MODEL_ROOT
+
+
+_LAZY_MAP: dict[str, str] = {
+    "FinE5Scorer": "fine5_scorer",
+    "FinBERTScorer": "finbert_scorer",
+    "get_default_scorer": "finbert_scorer",
+    "reset_default_scorer": "finbert_scorer",
+    "backfill_importance": "importance_baseline",
+    "baseline_importance": "importance_baseline",
+    "LABEL_NAME": "label_utils",
+    "forward_return_5d": "label_utils",
+    "LightGBMScorer": "lightgbm_scorer",
+    "ML_SCORE_COLUMN": "lightgbm_scorer",
+    "ML_SCORE_GROUP": "lightgbm_scorer",
+    "evaluate_ml_score": "lightgbm_scorer",
+    "DEFAULT_PARAMS": "lightgbm_trainer",
+    "train_and_save": "lightgbm_trainer",
+    "train_lightgbm": "lightgbm_trainer",
+    "walk_forward_splits": "lightgbm_trainer",
+    "LocalSentimentProvider": "local_sentiment_provider",
+    "InvalidArtifactError": "model_io",
+    "NotFoundError": "model_io",
+    "artifact_path": "model_io",
+    "list_versions": "model_io",
+    "load_pickle": "model_io",
+    "save_pickle": "model_io",
+    "update_symlink": "model_io",
+    "ML_SCORE_PARQUET": "paths",
+    "MODEL_ROOT": "paths",
+}
+
+
+def __getattr__(name: str) -> Any:
+    submodule = _LAZY_MAP.get(name)
+    if submodule is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    mod = importlib.import_module(f".{submodule}", __name__)
+    value = getattr(mod, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(_LAZY_MAP))
+
 
 __all__ = [
     "DEFAULT_PARAMS",

--- a/src/stockbee/small_models/__init__.py
+++ b/src/stockbee/small_models/__init__.py
@@ -7,6 +7,7 @@
 - m2a: FinBERTScorer, get_default_scorer, reset_default_scorer (纯推理 + singleton)
 - m3: forward_return_5d (B3 label) + train_lightgbm + train_and_save + walk_forward_splits
 - m5: FinE5Scorer (encode + cosine_sim + cosine_dedup) + baseline_importance + backfill_importance
+- m2b: LocalSentimentProvider (SentimentProvider 实现 + g2 P3 重构)
 """
 
 from .fine5_scorer import FinE5Scorer
@@ -16,6 +17,7 @@ from .finbert_scorer import (
     reset_default_scorer,
 )
 from .importance_baseline import backfill_importance, baseline_importance
+from .local_sentiment_provider import LocalSentimentProvider
 from .label_utils import LABEL_NAME, forward_return_5d
 from .lightgbm_trainer import (
     DEFAULT_PARAMS,
@@ -40,6 +42,7 @@ __all__ = [
     "FinE5Scorer",
     "InvalidArtifactError",
     "LABEL_NAME",
+    "LocalSentimentProvider",
     "ML_SCORE_PARQUET",
     "MODEL_ROOT",
     "NotFoundError",

--- a/src/stockbee/small_models/__init__.py
+++ b/src/stockbee/small_models/__init__.py
@@ -1,0 +1,30 @@
+"""small_models — FinBERT / Fin-E5 / LightGBM 本地模型 (02-small-models Room)。
+
+每个 milestone 向本文件增量 re-export 自己的对外符号。
+
+当前:
+- m1: paths, model_io (artifact 版本管理 + save/load pickle)
+"""
+
+from .model_io import (
+    InvalidArtifactError,
+    NotFoundError,
+    artifact_path,
+    list_versions,
+    load_pickle,
+    save_pickle,
+    update_symlink,
+)
+from .paths import ML_SCORE_PARQUET, MODEL_ROOT
+
+__all__ = [
+    "InvalidArtifactError",
+    "ML_SCORE_PARQUET",
+    "MODEL_ROOT",
+    "NotFoundError",
+    "artifact_path",
+    "list_versions",
+    "load_pickle",
+    "save_pickle",
+    "update_symlink",
+]

--- a/src/stockbee/small_models/__init__.py
+++ b/src/stockbee/small_models/__init__.py
@@ -6,13 +6,16 @@
 - m1: paths, model_io (artifact 版本管理 + save/load pickle)
 - m2a: FinBERTScorer, get_default_scorer, reset_default_scorer (纯推理 + singleton)
 - m3: forward_return_5d (B3 label) + train_lightgbm + train_and_save + walk_forward_splits
+- m5: FinE5Scorer (encode + cosine_sim + cosine_dedup) + baseline_importance + backfill_importance
 """
 
+from .fine5_scorer import FinE5Scorer
 from .finbert_scorer import (
     FinBERTScorer,
     get_default_scorer,
     reset_default_scorer,
 )
+from .importance_baseline import backfill_importance, baseline_importance
 from .label_utils import LABEL_NAME, forward_return_5d
 from .lightgbm_trainer import (
     DEFAULT_PARAMS,
@@ -34,12 +37,15 @@ from .paths import ML_SCORE_PARQUET, MODEL_ROOT
 __all__ = [
     "DEFAULT_PARAMS",
     "FinBERTScorer",
+    "FinE5Scorer",
     "InvalidArtifactError",
     "LABEL_NAME",
     "ML_SCORE_PARQUET",
     "MODEL_ROOT",
     "NotFoundError",
     "artifact_path",
+    "backfill_importance",
+    "baseline_importance",
     "forward_return_5d",
     "get_default_scorer",
     "list_versions",

--- a/src/stockbee/small_models/finbert_scorer.py
+++ b/src/stockbee/small_models/finbert_scorer.py
@@ -1,0 +1,274 @@
+"""FinBERT 情绪评分器 — 纯推理层。
+
+加载 ProsusAI/finbert (或兼容模型)，batch tokenize + forward + softmax，
+返回 {positive, negative, neutral, confidence}。
+
+PRD 硬约束: batch=32, max_length=128 推理 <100ms (GPU) / <300ms (CPU)。
+性能基准见 tests/small_models/test_finbert_scorer.py::TestFinBERTPerfGate。
+
+设计:
+- lazy load: 首次 score_texts 才加载模型 (空列表短路,不触发加载)
+- device=None: cuda → mps → cpu 自动选择
+- device="mock": 走确定性关键词 heuristic,不加载 HF (m2b / g2 单测复用,避免下 440MB)
+- 标签顺序从 model.config.id2label 动态读 (不硬编码 ProsusAI/finbert 特定顺序)
+- singleton: get_default_scorer() 供 m2b LocalSentimentProvider + g2_classifier 共享
+
+**架构契约 (P3)**: m2b 和 g2 必须走 get_default_scorer(),消除重复推理。
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import threading
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_LABELS = ("positive", "negative", "neutral")
+_DEFAULT_MODEL = "ProsusAI/finbert"
+_MAX_LENGTH = 128  # Tech Design §3.3 约束
+_MOCK_POS_PATTERN = re.compile(
+    r"\b(beat|beats|beating|surge|surged|gain|gains|gained|rise|rises|rose|"
+    r"record|upgrade|upgraded|buy|strong|grow|grows|growing|growth|"
+    r"boost|boosts|boosted|hike|hikes|raised|raising|high|highs|"
+    r"profit|profits|profitable|dividend|positive|bullish)\b",
+    re.IGNORECASE,
+)
+_MOCK_NEG_PATTERN = re.compile(
+    r"\b(miss|misses|missed|plunge|plunged|drop|drops|dropped|fall|fell|"
+    r"crash|crashed|cut|cuts|slash|slashed|slashes|layoff|layoffs|"
+    r"fine|fined|fines|fraud|scandal|investigation|violation|violations|"
+    r"resign|resigned|sue|sued|loss|losses|collapse|collapsed|collapses|"
+    r"weak|weakness|decline|declines|declining|bearish|"
+    r"warn|warns|warning|concern|concerns|downgrade|downgraded)\b",
+    re.IGNORECASE,
+)
+
+
+class FinBERTScorer:
+    """FinBERT 情绪评分器。
+
+    示例::
+
+        scorer = FinBERTScorer()          # 自动选 device
+        out = scorer.score_texts(["stock beats earnings", "layoffs announced"])
+        # [{"positive": 0.55, "negative": 0.23, "neutral": 0.21, "confidence": 0.55},
+        #  {"positive": 0.02, "negative": 0.77, "neutral": 0.20, "confidence": 0.77}]
+
+    测试/下游共享 FinBERT 实例::
+
+        scorer = FinBERTScorer(device="mock")   # 不加载 HF, 关键词 heuristic
+    """
+
+    def __init__(
+        self,
+        device: str | None = None,
+        model_name: str = _DEFAULT_MODEL,
+    ) -> None:
+        self._model_name = model_name
+        self._device_arg = device
+        self._mock = (device == "mock")
+        self._model: Any = None
+        self._tokenizer: Any = None
+        self._torch: Any = None
+        self._resolved_device: str | None = "mock" if self._mock else None
+        # id2label 顺序可能和 _LABELS 不同,加载后按 index 映射
+        self._label_index: dict[str, int] | None = None
+        self._load_lock = threading.Lock()
+
+    def __repr__(self) -> str:
+        loaded = self._model is not None or self._mock
+        dev = self._resolved_device or "unloaded"
+        return f"FinBERTScorer(model={self._model_name!r}, device={dev!r}, loaded={loaded})"
+
+    @property
+    def device(self) -> str | None:
+        """已解析的 device (None = 尚未 lazy load)。"""
+        return self._resolved_device
+
+    def score_texts(
+        self,
+        texts: list[str],
+        batch_size: int = 32,
+    ) -> list[dict[str, float]]:
+        """批量情绪评分。
+
+        Args:
+            texts: 待评分文本列表;空列表直接返回 []
+            batch_size: 每次 forward 的样本数,默认 32
+
+        Returns:
+            长度等于 texts 的 list[dict],每个 dict 含 positive/negative/neutral/confidence
+            (confidence = max(三项); 三项 softmax sum ≈ 1.0)
+        """
+        # 类型检查必须先于空检查: 否则 "" / None 会触发 `not texts` 短路,
+        # 把非法输入静默当空列表返回
+        if not isinstance(texts, list):
+            raise TypeError(f"texts must be list[str], got {type(texts).__name__}")
+        if not all(isinstance(t, str) for t in texts):
+            raise TypeError("texts must be list[str]; found non-str element")
+        if batch_size < 1:
+            raise ValueError(f"batch_size must be >= 1, got {batch_size}")
+        if not texts:
+            return []
+
+        if self._mock:
+            return [_mock_score(t) for t in texts]
+
+        self._ensure_loaded()
+        out: list[dict[str, float]] = []
+        for start in range(0, len(texts), batch_size):
+            batch = texts[start : start + batch_size]
+            out.extend(self._score_batch(batch))
+        return out
+
+    # ---- 内部 ----
+
+    def _ensure_loaded(self) -> None:
+        if self._model is not None:
+            return
+        with self._load_lock:
+            if self._model is not None:  # 双检锁
+                return
+            try:
+                import torch
+                from transformers import (
+                    AutoModelForSequenceClassification,
+                    AutoTokenizer,
+                )
+            except ImportError as exc:  # pragma: no cover - 依赖检查
+                raise RuntimeError(
+                    "FinBERTScorer requires transformers + torch. "
+                    "Install with `pip install transformers torch` "
+                    "or pass device='mock' for test-only fake scoring."
+                ) from exc
+
+            self._torch = torch
+            device = self._resolve_device(torch, self._device_arg)
+            logger.info(
+                "Loading FinBERT: model=%s device=%s", self._model_name, device
+            )
+            tokenizer = AutoTokenizer.from_pretrained(self._model_name)
+            model = AutoModelForSequenceClassification.from_pretrained(
+                self._model_name
+            )
+            model.to(device)
+            model.eval()
+
+            id2label = getattr(model.config, "id2label", None) or {}
+            label_index: dict[str, int] = {}
+            for idx, lbl in id2label.items():
+                key = str(lbl).lower()
+                if key in _LABELS:
+                    label_index[key] = int(idx)
+            missing = [lbl for lbl in _LABELS if lbl not in label_index]
+            if missing:
+                raise RuntimeError(
+                    f"model {self._model_name} id2label {id2label!r} "
+                    f"missing labels: {missing}"
+                )
+
+            self._tokenizer = tokenizer
+            self._model = model
+            self._resolved_device = device
+            self._label_index = label_index
+
+    @staticmethod
+    def _resolve_device(torch_mod: Any, device_arg: str | None) -> str:
+        if device_arg in ("cpu", "cuda", "mps"):
+            return device_arg
+        if device_arg is None:
+            if torch_mod.cuda.is_available():
+                return "cuda"
+            mps = getattr(torch_mod.backends, "mps", None)
+            if mps is not None and mps.is_available():
+                return "mps"
+            return "cpu"
+        raise ValueError(
+            f"Invalid device {device_arg!r}; expected None/'cpu'/'cuda'/'mps'/'mock'"
+        )
+
+    def _score_batch(self, batch: list[str]) -> list[dict[str, float]]:
+        torch = self._torch
+        tok = self._tokenizer(
+            batch,
+            padding=True,
+            truncation=True,
+            max_length=_MAX_LENGTH,
+            return_tensors="pt",
+        )
+        tok = {k: v.to(self._resolved_device) for k, v in tok.items()}
+        with torch.no_grad():
+            logits = self._model(**tok).logits
+        probs = torch.softmax(logits, dim=-1).cpu().tolist()
+        idx = self._label_index or {}
+        return [
+            {
+                "positive": float(row[idx["positive"]]),
+                "negative": float(row[idx["negative"]]),
+                "neutral": float(row[idx["neutral"]]),
+                "confidence": float(max(row)),
+            }
+            for row in probs
+        ]
+
+
+# ---- singleton (供 m2b + g2_classifier 共享,消除重复推理) ----
+
+_default_scorer: FinBERTScorer | None = None
+_default_lock = threading.Lock()
+
+
+def get_default_scorer() -> FinBERTScorer:
+    """返回进程级 FinBERTScorer singleton。
+
+    首次调用 lazy 创建 FinBERTScorer() (device=None 自动选择)。
+    m2b LocalSentimentProvider 和 g2_classifier (P3 重构后) 共享同一实例,
+    避免同一进程两次加载 FinBERT 权重 (~440MB) 及重复推理。
+    """
+    global _default_scorer
+    if _default_scorer is not None:
+        return _default_scorer
+    with _default_lock:
+        if _default_scorer is None:
+            _default_scorer = FinBERTScorer()
+    return _default_scorer
+
+
+def reset_default_scorer() -> None:
+    """清除 singleton (测试 hook)。下次 get_default_scorer 重建。"""
+    global _default_scorer
+    with _default_lock:
+        _default_scorer = None
+
+
+# ---- mock scoring (device="mock") ----
+
+
+def _mock_score(text: str) -> dict[str, float]:
+    """确定性关键词 heuristic,不加载 HF。
+
+    用于 m2b / g2 单元测试,避免每次测试下载 440MB。
+    - 含正向关键词 → positive ≈ 0.70, neutral 0.20, negative 0.10
+    - 含负向关键词 → negative ≈ 0.70, neutral 0.20, positive 0.10
+    - 两边都有或都没 → neutral ≈ 0.60, 其余各 0.20
+    confidence = max 三项。
+    """
+    has_pos = bool(_MOCK_POS_PATTERN.search(text))
+    has_neg = bool(_MOCK_NEG_PATTERN.search(text))
+    if has_pos and not has_neg:
+        probs = {"positive": 0.70, "negative": 0.10, "neutral": 0.20}
+    elif has_neg and not has_pos:
+        probs = {"positive": 0.10, "negative": 0.70, "neutral": 0.20}
+    else:
+        probs = {"positive": 0.20, "negative": 0.20, "neutral": 0.60}
+    probs["confidence"] = max(probs.values())
+    return probs
+
+
+__all__ = [
+    "FinBERTScorer",
+    "get_default_scorer",
+    "reset_default_scorer",
+]

--- a/src/stockbee/small_models/fine5_scorer.py
+++ b/src/stockbee/small_models/fine5_scorer.py
@@ -1,0 +1,294 @@
+"""Fin-E5 Embedding Scorer — 加载 + batch encode + cosine 去重。
+
+决策 (见 spec.md):
+- Fin-E5 本 room scope 降级为 embedding infra + 去重 + rule baseline importance;
+  精确 importance fine-tune 推迟到 04-alpha-mining
+- HF 无 canonical `fin-e5`,用 `intfloat/e5-large-v2` 作 fallback (hidden_size=1024)
+- embedding_dim 从 model.config.hidden_size 动态读,不硬编码
+- cosine_dedup 语义 = union-find 传递闭包 (A~B, B~C → A/B/C 同 cluster)
+
+E5 模型输入惯例可加 "passage: " 前缀,本 scorer 不自动加;调用方自选一致即可
+(同批文本同样处理,cosine 距离相对可比)。
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MODEL = "intfloat/e5-large-v2"
+_DEFAULT_MAX_LENGTH = 512
+_DEFAULT_BATCH = 16
+
+
+class FinE5Scorer:
+    """Fin-E5 / E5-large-v2 encoder。
+
+    用法::
+
+        scorer = FinE5Scorer()              # 自动 device
+        emb = scorer.encode(["news1", "news2"])   # shape (2, hidden_size)
+        sim = scorer.cosine_sim(emb)              # (2, 2) 对称矩阵
+        keep = scorer.cosine_dedup(emb, 0.95)     # list[int] 去重后索引
+    """
+
+    def __init__(
+        self,
+        device: str | None = None,
+        model_name: str = _DEFAULT_MODEL,
+    ) -> None:
+        self._model_name = model_name
+        self._device_arg = device
+        self._mock = (device == "mock")
+        self._model: Any = None
+        self._tokenizer: Any = None
+        self._torch: Any = None
+        self._resolved_device: str | None = "mock" if self._mock else None
+        self._hidden_size: int | None = None
+        self._load_lock = threading.Lock()
+
+    def __repr__(self) -> str:
+        loaded = self._model is not None or self._mock
+        return (
+            f"FinE5Scorer(model={self._model_name!r}, "
+            f"device={self._resolved_device or 'unloaded'!r}, loaded={loaded})"
+        )
+
+    @property
+    def device(self) -> str | None:
+        return self._resolved_device
+
+    @property
+    def embedding_dim(self) -> int:
+        """hidden_size。lazy-load 前对 mock 返回 1024,对真实模型触发加载。"""
+        if self._mock:
+            return self._hidden_size or 1024
+        self._ensure_loaded()
+        assert self._hidden_size is not None
+        return self._hidden_size
+
+    def encode(
+        self,
+        texts: list[str],
+        batch_size: int = _DEFAULT_BATCH,
+        max_length: int = _DEFAULT_MAX_LENGTH,
+    ) -> np.ndarray:
+        """将文本编码为 L2-normalized embedding 矩阵。
+
+        Args:
+            texts: list[str]
+            batch_size: 默认 16
+            max_length: 默认 512
+
+        Returns:
+            np.ndarray shape (N, hidden_size), dtype float32, 每行 L2 范数 ≈ 1
+        """
+        if not isinstance(texts, list):
+            raise TypeError(f"texts must be list[str], got {type(texts).__name__}")
+        if not all(isinstance(t, str) for t in texts):
+            raise TypeError("texts must be list[str]; found non-str element")
+        if batch_size < 1:
+            raise ValueError(f"batch_size must be >= 1, got {batch_size}")
+        if max_length < 1:
+            raise ValueError(f"max_length must be >= 1, got {max_length}")
+
+        if not texts:
+            dim = self.embedding_dim if self._mock or self._model else 1
+            return np.zeros((0, dim), dtype=np.float32)
+
+        if self._mock:
+            return _mock_encode(texts, self._hidden_size or 1024)
+
+        self._ensure_loaded()
+        out_batches: list[np.ndarray] = []
+        for start in range(0, len(texts), batch_size):
+            batch = texts[start : start + batch_size]
+            out_batches.append(self._encode_batch(batch, max_length))
+        emb = np.vstack(out_batches).astype(np.float32)
+        return _l2_normalize(emb)
+
+    def cosine_sim(
+        self,
+        a: np.ndarray,
+        b: np.ndarray | None = None,
+    ) -> np.ndarray:
+        """余弦相似度矩阵。假设行已 L2 归一化 → 直接 a @ b.T。
+
+        Args:
+            a: (M, D)
+            b: (N, D) 或 None; None → 返回 (M, M) 对称矩阵
+
+        Returns:
+            np.ndarray shape (M, N)
+        """
+        if a.ndim != 2:
+            raise ValueError(f"a must be 2D, got shape {a.shape}")
+        a_n = _l2_normalize(a)
+        if b is None:
+            b_n = a_n
+        else:
+            if b.ndim != 2 or b.shape[1] != a.shape[1]:
+                raise ValueError(
+                    f"b shape {b.shape} incompatible with a shape {a.shape}"
+                )
+            b_n = _l2_normalize(b)
+        return a_n @ b_n.T
+
+    def cosine_dedup(
+        self,
+        embeds: np.ndarray,
+        threshold: float = 0.95,
+    ) -> list[int]:
+        """Union-find 去重。
+
+        对 i<j,若 cosine_sim(i,j) >= threshold 则 i,j 合并到同 cluster
+        (**传递闭包**: A~B, B~C → A/B/C 同组,即使 A-C 直接距离 < threshold)。
+
+        复杂度: O(N²) 时间 + 内存 (构造 N×N sim 矩阵),适合 N ≲ 数千 的批次。
+        更大规模去重请用 FAISS + blocking 策略 (本 room scope 不覆盖)。
+
+        Args:
+            embeds: (N, D) 行 L2 归一化 (非归一化也允许,内部重新算 cosine)
+            threshold: 合并阈值 ∈ [0, 1],默认 0.95 (相等也合并,使用 >=)
+
+        Returns:
+            list[int]: 去重后保留的行索引 (每 cluster 取最小下标作代表),升序返回
+        """
+        if embeds.ndim != 2:
+            raise ValueError(f"embeds must be 2D, got shape {embeds.shape}")
+        n = embeds.shape[0]
+        if n == 0:
+            return []
+        if not (0.0 <= threshold <= 1.0):
+            raise ValueError(f"threshold must be in [0, 1], got {threshold}")
+
+        sim = self.cosine_sim(embeds)
+        parent = list(range(n))
+
+        def find(x: int) -> int:
+            root = x
+            while parent[root] != root:
+                root = parent[root]
+            while parent[x] != root:  # 路径压缩
+                nxt = parent[x]
+                parent[x] = root
+                x = nxt
+            return root
+
+        def union(a: int, b: int) -> None:
+            ra, rb = find(a), find(b)
+            if ra == rb:
+                return
+            # 始终让较小索引做根,保证 "每 cluster 代表 = 最小下标"
+            if ra < rb:
+                parent[rb] = ra
+            else:
+                parent[ra] = rb
+
+        for i in range(n):
+            for j in range(i + 1, n):
+                if sim[i, j] >= threshold:
+                    union(i, j)
+
+        representatives = sorted({find(i) for i in range(n)})
+        return representatives
+
+    # ---- 内部 ----
+
+    def _ensure_loaded(self) -> None:
+        if self._model is not None:
+            return
+        with self._load_lock:
+            if self._model is not None:
+                return
+            try:
+                import torch
+                from transformers import AutoModel, AutoTokenizer
+            except ImportError as exc:  # pragma: no cover
+                raise RuntimeError(
+                    "FinE5Scorer requires transformers + torch. "
+                    "Install with `pip install transformers torch` "
+                    "or pass device='mock' for test-only fake encoding."
+                ) from exc
+
+            self._torch = torch
+            device = _resolve_device(torch, self._device_arg)
+            logger.info(
+                "Loading Fin-E5: model=%s device=%s", self._model_name, device
+            )
+            tokenizer = AutoTokenizer.from_pretrained(self._model_name)
+            model = AutoModel.from_pretrained(self._model_name)
+            model.to(device)
+            model.eval()
+
+            self._tokenizer = tokenizer
+            self._model = model
+            self._resolved_device = device
+            self._hidden_size = int(model.config.hidden_size)
+
+    def _encode_batch(self, batch: list[str], max_length: int) -> np.ndarray:
+        torch = self._torch
+        tok = self._tokenizer(
+            batch,
+            padding=True,
+            truncation=True,
+            max_length=max_length,
+            return_tensors="pt",
+        )
+        tok = {k: v.to(self._resolved_device) for k, v in tok.items()}
+        with torch.no_grad():
+            out = self._model(**tok)
+        # mean-pool with attention mask
+        last_hidden = out.last_hidden_state  # (B, L, H)
+        mask = tok["attention_mask"].unsqueeze(-1).float()  # (B, L, 1)
+        summed = (last_hidden * mask).sum(dim=1)  # (B, H)
+        counts = mask.sum(dim=1).clamp(min=1e-9)  # (B, 1)
+        pooled = summed / counts  # (B, H)
+        return pooled.cpu().numpy()
+
+
+# ---- 模块级辅助 ----
+
+
+def _resolve_device(torch_mod: Any, device_arg: str | None) -> str:
+    if device_arg in ("cpu", "cuda", "mps"):
+        return device_arg
+    if device_arg is None:
+        if torch_mod.cuda.is_available():
+            return "cuda"
+        mps = getattr(torch_mod.backends, "mps", None)
+        if mps is not None and mps.is_available():
+            return "mps"
+        return "cpu"
+    raise ValueError(
+        f"Invalid device {device_arg!r}; expected None/'cpu'/'cuda'/'mps'/'mock'"
+    )
+
+
+def _l2_normalize(x: np.ndarray) -> np.ndarray:
+    norms = np.linalg.norm(x, axis=1, keepdims=True)
+    # < 1e-12 兜底 denormal,避免 float32 近零除法产出 inf
+    norms = np.where(norms < 1e-12, 1.0, norms)
+    return (x / norms).astype(np.float32)
+
+
+def _mock_encode(texts: list[str], dim: int) -> np.ndarray:
+    """确定性哈希 → 随机向量 → L2 归一化。
+
+    同文本返回同向量;不同文本几乎正交 (dim=1024 下 cosine ~ 0)。
+    测试 cosine_dedup 传递闭包需要手工构造相似向量,不走 _mock_encode。
+    """
+    out = np.zeros((len(texts), dim), dtype=np.float32)
+    for i, t in enumerate(texts):
+        rng = np.random.default_rng(hash(t) & 0xFFFF_FFFF)
+        v = rng.standard_normal(dim).astype(np.float32)
+        out[i] = v
+    return _l2_normalize(out)
+
+
+__all__ = ["FinE5Scorer"]

--- a/src/stockbee/small_models/fine5_scorer.py
+++ b/src/stockbee/small_models/fine5_scorer.py
@@ -98,7 +98,11 @@ class FinE5Scorer:
             raise ValueError(f"max_length must be >= 1, got {max_length}")
 
         if not texts:
-            dim = self.embedding_dim if self._mock or self._model else 1
+            # review L1: 空输入短路,但返回形状必须与后续真实 encode 一致 ——
+            # 此前未加载阶段返回 (0, 1),真实模型加载后变 (0, hidden_size),
+            # 让 shape 依赖调用顺序,调试困难。此处统一用缓存的 _hidden_size,
+            # 未缓存则回退到默认模型 (e5-large-v2 = 1024),不触发 load。
+            dim = self._hidden_size if self._hidden_size is not None else 1024
             return np.zeros((0, dim), dtype=np.float32)
 
         if self._mock:

--- a/src/stockbee/small_models/importance_baseline.py
+++ b/src/stockbee/small_models/importance_baseline.py
@@ -1,0 +1,200 @@
+"""Rule-baseline importance 评分 + SQLite 回写。
+
+决策 (见 spec.md):
+- Fin-E5 fine-tune importance 推迟到 04-alpha-mining;本 room 只交付 baseline 公式
+- 公式: min(count_30d/10, 1.0) × |sentiment_score - 0.5| × 2 × clip(reliability, 0, 1)
+  * count_30d 单调饱和: 10 条以上新闻 per ticker-30d 已足够 → factor=1
+  * |sentiment - 0.5| × 2: 情绪越极端越重要 ([0, 1])
+  * reliability clip: 来源信任度 ([0, 1])
+- 值域: [0, 1]
+- 回写目标列: fine5_importance (m1 schema 预留);不动 g2 写的 importance_score
+
+count_30d = 该新闻时间窗内 (t-30d, t) 与本条新闻至少共享一个 ticker 的其它新闻数。
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+_REQUIRED_COLS = ("count_30d", "sentiment_score", "reliability_score")
+_COUNT_SATURATION = 10
+DEFAULT_COUNT_WINDOW_DAYS = 30
+
+
+def baseline_importance(news_df: pd.DataFrame) -> pd.Series:
+    """对 news DataFrame 批量计算 baseline importance。
+
+    Args:
+        news_df: 含 count_30d / sentiment_score / reliability_score 三列
+
+    Returns:
+        pd.Series,值域 [0, 1],索引同 news_df。NaN 输入 → NaN 输出 (不 raise)。
+    """
+    missing = [c for c in _REQUIRED_COLS if c not in news_df.columns]
+    if missing:
+        raise ValueError(
+            f"news_df 缺列: {missing}; 需要 {list(_REQUIRED_COLS)}"
+        )
+
+    count = news_df["count_30d"].astype("float64")
+    sentiment = news_df["sentiment_score"].astype("float64")
+    reliability = news_df["reliability_score"].astype("float64")
+
+    count_factor = np.minimum(count / _COUNT_SATURATION, 1.0)
+    sentiment_factor = np.abs(sentiment - 0.5) * 2.0
+    reliability_factor = np.clip(reliability, 0.0, 1.0)
+    score = count_factor * sentiment_factor * reliability_factor
+    out = pd.Series(score, index=news_df.index, name="fine5_importance")
+    out = out.clip(lower=0.0, upper=1.0)  # 防止浮点误差越界
+    return out
+
+
+def backfill_importance(
+    news_store: Any,
+    since: pd.Timestamp | str | None = None,
+    batch: int = 1000,
+    window_days: int = DEFAULT_COUNT_WINDOW_DAYS,
+) -> int:
+    """对 news_events 中 fine5_importance IS NULL 的行批量计算并回写 baseline。
+
+    只更新 NULL 行,不覆盖任何已有非空值 (幂等)。需要 sentiment_score / reliability_score
+    存在 (NULL 行跳过);count_30d 由 SQL 按 ticker 联表聚合。
+
+    Args:
+        news_store: SqliteNewsProvider 实例,已 initialize (内部 _conn 可用)
+        since: 仅处理 timestamp >= since 的行;None = 全量
+        batch: 单次 UPDATE 的最大行数
+        window_days: count_30d 的窗口长度 (默认 30)
+
+    Returns:
+        实际写入的行数 (=被更新的 id 数)。
+    """
+    if batch < 1:
+        raise ValueError(f"batch must be >= 1, got {batch}")
+    if window_days < 1:
+        raise ValueError(f"window_days must be >= 1, got {window_days}")
+
+    conn = getattr(news_store, "_conn", None)
+    if conn is None:
+        raise RuntimeError(
+            "news_store._conn is None; 请先 news_store.initialize()"
+        )
+
+    # 1. 拉取待 backfill 的 candidate
+    where_since = ""
+    params: list[Any] = []
+    if since is not None:
+        where_since = " AND e.timestamp >= ?"
+        params.append(_normalize_since(since))
+    sql = f"""
+        SELECT e.id, e.timestamp, e.sentiment_score, e.reliability_score
+        FROM news_events e
+        WHERE e.fine5_importance IS NULL
+              AND e.sentiment_score IS NOT NULL
+              AND e.reliability_score IS NOT NULL
+              {where_since}
+        ORDER BY e.timestamp
+        LIMIT ?
+    """
+    params.append(batch)
+    rows = conn.execute(sql, params).fetchall()
+    if not rows:
+        return 0
+
+    # 2. 每行算 count_30d: 与本条共享至少一个 ticker, timestamp ∈ [t-window, t) 的其它 news
+    #    使用 correlated subquery,避免一次性拉全库
+    ids = [r[0] for r in rows]
+    counts: dict[int, int] = {}
+    for row_id, ts, _sent, _rel in rows:
+        if not ts:
+            logger.warning("backfill: row_id=%s 缺 timestamp,count_30d=0", row_id)
+            counts[row_id] = 0
+            continue
+        try:
+            t_end = pd.Timestamp(ts)
+        except (ValueError, TypeError):
+            logger.warning(
+                "backfill: row_id=%s timestamp=%r 无法解析,count_30d=0",
+                row_id,
+                ts,
+            )
+            counts[row_id] = 0
+            continue
+        t_start = (t_end - timedelta(days=window_days)).isoformat()
+        cnt_sql = """
+            SELECT COUNT(DISTINCT e2.id)
+            FROM news_events e2
+            JOIN news_tickers nt2 ON nt2.news_id = e2.id
+            WHERE e2.id != ?
+              AND e2.timestamp >= ?
+              AND e2.timestamp < ?
+              AND nt2.ticker IN (
+                  SELECT nt.ticker FROM news_tickers nt WHERE nt.news_id = ?
+              )
+        """
+        cnt = conn.execute(
+            cnt_sql, (row_id, t_start, t_end.isoformat(), row_id)
+        ).fetchone()
+        counts[row_id] = int(cnt[0]) if cnt and cnt[0] is not None else 0
+
+    # 3. 组装 DataFrame → 公式
+    df = pd.DataFrame(
+        {
+            "id": ids,
+            "count_30d": [counts.get(i, 0) for i in ids],
+            "sentiment_score": [r[2] for r in rows],
+            "reliability_score": [r[3] for r in rows],
+        }
+    )
+    df["fine5_importance"] = baseline_importance(df).to_numpy()
+
+    # 4. 回写 (同批次一个 transaction)
+    updated = 0
+    with news_store._cursor() as cur:
+        for _, rr in df.iterrows():
+            if pd.isna(rr["fine5_importance"]):
+                continue
+            cur.execute(
+                "UPDATE news_events SET fine5_importance = ? "
+                "WHERE id = ? AND fine5_importance IS NULL",
+                (float(rr["fine5_importance"]), int(rr["id"])),
+            )
+            updated += cur.rowcount
+    logger.info(
+        "baseline_importance backfill: %d candidates, %d updated "
+        "(window=%d days)",
+        len(rows),
+        updated,
+        window_days,
+    )
+    return updated
+
+
+def _normalize_since(since: Any) -> str:
+    """归一化 since → UTC ISO 8601。
+
+    review H1: DB 里 timestamp 统一 +00:00,非 UTC 时区的输入经 tz_convert 转成
+    +00:00 才能和 DB 字符串做字典序比较。
+    """
+    from datetime import timezone
+
+    ts = pd.Timestamp(since)
+    if ts.tz is None:
+        ts = ts.tz_localize(timezone.utc)
+    else:
+        ts = ts.tz_convert(timezone.utc)
+    return ts.isoformat()
+
+
+__all__ = [
+    "DEFAULT_COUNT_WINDOW_DAYS",
+    "backfill_importance",
+    "baseline_importance",
+]

--- a/src/stockbee/small_models/label_utils.py
+++ b/src/stockbee/small_models/label_utils.py
@@ -1,0 +1,95 @@
+"""LightGBM 训练标签工具。
+
+B3 决策: label = mean(next_horizon_days_daily_returns)
+  daily_ret[t] = (adj_close[t] - adj_close[t-1]) / adj_close[t-1]
+  label[t] = mean(daily_ret[t+1], ..., daily_ret[t+horizon])
+
+尾部 horizon 天无 label (NaN),训练前 drop。
+
+决策来源: spec.md Decisions 表 B3 (2026-04-13)。
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+DEFAULT_HORIZON = 5
+LABEL_NAME = "label_fwd_5d"
+
+
+def forward_return_5d(
+    prices: pd.Series | pd.DataFrame,
+    horizon: int = DEFAULT_HORIZON,
+) -> pd.Series:
+    """对 MultiIndex(date, ticker) 价格序列计算 B3 forward-return label。
+
+    Args:
+        prices: Series (MultiIndex date, ticker) 或 DataFrame (含 "adj_close" 列,
+                同样的 MultiIndex)
+        horizon: 前瞻天数,默认 5
+
+    Returns:
+        pd.Series,与输入同 MultiIndex,尾部最后 horizon 行按 ticker 为 NaN。
+        名字 = LABEL_NAME ("label_fwd_5d")。
+
+    Raises:
+        TypeError: prices 既不是 Series 也不是 DataFrame
+        ValueError: horizon < 1,或 prices 缺 MultiIndex (date, ticker),
+                    或 DataFrame 缺 "adj_close" 列
+
+    实现 (B3 公式):
+        daily_ret = prices.groupby("ticker").pct_change()
+        label = (daily_ret
+                  .groupby("ticker")
+                  .transform(lambda r: r.shift(-1).rolling(horizon).mean().shift(-(horizon-1))))
+        # 等价: [t+1, t+horizon] horizon 天日收益率均值
+    """
+    if horizon < 1:
+        raise ValueError(f"horizon must be >= 1, got {horizon}")
+
+    series = _extract_adj_close(prices)
+    _validate_multiindex(series.index)
+
+    # sort_index 保证 groupby(level='ticker') 内部按日期升序
+    series = series.sort_index()
+
+    daily_ret = series.groupby(level="ticker", group_keys=False).pct_change()
+    label = daily_ret.groupby(level="ticker", group_keys=False).transform(
+        lambda ret: ret.shift(-1).rolling(horizon).mean().shift(-(horizon - 1))
+    )
+    label.name = LABEL_NAME
+    return label
+
+
+# ---- 内部辅助 ----
+
+
+def _extract_adj_close(prices: pd.Series | pd.DataFrame) -> pd.Series:
+    if isinstance(prices, pd.Series):
+        return prices.astype("float64")
+    if isinstance(prices, pd.DataFrame):
+        if "adj_close" not in prices.columns:
+            raise ValueError(
+                "DataFrame 必须含 'adj_close' 列 (找到列: "
+                f"{list(prices.columns)})"
+            )
+        return prices["adj_close"].astype("float64")
+    raise TypeError(
+        f"prices 须为 Series 或 DataFrame, 实得 {type(prices).__name__}"
+    )
+
+
+def _validate_multiindex(idx: pd.Index) -> None:
+    if not isinstance(idx, pd.MultiIndex):
+        raise ValueError(
+            "prices 索引须为 MultiIndex(date, ticker), "
+            f"实得 {type(idx).__name__}"
+        )
+    names = [n for n in idx.names]
+    if "ticker" not in names:
+        raise ValueError(
+            f"MultiIndex 须包含 'ticker' level, 实得 names={names}"
+        )
+
+
+__all__ = ["DEFAULT_HORIZON", "LABEL_NAME", "forward_return_5d"]

--- a/src/stockbee/small_models/lightgbm_scorer.py
+++ b/src/stockbee/small_models/lightgbm_scorer.py
@@ -1,0 +1,252 @@
+"""LightGBM 推理 + ml_score Parquet 落盘 + evaluate_ml_score。
+
+决策:
+- m4 推理路径: load_pickle("lightgbm", version) → Booster → 批预测 →
+  写 data/factors/ml_score.parquet (group="ml_score", ParquetFactorStore)
+- LocalFactorProvider._build_precomputed_index 已泛化,ml_score 自动发现,
+  m4 对 factor-storage 代码零改动
+- D2: evaluate_ml_score(shift=5) 独立函数,不改 get_ic_report(shift=1 硬编码)
+- 性能约束: 1000 rows × 158 cols 推理 <50ms GPU / <150ms CPU (@pytest.mark.perf)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from stockbee.factor_data.ic_evaluator import compute as compute_ic
+from stockbee.factor_data.parquet_factor import ParquetFactorStore
+
+from .lightgbm_trainer import MODEL_NAME
+from .model_io import load_pickle
+from .paths import ML_SCORE_PARQUET
+
+logger = logging.getLogger(__name__)
+
+ML_SCORE_GROUP = "ml_score"
+ML_SCORE_COLUMN = "ml_score"
+# 交易日 → 日历日保守换算, 与 factor_data.local_provider 一致
+_CALENDAR_MULTIPLIER = 2
+
+
+class LightGBMScorer:
+    """LightGBM artifact 加载 + 批推理 + Parquet 落盘。
+
+    Args:
+        version: 传给 m1 model_io.load_pickle; 默认 "current" 读 symlink
+        booster: 直接注入已加载 booster (单测复用,跳过 pickle 反序列化)
+
+    使用::
+
+        s = LightGBMScorer()                    # 加载 data/models/lightgbm/current.pkl
+        s.predict(factor_df)                    # pd.Series, name="ml_score"
+        s.predict_and_save(factor_provider, tickers, start, end)  # Path
+    """
+
+    def __init__(
+        self,
+        version: str = "current",
+        booster: Any = None,
+    ) -> None:
+        self._version = version
+        self._booster = booster
+        if booster is None:
+            self._booster = load_pickle(MODEL_NAME, version=version)
+        self._feature_names: list[str] = list(
+            self._booster.feature_name() or []
+        )
+
+    @property
+    def booster(self) -> Any:
+        return self._booster
+
+    @property
+    def version(self) -> str:
+        return self._version
+
+    @property
+    def feature_names(self) -> list[str]:
+        return list(self._feature_names)
+
+    def predict(self, factor_df: pd.DataFrame) -> pd.Series:
+        """对 factor_df 做预测。
+
+        Args:
+            factor_df: MultiIndex(date, ticker) × feature 列;列序由 booster
+                       feature_name 自动对齐 (严格按 booster 顺序取子集)
+
+        Returns:
+            pd.Series, 同 X_df MultiIndex, dtype float, name="ml_score"。
+            全特征 NaN 的行 → NaN (review C1: 统一 mock/real 语义;LightGBM
+            Booster 原生会把 all-NaN 当 missing 返回非 NaN,本层显式 mask 保证
+            "无特征 → 无预测" 的可组合语义)。
+        """
+        if factor_df is None:
+            raise ValueError("factor_df is None")
+        _validate_multiindex(factor_df)
+        if factor_df.empty:
+            raise ValueError("factor_df 为空")
+
+        if not self._feature_names:
+            # review H2: booster 无 feature_name 则缺失列序锚点,强制报错
+            raise ValueError(
+                "booster 无 feature_name(), 无法做列对齐; "
+                "请用 m3 训练产物或在构造时显式注入 feature_names"
+            )
+        missing = [c for c in self._feature_names if c not in factor_df.columns]
+        if missing:
+            truncated = missing[:10]
+            raise ValueError(
+                f"factor_df 缺 booster 需要的特征列: {truncated}"
+                + (f" ... ({len(missing)} total)" if len(missing) > 10 else "")
+            )
+        X_df = factor_df[self._feature_names]
+
+        # review C1: 显式 mask all-NaN 行,保证输出 NaN 与 docstring 一致
+        all_nan_mask = X_df.isna().all(axis=1)
+        preds = self._booster.predict(X_df.fillna(0.0).to_numpy())
+        preds = np.asarray(preds, dtype=float)
+        if all_nan_mask.any():
+            preds[all_nan_mask.to_numpy()] = float("nan")
+        out = pd.Series(preds, index=X_df.index, dtype=float, name=ML_SCORE_COLUMN)
+        return out
+
+    def predict_and_save(
+        self,
+        factor_provider: Any,
+        tickers: list[str],
+        start: date,
+        end: date,
+        factor_names: list[str] | None = None,
+        store: ParquetFactorStore | None = None,
+    ) -> Path:
+        """Pull factors → predict → merge-write data/factors/ml_score.parquet。
+
+        Args:
+            factor_provider: FactorProvider 实例
+            tickers / start / end: 传 factor_provider.get_factors
+            factor_names: 特征列表, 默认 = booster.feature_name()
+            store: 注入 ParquetFactorStore (测试用); 默认指向 ML_SCORE_PARQUET 父目录
+
+        Returns:
+            落盘 parquet 文件路径
+        """
+        if not tickers:
+            raise ValueError("tickers 不能为空")
+        if factor_names is None:
+            if not self._feature_names:
+                raise ValueError(
+                    "booster 无 feature_name, 必须显式传 factor_names"
+                )
+            factor_names = self._feature_names
+
+        factor_df = factor_provider.get_factors(tickers, factor_names, start, end)
+        if factor_df is None or factor_df.empty:
+            raise ValueError(
+                f"factor_provider.get_factors 返回空 (tickers={tickers}, "
+                f"start={start}, end={end})"
+            )
+        preds = self.predict(factor_df).dropna()
+        if preds.empty:
+            raise ValueError("预测结果全为 NaN,不落盘")
+
+        df = preds.to_frame()
+        if store is None:
+            store = ParquetFactorStore(data_path=ML_SCORE_PARQUET.parent)
+        store.write_factors(ML_SCORE_GROUP, df)
+
+        # review H1: 不再比较 Path 相等性 (绝对/相对路径语义差异);
+        # 直接用 store 的 data_path 拼接 group 文件名,保证与 ParquetFactorStore
+        # 内部的 _group_path() 一致
+        out_path = store._data_path / f"{ML_SCORE_GROUP}.parquet"
+        logger.info(
+            "LightGBMScorer.predict_and_save: %d rows → %s", len(df), out_path
+        )
+        return out_path
+
+
+# ---- D2: 独立 IC 评估 ----
+
+
+def evaluate_ml_score(
+    factor_provider: Any,
+    market_data_provider: Any,
+    universe: list[str],
+    start: date,
+    end: date,
+    shift: int = 5,
+    window: int = 252,
+) -> dict[str, float]:
+    """对 ml_score 因子计算 IC / ICIR (D2 决策: 独立于 get_ic_report,不改 factor-storage)。
+
+    Args:
+        factor_provider: FactorProvider 实例 (读 ml_score)
+        market_data_provider: MarketDataProvider 实例 (读 OHLCV adj_close)
+        universe: 股票代码列表 (非空)
+        start / end: 日期范围
+        shift: 前向收益天数,默认 5 (B3 label horizon)
+        window: IC 汇总窗口,默认 252
+
+    Returns:
+        dict(ic_mean, ic_std, icir)
+
+    Raises:
+        ValueError: universe 为空 / 无 ml_score 因子 / prices 缺 adj_close
+    """
+    if not universe:
+        raise ValueError("universe 不能为空")
+    if shift < 1:
+        raise ValueError(f"shift must be >= 1, got {shift}")
+
+    factor_df = factor_provider.get_factors(
+        universe, [ML_SCORE_COLUMN], start, end
+    )
+    if factor_df is None or factor_df.empty:
+        raise ValueError(
+            f"factor_provider 未返回 ml_score 数据 "
+            f"(universe={universe}, range={start}..{end})"
+        )
+    if ML_SCORE_COLUMN not in factor_df.columns:
+        raise ValueError(
+            f"factor_provider 返回列缺 {ML_SCORE_COLUMN!r}: "
+            f"{list(factor_df.columns)}"
+        )
+
+    prices = market_data_provider.get_daily_bars(
+        universe,
+        start,
+        end + timedelta(days=shift * _CALENDAR_MULTIPLIER),
+    )
+    return compute_ic(
+        factor_df[[ML_SCORE_COLUMN]],
+        prices,
+        shift=shift,
+        window=window,
+    )
+
+
+# ---- 内部 ----
+
+
+def _validate_multiindex(df: pd.DataFrame) -> None:
+    if not isinstance(df.index, pd.MultiIndex):
+        raise ValueError(
+            f"factor_df 须 MultiIndex(date, ticker), 实得 {type(df.index).__name__}"
+        )
+    if set(df.index.names) < {"date", "ticker"}:
+        raise ValueError(
+            f"MultiIndex 须含 date+ticker, 实得 names={df.index.names}"
+        )
+
+
+__all__ = [
+    "LightGBMScorer",
+    "ML_SCORE_COLUMN",
+    "ML_SCORE_GROUP",
+    "evaluate_ml_score",
+]

--- a/src/stockbee/small_models/lightgbm_trainer.py
+++ b/src/stockbee/small_models/lightgbm_trainer.py
@@ -1,0 +1,286 @@
+"""LightGBM Trainer — Alpha158 × B3 label 训练 + artifact 落盘。
+
+Walk-forward 严格无前看切分 → train_lightgbm (drop NaN + valid split + early stop) →
+save_pickle 落 data/models/lightgbm/{version}.pkl → update_symlink 指向 current。
+
+决策:
+- B3: label = forward_return_5d(adj_close, horizon=5)
+- m1: save_pickle 默认 overwrite=False, 同版本再训需显式 overwrite=True
+- OQ4: 不自动 update_symlink,训练流程显式调用 (保留"先保存再评审再上线")
+- 本模块只依赖 FactorProvider + MarketDataProvider + lightgbm + m1 model_io;
+  与 m2a / m5 完全解耦
+
+训练产出的 booster 通过 save_pickle 持久化 lgb.Booster 对象本身。
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from pathlib import Path
+from typing import Any, Iterator
+
+import numpy as np
+import pandas as pd
+
+from .label_utils import LABEL_NAME, forward_return_5d
+from .model_io import save_pickle, update_symlink
+
+logger = logging.getLogger(__name__)
+
+MODEL_NAME = "lightgbm"
+
+DEFAULT_PARAMS: dict[str, Any] = {
+    "objective": "regression",
+    "metric": "rmse",
+    "learning_rate": 0.05,
+    "num_leaves": 31,
+    "max_depth": -1,
+    "min_data_in_leaf": 20,
+    "feature_fraction": 0.9,
+    "bagging_fraction": 0.8,
+    "bagging_freq": 5,
+    "verbose": -1,
+    "seed": 42,
+    "deterministic": True,
+    "force_col_wise": True,
+}
+
+_DEFAULT_NUM_ROUNDS = 500
+_DEFAULT_EARLY_STOP = 50
+_VALID_FRACTION = 0.2
+
+
+def walk_forward_splits(
+    dates: pd.DatetimeIndex | pd.Index,
+    train_size: int = 252,
+    test_size: int = 21,
+    step: int = 21,
+) -> Iterator[tuple[pd.DatetimeIndex, pd.DatetimeIndex]]:
+    """生成 walk-forward 训练/测试日期切分 (严格无前看)。
+
+    Args:
+        dates: 按升序排列的唯一日期序列 (DatetimeIndex 或类似)
+        train_size: 训练窗口天数
+        test_size: 测试窗口天数
+        step: 每次滑动天数
+
+    Yields:
+        (train_dates, test_dates) 各为 pd.DatetimeIndex,
+        train_dates.max() < test_dates.min() 严格成立。
+
+    Raises:
+        ValueError: 参数非正,或总长不够一个 train+test 窗
+    """
+    if train_size < 1 or test_size < 1 or step < 1:
+        raise ValueError(
+            f"train_size/test_size/step must be positive, "
+            f"got {train_size}/{test_size}/{step}"
+        )
+    unique = pd.DatetimeIndex(dates).unique().sort_values()
+    n = len(unique)
+    if n < train_size + test_size:
+        raise ValueError(
+            f"dates length {n} < train_size + test_size = {train_size + test_size}"
+        )
+
+    start = 0
+    while start + train_size + test_size <= n:
+        train_end = start + train_size
+        test_end = train_end + test_size
+        train_dates = unique[start:train_end]
+        test_dates = unique[train_end:test_end]
+        # 不变式: 严格无前看
+        assert train_dates.max() < test_dates.min()
+        yield train_dates, test_dates
+        start += step
+
+
+def train_lightgbm(
+    factor_df: pd.DataFrame,
+    label_sr: pd.Series,
+    params: dict[str, Any] | None = None,
+    num_rounds: int = _DEFAULT_NUM_ROUNDS,
+    early_stop: int = _DEFAULT_EARLY_STOP,
+) -> "Any":
+    """训练 LightGBM booster。
+
+    Args:
+        factor_df: MultiIndex(date, ticker) × feature 列
+        label_sr: MultiIndex(date, ticker), 与 factor_df 索引对齐
+        params: 覆盖 DEFAULT_PARAMS (浅合并)
+        num_rounds: 最大迭代轮数
+        early_stop: 在 valid set 上连续 n 轮无改进则停止
+
+    Returns:
+        lgb.Booster
+
+    流程:
+      1. inner-join factor_df 和 label_sr 索引
+      2. drop NaN 行 (任意特征或 label NaN)
+      3. 按时间顺序切 valid (最后 _VALID_FRACTION)
+      4. lgb.train + early_stopping
+    """
+    import lightgbm as lgb
+
+    if factor_df.empty:
+        raise ValueError("factor_df 为空")
+    if label_sr.empty:
+        raise ValueError("label_sr 为空")
+
+    merged = factor_df.join(label_sr.rename("_label"), how="inner")
+    if merged.empty:
+        # review H3: inner-join 为空 = 索引无交集,明确报错
+        raise ValueError(
+            "factor_df 和 label_sr 索引无交集; "
+            "检查 MultiIndex(date, ticker) 是否一致"
+        )
+    feature_cols = [c for c in merged.columns if c != "_label"]
+    if not feature_cols:
+        raise ValueError("factor_df 无特征列")
+
+    # drop 任一特征/label NaN
+    before_drop = len(merged)
+    clean = merged.dropna(subset=feature_cols + ["_label"])
+    after_drop = len(clean)
+    if clean.empty:
+        raise ValueError("drop NaN 后无样本可训")
+
+    # 按 (date, ticker) 全索引排序,保证同日 ticker 顺序在 pandas 版本间确定
+    clean = clean.sort_index()
+
+    # review H1: 按 **唯一日期** 切 train/valid,避免在 uneven panel (listings/delistings
+    # /suspensions) 上把同一天的部分 ticker 划到 train、部分划到 valid 产生日内 look-ahead
+    unique_dates = clean.index.get_level_values("date").unique().sort_values()
+    if len(unique_dates) < 2:
+        raise ValueError(
+            f"unique dates {len(unique_dates)} < 2, 无法切 train+valid"
+        )
+    split_idx = max(1, int(len(unique_dates) * (1 - _VALID_FRACTION)))
+    split_idx = min(split_idx, len(unique_dates) - 1)
+    split_date = unique_dates[split_idx]
+    dates_all = clean.index.get_level_values("date")
+    train_part = clean[dates_all < split_date]
+    valid_part = clean[dates_all >= split_date]
+    if train_part.empty or valid_part.empty:
+        raise ValueError(
+            f"样本 {after_drop} (unique dates {len(unique_dates)}) "
+            f"不足以切 train+valid"
+        )
+    logger.info(
+        "lgb split: %d rows before drop, %d after; "
+        "train=%d valid=%d (split_date=%s)",
+        before_drop,
+        after_drop,
+        len(train_part),
+        len(valid_part),
+        split_date,
+    )
+
+    X_train = train_part[feature_cols].to_numpy()
+    y_train = train_part["_label"].to_numpy()
+    X_valid = valid_part[feature_cols].to_numpy()
+    y_valid = valid_part["_label"].to_numpy()
+
+    merged_params = {**DEFAULT_PARAMS, **(params or {})}
+    train_ds = lgb.Dataset(X_train, label=y_train, feature_name=feature_cols)
+    valid_ds = lgb.Dataset(
+        X_valid, label=y_valid, reference=train_ds, feature_name=feature_cols
+    )
+    callbacks = [lgb.early_stopping(early_stop, verbose=False)]
+    booster = lgb.train(
+        merged_params,
+        train_ds,
+        num_boost_round=num_rounds,
+        valid_sets=[valid_ds],
+        valid_names=["valid"],
+        callbacks=callbacks,
+    )
+    logger.info(
+        "lgb trained: features=%d train=%d valid=%d best_iter=%d",
+        len(feature_cols),
+        len(train_part),
+        len(valid_part),
+        getattr(booster, "best_iteration", -1),
+    )
+    return booster
+
+
+def train_and_save(
+    factor_provider: Any,
+    market_data_provider: Any,
+    tickers: list[str],
+    start: date,
+    end: date,
+    factor_names: list[str] | None = None,
+    version: str | None = None,
+    params: dict[str, Any] | None = None,
+    num_rounds: int = _DEFAULT_NUM_ROUNDS,
+    early_stop: int = _DEFAULT_EARLY_STOP,
+    promote_current: bool = True,
+    overwrite: bool = False,
+) -> Path:
+    """端到端: 拉因子 + 行情 → 计算 label → 训练 → save_pickle → update_symlink。
+
+    Args:
+        factor_provider: FactorProvider 实例 (get_factors + list_factors)
+        market_data_provider: MarketDataProvider 实例 (get_daily_bars)
+        tickers: 股票代码列表
+        start / end: 日期范围 (需留足 horizon 尾部用于 label)
+        factor_names: 特征列表;None → factor_provider.list_factors() 过滤 type=expression
+        version: YYYYMMDD,None = today
+        params / num_rounds / early_stop: 传给 train_lightgbm
+        promote_current: 默认 True,训练完自动 update_symlink 把 current 指向本版本;
+                         False 保留"先保存再上线"流程 (OQ4)
+        overwrite: 默认 False,同版本已存在则 FileExistsError;调参重训需显式 True
+                   (review H2: 避免同日重训静默失败)
+
+    Returns:
+        版本化 artifact 路径 (如 data/models/lightgbm/20260420.pkl)
+    """
+    if not tickers:
+        raise ValueError("tickers 不能为空")
+
+    if factor_names is None:
+        listed = factor_provider.list_factors()
+        factor_names = [
+            e["name"] for e in listed if e.get("type") == "expression"
+        ]
+        if not factor_names:
+            raise ValueError(
+                "factor_names 未指定且 list_factors() 无 expression 因子"
+            )
+
+    factor_df = factor_provider.get_factors(tickers, factor_names, start, end)
+    bars = market_data_provider.get_daily_bars(tickers, start, end)
+    if "adj_close" not in bars.columns:
+        raise ValueError(
+            f"market_data_provider.get_daily_bars 缺 'adj_close' 列, "
+            f"实得 {list(bars.columns)}"
+        )
+    label = forward_return_5d(bars["adj_close"])
+    label.name = LABEL_NAME
+
+    booster = train_lightgbm(
+        factor_df,
+        label,
+        params=params,
+        num_rounds=num_rounds,
+        early_stop=early_stop,
+    )
+
+    artifact = save_pickle(booster, MODEL_NAME, version=version, overwrite=overwrite)
+    if promote_current:
+        version_resolved = artifact.stem
+        update_symlink(MODEL_NAME, version_resolved)
+    logger.info("lightgbm train_and_save: %s", artifact)
+    return artifact
+
+
+__all__ = [
+    "DEFAULT_PARAMS",
+    "MODEL_NAME",
+    "train_and_save",
+    "train_lightgbm",
+    "walk_forward_splits",
+]

--- a/src/stockbee/small_models/local_sentiment_provider.py
+++ b/src/stockbee/small_models/local_sentiment_provider.py
@@ -1,0 +1,293 @@
+"""LocalSentimentProvider — 实现 providers.SentimentProvider 契约。
+
+核心功能:
+- score_texts: 透传 m2a FinBERTScorer singleton (共享推理, 消除重复)
+- get_ticker_sentiment: SQLite 查询 + confidence-weighted 均值 (见 spec.md "加权公式")
+- backfill: 读 fine5_importance 那一批类似的方式 - 本 provider 补齐缺失的
+  finbert_negative/neutral/confidence, 但**不触** sentiment_score (g2 已写)
+
+决策:
+- P3 共享 FinBERTScorer singleton: g2_classifier 和本 provider 跑同一个权重副本
+- 加权公式: Σ(conf_i × prob_i) / Σ conf_i, 权重 = finbert_confidence
+- Σ conf = 0 → 返回 zeros + count=0, 不 raise (PRD 可用性约束)
+- backfill 只处理 finbert_confidence IS NULL 的行, 旧数据兼容
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from stockbee.providers.base import ProviderConfig
+from stockbee.providers.interfaces import SentimentProvider
+
+from .finbert_scorer import FinBERTScorer, get_default_scorer
+
+logger = logging.getLogger(__name__)
+
+_ZERO_SENTIMENT: dict[str, float] = {
+    "positive": 0.0,
+    "negative": 0.0,
+    "neutral": 0.0,
+    "confidence": 0.0,
+    "count": 0.0,
+}
+
+
+class LocalSentimentProvider(SentimentProvider):
+    """本地 FinBERT 情绪 Provider。
+
+    依赖注入:
+        scorer:     m2a FinBERTScorer, 默认 get_default_scorer() singleton
+        news_store: 已 initialize 的 SqliteNewsProvider (get_ticker_sentiment /
+                    backfill 需要)
+
+    使用::
+
+        provider = LocalSentimentProvider(news_store=store)
+        provider.initialize()
+        provider.score_texts(["company beats earnings"])
+        provider.get_ticker_sentiment("AAPL", lookback_days=7)
+        n = provider.backfill(limit=1000)
+    """
+
+    def __init__(
+        self,
+        config: ProviderConfig | None = None,
+        scorer: FinBERTScorer | None = None,
+        news_store: Any | None = None,
+    ) -> None:
+        super().__init__(config)
+        self._scorer = scorer
+        self._news_store = news_store
+
+    # ------ 生命周期 ------
+
+    def _do_initialize(self) -> None:
+        if self._scorer is None:
+            self._scorer = get_default_scorer()
+        if self._news_store is not None and not getattr(
+            self._news_store, "is_initialized", False
+        ):
+            self._news_store.initialize()
+
+    def _do_shutdown(self) -> None:
+        # scorer 是 singleton,不在此关闭
+        # news_store 生命周期由注入方管理
+        self._scorer = None
+
+    # ------ SentimentProvider 接口 ------
+
+    def score_texts(self, texts: list[str]) -> list[dict[str, float]]:
+        """透传到 m2a FinBERTScorer。"""
+        self._require_initialized()
+        return self._scorer.score_texts(texts)
+
+    def get_ticker_sentiment(
+        self, ticker: str, lookback_days: int = 7
+    ) -> dict[str, float]:
+        """取 ticker 近期 (confidence-weighted) 情绪聚合。
+
+        公式: agg_prob = Σ(conf_i × prob_i) / Σ conf_i,权重 = finbert_confidence
+
+        返回键: positive / negative / neutral / confidence / count
+        无匹配或 Σconf=0 → 全零 + count=0 (不 raise)。
+        """
+        self._require_news_store()
+        if not ticker or not isinstance(ticker, str):
+            raise ValueError(f"ticker must be non-empty str, got {ticker!r}")
+        if lookback_days < 0:
+            raise ValueError(f"lookback_days must be >= 0, got {lookback_days}")
+
+        end_ts = datetime.now(timezone.utc)
+        start_ts = end_ts - timedelta(days=lookback_days)
+        rows = self._news_store._conn.execute(
+            """
+            SELECT DISTINCT e.id, e.sentiment_score, e.finbert_negative,
+                   e.finbert_neutral, e.finbert_confidence
+            FROM news_events e
+            JOIN news_tickers nt ON nt.news_id = e.id
+            WHERE nt.ticker = ?
+              AND e.timestamp >= ?
+              AND e.timestamp <= ?
+              AND e.finbert_confidence IS NOT NULL
+            """,
+            (ticker.upper(), start_ts.isoformat(), end_ts.isoformat()),
+        ).fetchall()
+        if not rows:
+            return dict(_ZERO_SENTIMENT)
+
+        sum_conf = 0.0
+        weighted = {"positive": 0.0, "negative": 0.0, "neutral": 0.0}
+        count = 0
+        skipped_partial = 0
+        for _id, pos, neg, neu, conf in rows:
+            if any(v is None or (isinstance(v, float) and math.isnan(v)) for v in (pos, neg, neu, conf)):
+                # review H5: 部分 NULL 行静默跳过,计数后调试可见
+                skipped_partial += 1
+                continue
+            c = float(conf)
+            if c <= 0.0:
+                continue
+            sum_conf += c
+            weighted["positive"] += c * float(pos)
+            weighted["negative"] += c * float(neg)
+            weighted["neutral"] += c * float(neu)
+            count += 1
+        if skipped_partial:
+            logger.debug(
+                "get_ticker_sentiment(%s): skipped %d rows with partial NULL",
+                ticker,
+                skipped_partial,
+            )
+        if sum_conf == 0.0 or count == 0:
+            return dict(_ZERO_SENTIMENT)
+        out = {k: v / sum_conf for k, v in weighted.items()}
+        # review H1 / M1: confidence = max 聚合概率 (与 FinBERTScorer 单行 confidence
+        # = max 三项 softmax 的语义对齐),便于下游当"置信度"使用
+        out["confidence"] = max(out["positive"], out["negative"], out["neutral"])
+        out["count"] = float(count)
+        return out
+
+    # ------ Backfill ------
+
+    def backfill(
+        self,
+        since: str | datetime | None = None,
+        limit: int = 1000,
+    ) -> int:
+        """补齐 finbert_confidence IS NULL 的行; 批量 scorer.score_texts 后 UPDATE。
+
+        Args:
+            since: 仅处理 timestamp >= since 的行 (None = 全量)
+            limit: 单次 LIMIT 上限 (分页调用时传不同值)
+
+        Returns:
+            实际写入的行数。**不修改** sentiment_score (g2 所有)。
+        """
+        self._require_initialized()
+        self._require_news_store()
+        if limit < 1:
+            raise ValueError(f"limit must be >= 1, got {limit}")
+
+        conn = self._news_store._conn
+        where_since = ""
+        params: list[Any] = []
+        if since is not None:
+            where_since = " AND timestamp >= ?"
+            params.append(_normalize_since(since))
+        sql = f"""
+            SELECT id, headline, snippet FROM news_events
+            WHERE finbert_confidence IS NULL
+                  {where_since}
+            ORDER BY timestamp
+            LIMIT ?
+        """
+        params.append(limit)
+        rows = conn.execute(sql, params).fetchall()
+        if not rows:
+            return 0
+
+        texts = [_join_text(h, s) for _id, h, s in rows]
+        scored = self._scorer.score_texts(texts)
+        assert len(scored) == len(rows)
+
+        updated = 0
+        with self._news_store._cursor() as cur:
+            for (row_id, _h, _s), sc in zip(rows, scored):
+                cur.execute(
+                    """UPDATE news_events
+                       SET finbert_negative = ?,
+                           finbert_neutral = ?,
+                           finbert_confidence = ?
+                       WHERE id = ? AND finbert_confidence IS NULL""",
+                    (
+                        float(sc["negative"]),
+                        float(sc["neutral"]),
+                        float(sc["confidence"]),
+                        row_id,
+                    ),
+                )
+                # review H4: cur.rowcount==-1 (某些驱动) 当 0 处理,不回退计数
+                updated += max(cur.rowcount, 0)
+        logger.info(
+            "LocalSentimentProvider.backfill: %d candidates, %d written",
+            len(rows),
+            updated,
+        )
+        return updated
+
+    # ------ Registry ------
+
+    @classmethod
+    def register_default(
+        cls,
+        registry: Any,
+        news_store: Any | None = None,
+    ) -> "LocalSentimentProvider":
+        """注册本 Provider 类到 Registry 并可选创建默认实例。
+
+        Args:
+            registry: ProviderRegistry 实例
+            news_store: 注入给 LocalSentimentProvider 的 news_store;
+                        None 时调用方负责后续注入
+
+        Returns:
+            创建并注册的 LocalSentimentProvider 实例 (注入了 registry.cache)
+        """
+        registry.register("LocalSentimentProvider", cls)
+        cfg = ProviderConfig(implementation="LocalSentimentProvider")
+        instance = cls(cfg, news_store=news_store)
+        # review H3: 手工创建的实例也必须注入 cache,
+        # 与 registry.create() 行为一致 (registry.py:70)
+        instance.cache = registry.cache
+        if news_store is not None and not getattr(news_store, "is_initialized", False):
+            news_store.initialize()
+        instance.initialize()
+        registry._instances["SentimentProvider"] = instance
+        return instance
+
+    # ------ 内部 ------
+
+    def _require_initialized(self) -> None:
+        if not self.is_initialized:
+            raise RuntimeError(
+                "LocalSentimentProvider not initialized; call .initialize()"
+            )
+
+    def _require_news_store(self) -> None:
+        if self._news_store is None:
+            raise RuntimeError(
+                "news_store not injected; pass via ctor or setter before calling"
+            )
+        if getattr(self._news_store, "_conn", None) is None:
+            raise RuntimeError(
+                "news_store._conn is None; call news_store.initialize() first"
+            )
+
+
+# ---- 模块级辅助 ----
+
+
+def _join_text(headline: str | None, snippet: str | None) -> str:
+    h = (headline or "").strip()
+    s = (snippet or "").strip()
+    if not s:
+        return h
+    return f"{h} {s}" if h else s
+
+
+def _normalize_since(since: Any) -> str:
+    import pandas as pd
+
+    ts = pd.Timestamp(since)
+    if ts.tz is None:
+        ts = ts.tz_localize(timezone.utc)
+    else:
+        ts = ts.tz_convert(timezone.utc)
+    return ts.isoformat()
+
+
+__all__ = ["LocalSentimentProvider"]

--- a/src/stockbee/small_models/local_sentiment_provider.py
+++ b/src/stockbee/small_models/local_sentiment_provider.py
@@ -158,15 +158,20 @@ class LocalSentimentProvider(SentimentProvider):
         since: str | datetime | None = None,
         limit: int = 1000,
     ) -> int:
-        """补齐 finbert_confidence IS NULL 的行; 批量 scorer.score_texts 后 UPDATE。
+        """补齐任一情绪字段为 NULL 的行; 批量 scorer.score_texts 后 UPDATE。
 
         Args:
             since: 仅处理 timestamp >= since 的行 (None = 全量)
             limit: 单次 LIMIT 上限 (分页调用时传不同值)
 
         Returns:
-            实际写入的行数。**不修改** sentiment_score (g2 所有)。
+            实际写入的行数。sentiment_score 仅在当前为 NULL 时由 scorer 的
+            positive 概率填入 (COALESCE);若 g2 已写入,保持不动。
         """
+        # review H6: 只按 finbert_confidence IS NULL 选行会永久冻结 sentiment_score
+        # 仍 NULL 但 finbert_* 已填的"部分 G1 / 部分 backfill"行 —
+        # get_ticker_sentiment 因 positive IS NULL 跳过,backfill 又不再命中。
+        # 改为任一字段 NULL 即候选,并用 COALESCE 保留 g2 写入的 positive。
         self._require_initialized()
         self._require_news_store()
         if limit < 1:
@@ -180,7 +185,12 @@ class LocalSentimentProvider(SentimentProvider):
             params.append(_normalize_since(since))
         sql = f"""
             SELECT id, headline, snippet FROM news_events
-            WHERE finbert_confidence IS NULL
+            WHERE (
+                      finbert_confidence IS NULL
+                   OR finbert_negative IS NULL
+                   OR finbert_neutral IS NULL
+                   OR sentiment_score IS NULL
+                  )
                   {where_since}
             ORDER BY timestamp
             LIMIT ?
@@ -199,11 +209,18 @@ class LocalSentimentProvider(SentimentProvider):
             for (row_id, _h, _s), sc in zip(rows, scored):
                 cur.execute(
                     """UPDATE news_events
-                       SET finbert_negative = ?,
-                           finbert_neutral = ?,
-                           finbert_confidence = ?
-                       WHERE id = ? AND finbert_confidence IS NULL""",
+                       SET sentiment_score = COALESCE(sentiment_score, ?),
+                           finbert_negative = COALESCE(finbert_negative, ?),
+                           finbert_neutral = COALESCE(finbert_neutral, ?),
+                           finbert_confidence = COALESCE(finbert_confidence, ?)
+                       WHERE id = ? AND (
+                                 finbert_confidence IS NULL
+                              OR finbert_negative IS NULL
+                              OR finbert_neutral IS NULL
+                              OR sentiment_score IS NULL
+                             )""",
                     (
+                        float(sc["positive"]),
                         float(sc["negative"]),
                         float(sc["neutral"]),
                         float(sc["confidence"]),

--- a/src/stockbee/small_models/model_io.py
+++ b/src/stockbee/small_models/model_io.py
@@ -1,0 +1,280 @@
+"""通用模型 artifact IO。
+
+目录结构::
+
+    data/models/{name}/{YYYYMMDD}.pkl      # 版本化 artifact
+    data/models/{name}/current.pkl         # POSIX symlink -> 版本文件
+    data/models/{name}/current.txt         # Windows fallback,明文记录当前版本号
+
+m2a / m3 / m4 / m5 全部走 save_pickle / load_pickle / update_symlink。
+
+版本号约定: 传入 str(形如 20260413) 或 None 取 today().strftime("%Y%m%d")。
+
+**安全约束**:`load_pickle` 反序列化会执行任意 `__reduce__`,仅用于受信任的
+本地训练产物。不要读外网或 user-uploaded pickle。
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import pickle
+import re
+import sys
+import uuid
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+from . import paths as _paths
+
+logger = logging.getLogger(__name__)
+
+_VERSION_RE = re.compile(r"^\d{8}$")
+_CURRENT = "current"
+_PICKLE_SUFFIX = ".pkl"
+_WINDOWS_CURRENT_TXT = "current.txt"
+
+# 向后兼容 re-export(tmp_artifact_dir 测试 fixture 直接 monkeypatch 这个名字)。
+# 实际读取走 _root() 以支持 paths.MODEL_ROOT 运行时被替换。
+MODEL_ROOT = _paths.MODEL_ROOT
+
+
+class NotFoundError(FileNotFoundError):
+    """请求的 artifact 不存在。"""
+
+
+class InvalidArtifactError(ValueError):
+    """artifact 文件损坏、格式错误或 current.txt 内容非法。"""
+
+
+def _root() -> Path:
+    """返回当前 MODEL_ROOT。优先读本模块 MODEL_ROOT(兼容老 monkeypatch 写法),
+    其次 paths.MODEL_ROOT(新代码推荐改这里)。两者一致时无差别。"""
+    return Path(globals().get("MODEL_ROOT") or _paths.MODEL_ROOT)
+
+
+def _model_dir(name: str) -> Path:
+    if not isinstance(name, str) or not name:
+        raise ValueError(f"Invalid artifact name: {name!r}")
+    if "/" in name or "\\" in name or name in (".", "..") or name.startswith("."):
+        raise ValueError(f"Invalid artifact name: {name!r}")
+    if "\x00" in name:
+        raise ValueError(f"Invalid artifact name: {name!r}")
+    return _root() / name
+
+
+def _resolve_version(version: str | None) -> str:
+    if version is None:
+        return date.today().strftime("%Y%m%d")
+    if not isinstance(version, str):
+        raise TypeError(
+            f"version must be str or None, got {type(version).__name__}"
+        )
+    if version == _CURRENT:
+        return _CURRENT
+    if not _VERSION_RE.match(version):
+        raise ValueError(
+            f"version must be 'current' or 8-digit YYYYMMDD, got {version!r}"
+        )
+    try:
+        datetime.strptime(version, "%Y%m%d")
+    except ValueError as exc:
+        raise ValueError(
+            f"version {version!r} is not a valid calendar date"
+        ) from exc
+    return version
+
+
+def artifact_path(name: str, version: str = "current") -> Path:
+    """返回 artifact 文件路径。
+
+    version='current' → 返回 current.pkl 路径 (POSIX 下为 symlink)。
+    version='YYYYMMDD' → 返回版本文件路径。
+    不校验文件是否存在。
+    """
+    version = _resolve_version(version)
+    return _model_dir(name) / f"{version}{_PICKLE_SUFFIX}"
+
+
+def save_pickle(
+    obj: Any,
+    name: str,
+    version: str | None = None,
+    overwrite: bool = False,
+) -> Path:
+    """将 obj pickle 到 data/models/{name}/{version}.pkl (原子写)。
+
+    version=None 默认取 today (YYYYMMDD)。
+    overwrite=False (默认) 若同版本文件已存在则 raise FileExistsError;
+    m3 重训等显式覆盖场景传 overwrite=True。
+
+    实现为 tmp + rename,崩溃不会留半写文件;Windows 下同样可覆盖读中的文件。
+
+    **不自动** update current symlink — 训练完需显式 `update_symlink(name, version)`。
+    """
+    version_str = _resolve_version(version)
+    if version_str == _CURRENT:
+        raise ValueError("save_pickle version 不能是 'current',必须是 YYYYMMDD")
+
+    target = _model_dir(name) / f"{version_str}{_PICKLE_SUFFIX}"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists() and not overwrite:
+        raise FileExistsError(
+            f"artifact already exists: {target}; pass overwrite=True to replace"
+        )
+    tmp = target.parent / f"{version_str}.pkl.tmp.{os.getpid()}.{uuid.uuid4().hex[:8]}"
+    try:
+        with tmp.open("wb") as f:
+            pickle.dump(obj, f, protocol=pickle.HIGHEST_PROTOCOL)
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            tmp.unlink(missing_ok=True)
+    logger.debug("save_pickle: %s -> %s", name, target)
+    return target
+
+
+def load_pickle(name: str, version: str = "current") -> Any:
+    """加载 artifact。
+
+    version='current' POSIX 读 symlink;若 symlink 悬挂则降级到 current.txt;
+    都缺则 NotFoundError。pickle 损坏 → InvalidArtifactError。
+
+    **安全**:仅用于受信任的本地产物,见模块 docstring。
+    """
+    version_str = _resolve_version(version)
+    model_dir = _model_dir(name)
+
+    if version_str == _CURRENT:
+        target = _resolve_current_file(model_dir, name)
+    else:
+        target = model_dir / f"{version_str}{_PICKLE_SUFFIX}"
+
+    if not target.exists():
+        raise NotFoundError(f"artifact not found: {target}")
+    try:
+        with target.open("rb") as f:
+            return pickle.load(f)
+    except (pickle.UnpicklingError, EOFError, AttributeError, ImportError) as exc:
+        raise InvalidArtifactError(f"corrupt artifact at {target}: {exc}") from exc
+
+
+def update_symlink(name: str, version: str) -> None:
+    """将 {name}/current.pkl 指向 {name}/{version}.pkl。
+
+    POSIX: 原子替换 symlink (tmp + rename);完成后清理残留 current.txt。
+    Windows / 无 symlink 权限: 写 current.txt 记录版本号;同时清理残留 current.pkl
+    避免旧 symlink 被误读。OSError 触发从 POSIX 降级到 txt 时同样清理。
+    """
+    version_str = _resolve_version(version)
+    if version_str == _CURRENT:
+        raise ValueError("update_symlink version 不能是 'current'")
+
+    model_dir = _model_dir(name)
+    source = model_dir / f"{version_str}{_PICKLE_SUFFIX}"
+    if not source.exists():
+        raise NotFoundError(f"cannot point current to missing version: {source}")
+
+    current_link = model_dir / f"{_CURRENT}{_PICKLE_SUFFIX}"
+    current_txt = model_dir / _WINDOWS_CURRENT_TXT
+
+    if _supports_symlink():
+        tmp = model_dir / f"{_CURRENT}.pkl.tmp.{os.getpid()}.{uuid.uuid4().hex[:8]}"
+        try:
+            tmp.symlink_to(source.name)
+            os.replace(tmp, current_link)
+        except OSError:
+            _unlink_silent(tmp)
+            _unlink_silent(current_link)  # C1: 清理旧 symlink/文件防读到 stale
+            _write_current_txt(current_txt, version_str)
+            return
+        _unlink_silent(current_txt)
+    else:
+        _unlink_silent(current_link)
+        _write_current_txt(current_txt, version_str)
+
+    logger.debug("update_symlink: %s/current -> %s", name, source.name)
+
+
+def list_versions(name: str) -> list[str]:
+    """返回 name 的所有版本号 (YYYYMMDD),按降序排列。current.pkl 不计入。"""
+    model_dir = _model_dir(name)
+    if not model_dir.exists():
+        return []
+    out: list[str] = []
+    for p in model_dir.iterdir():
+        if p.suffix != _PICKLE_SUFFIX or p.is_symlink():
+            continue
+        stem = p.stem
+        if _VERSION_RE.match(stem):
+            out.append(stem)
+    return sorted(out, reverse=True)
+
+
+# ------ 内部辅助 ------
+
+
+def _supports_symlink() -> bool:
+    """POSIX 默认支持;Windows 视权限。"""
+    return sys.platform != "win32" and hasattr(os, "symlink")
+
+
+def _unlink_silent(p: Path) -> None:
+    """删文件或 symlink,不存在时静默返回。兼容悬挂 symlink(exists()=False)。"""
+    try:
+        p.unlink(missing_ok=True)
+    except IsADirectoryError:
+        raise
+    except OSError:
+        # 悬挂 symlink: unlink 走链接自己,若未能删再 fallback to os.remove on link path
+        if p.is_symlink():
+            os.unlink(p)
+
+
+def _write_current_txt(path: Path, version: str) -> None:
+    tmp = path.with_suffix(
+        path.suffix + f".tmp.{os.getpid()}.{uuid.uuid4().hex[:8]}"
+    )
+    tmp.write_text(version, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _resolve_current_file(model_dir: Path, name: str) -> Path:
+    """load_pickle 'current' 路径解析。
+
+    顺序:
+      1. symlink (POSIX):若存在且未悬挂 → 直读
+      2. 悬挂 symlink 或无 symlink → 查 current.txt 拼版本文件
+      3. 都缺 → NotFoundError
+    """
+    current_link = model_dir / f"{_CURRENT}{_PICKLE_SUFFIX}"
+    if current_link.exists():
+        return current_link
+    # symlink 悬挂:降级查 current.txt(H1)
+    current_txt = model_dir / _WINDOWS_CURRENT_TXT
+    if current_txt.exists():
+        version = current_txt.read_text(encoding="utf-8").strip()
+        if not _VERSION_RE.match(version):
+            raise InvalidArtifactError(
+                f"{current_txt} content {version!r} is not YYYYMMDD"
+            )
+        return model_dir / f"{version}{_PICKLE_SUFFIX}"
+    if current_link.is_symlink():
+        raise InvalidArtifactError(
+            f"dangling current symlink at {current_link} -> "
+            f"{os.readlink(current_link)!r}"
+        )
+    raise NotFoundError(f"no current artifact for {name} in {model_dir}")
+
+
+__all__ = [
+    "InvalidArtifactError",
+    "MODEL_ROOT",
+    "NotFoundError",
+    "artifact_path",
+    "list_versions",
+    "load_pickle",
+    "save_pickle",
+    "update_symlink",
+]

--- a/src/stockbee/small_models/model_io.py
+++ b/src/stockbee/small_models/model_io.py
@@ -119,15 +119,22 @@ def save_pickle(
 
     target = _model_dir(name) / f"{version_str}{_PICKLE_SUFFIX}"
     target.parent.mkdir(parents=True, exist_ok=True)
-    if target.exists() and not overwrite:
-        raise FileExistsError(
-            f"artifact already exists: {target}; pass overwrite=True to replace"
-        )
     tmp = target.parent / f"{version_str}.pkl.tmp.{os.getpid()}.{uuid.uuid4().hex[:8]}"
     try:
         with tmp.open("wb") as f:
             pickle.dump(obj, f, protocol=pickle.HIGHEST_PROTOCOL)
-        os.replace(tmp, target)
+        if overwrite:
+            os.replace(tmp, target)
+        else:
+            # 原子"存在即失败"建链。os.link 在目标存在时抛 FileExistsError,
+            # 消除 check-then-replace 的 TOCTOU — 两进程并发 save 同版本,
+            # 只有一个能成功;另一个拿到 FileExistsError 而不是静默覆盖。
+            try:
+                os.link(tmp, target)
+            except FileExistsError:
+                raise FileExistsError(
+                    f"artifact already exists: {target}; pass overwrite=True to replace"
+                )
     finally:
         if tmp.exists():
             tmp.unlink(missing_ok=True)

--- a/src/stockbee/small_models/paths.py
+++ b/src/stockbee/small_models/paths.py
@@ -1,0 +1,14 @@
+"""small_models 路径常量。
+
+统一模型 artifact 与 precomputed 因子落盘位置,供 m2a-m6 共享。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+MODEL_ROOT: Path = Path("data/models")
+"""模型 artifact 根目录。子目录按模型名组织: data/models/{name}/{version}.pkl"""
+
+ML_SCORE_PARQUET: Path = Path("data/factors/ml_score.parquet")
+"""LightGBM 推理结果 precomputed 因子落盘路径 (m4 写, FactorProvider 读)。"""

--- a/tests/small_models/conftest.py
+++ b/tests/small_models/conftest.py
@@ -1,0 +1,155 @@
+"""02-small-models 共享 pytest fixtures。
+
+决策 OQ2: 放在 tests/small_models/ 下,pytest 自动发现,m2-m6 测试文件同目录零样板使用。
+
+提供 fixture:
+- ohlcv_fixture        : 2 tickers × 60 天 OHLCV (adj_close / open / high / low / close / volume)
+- alpha158_fixture     : 5 因子 × 50 天 × 2 tickers MultiIndex(date, ticker)
+- news_fixture         : 20 条假新闻 (含 ticker 关联 + timestamp)
+- embeddings_fixture   : 假 embedding matrix (N, D), D 参数化默认 1024 (e5-large-v2)
+- finbert_golden       : 10 条已知情感 (4 正 / 4 负 / 2 中性)
+- tmp_artifact_dir     : 把 small_models.paths.MODEL_ROOT 重定向到 pytest tmp_path,
+                         隔离 data/models/ 不污染真实目录
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from stockbee.small_models import paths as small_model_paths
+
+_TICKERS = ["AAPL", "MSFT"]
+
+
+@pytest.fixture
+def ohlcv_fixture() -> pd.DataFrame:
+    """60 个交易日 × 2 tickers 的 OHLCV。MultiIndex (date, ticker)。
+
+    adj_close 走随机游走 (seed 固定),其他列机械派生;无缺失,便于 label_utils 测试。
+    """
+    rng = np.random.default_rng(42)
+    n_days = 60
+    start = pd.Timestamp("2026-01-02")
+    dates = pd.bdate_range(start, periods=n_days)
+    rows = []
+    for ticker in _TICKERS:
+        base = 100.0 + (10.0 if ticker == "AAPL" else 0.0)
+        returns = rng.normal(0.0005, 0.015, size=n_days)
+        prices = base * np.exp(np.cumsum(returns))
+        for d, px in zip(dates, prices):
+            open_ = px * (1 + rng.normal(0, 0.002))
+            high = max(open_, px) * (1 + abs(rng.normal(0, 0.003)))
+            low = min(open_, px) * (1 - abs(rng.normal(0, 0.003)))
+            close = px
+            adj_close = px
+            volume = rng.integers(1_000_000, 5_000_000)
+            rows.append((d, ticker, open_, high, low, close, adj_close, volume))
+    df = pd.DataFrame(
+        rows,
+        columns=["date", "ticker", "open", "high", "low", "close", "adj_close", "volume"],
+    )
+    return df.set_index(["date", "ticker"]).sort_index()
+
+
+@pytest.fixture
+def alpha158_fixture() -> pd.DataFrame:
+    """5 因子 × 50 天 × 2 tickers。MultiIndex (date, ticker) × 因子名列。"""
+    rng = np.random.default_rng(7)
+    n_days = 50
+    dates = pd.bdate_range("2026-01-02", periods=n_days)
+    factor_cols = ["MA5", "MA10", "STD20", "RSQR20", "KMID"]
+    idx = pd.MultiIndex.from_product([dates, _TICKERS], names=["date", "ticker"])
+    data = rng.standard_normal((len(idx), len(factor_cols)))
+    return pd.DataFrame(data, index=idx, columns=factor_cols)
+
+
+@pytest.fixture
+def news_fixture() -> pd.DataFrame:
+    """20 条假新闻,覆盖多 ticker + 时间范围。"""
+    rows = []
+    base_ts = datetime(2026, 3, 1, 9, 30, tzinfo=timezone.utc)
+    headlines = [
+        ("AAPL beats Q1 earnings by 12%", ["AAPL"]),
+        ("Apple cuts iPhone production 10%", ["AAPL"]),
+        ("MSFT cloud revenue grows 35%", ["MSFT"]),
+        ("Microsoft announces layoffs", ["MSFT"]),
+        ("AAPL announces new M4 chip", ["AAPL"]),
+        ("Apple services revenue flat", ["AAPL"]),
+        ("MSFT wins DoD contract worth $10B", ["MSFT"]),
+        ("Microsoft Azure outage affects thousands", ["MSFT"]),
+        ("AAPL supplier warns on demand", ["AAPL"]),
+        ("Apple hit with EU antitrust fine", ["AAPL"]),
+        ("Microsoft acquires AI startup", ["MSFT"]),
+        ("MSFT stock hits all-time high", ["MSFT"]),
+        ("Tech sector mixed on inflation data", ["AAPL", "MSFT"]),
+        ("AAPL pauses Vision Pro production", ["AAPL"]),
+        ("Microsoft Copilot adoption accelerates", ["MSFT"]),
+        ("Apple beats analyst estimates", ["AAPL"]),
+        ("MSFT gaming division slows", ["MSFT"]),
+        ("AI boom lifts AAPL and MSFT", ["AAPL", "MSFT"]),
+        ("Apple App Store policy under scrutiny", ["AAPL"]),
+        ("Microsoft cybersecurity breach disclosed", ["MSFT"]),
+    ]
+    for i, (headline, tickers) in enumerate(headlines):
+        ts = base_ts + timedelta(hours=i * 6)
+        rows.append({
+            "id": i + 1,
+            "timestamp": ts.isoformat(),
+            "source": "reuters" if i % 2 == 0 else "bloomberg",
+            "headline": headline,
+            "tickers": tickers,
+            "g_level": 2,
+        })
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture(params=[1024, 768])
+def embeddings_fixture(request) -> tuple[np.ndarray, int]:
+    """假 embedding 矩阵 (N, D),D 参数化 (e5-large-v2=1024, e5-base=768)。
+
+    行范数归一化,便于 cosine 测试。返回 (matrix, dim)。
+    """
+    dim = request.param
+    rng = np.random.default_rng(dim)  # 不同 dim 不同种子便于调试
+    n = 12
+    raw = rng.standard_normal((n, dim)).astype(np.float32)
+    norms = np.linalg.norm(raw, axis=1, keepdims=True)
+    return raw / norms, dim
+
+
+@pytest.fixture
+def finbert_golden() -> list[dict]:
+    """10 条金融新闻 + 已知情感 (4 正 / 4 负 / 2 中性),供 m2a 性能/准确性验证。"""
+    return [
+        {"text": "Company beats earnings expectations, raises full-year guidance", "label": "positive"},
+        {"text": "Stock hits new 52-week high on record quarterly profit", "label": "positive"},
+        {"text": "Dividend increased 15% as free cash flow grows", "label": "positive"},
+        {"text": "Analysts upgrade rating to buy after strong results", "label": "positive"},
+        {"text": "Company slashes guidance amid demand collapse", "label": "negative"},
+        {"text": "Regulator fines firm $500M for antitrust violations", "label": "negative"},
+        {"text": "CFO resigns amid accounting investigation", "label": "negative"},
+        {"text": "Layoffs announced, 10% of workforce affected", "label": "negative"},
+        {"text": "Company to report earnings next Tuesday", "label": "neutral"},
+        {"text": "Board approves routine share buyback program", "label": "neutral"},
+    ]
+
+
+@pytest.fixture
+def tmp_artifact_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """把 small_models.paths.MODEL_ROOT 重定向到 tmp_path/models,隔离真实 data/models。
+
+    monkeypatch 覆盖模块级 MODEL_ROOT 以及 model_io 里引用的 MODEL_ROOT
+    (模块在 import 时复制了常量引用,需同步覆盖)。
+    """
+    from stockbee.small_models import model_io as _model_io
+
+    new_root = tmp_path / "models"
+    new_root.mkdir()
+    monkeypatch.setattr(small_model_paths, "MODEL_ROOT", new_root)
+    monkeypatch.setattr(_model_io, "MODEL_ROOT", new_root)
+    return new_root

--- a/tests/small_models/test_contracts.py
+++ b/tests/small_models/test_contracts.py
@@ -120,6 +120,32 @@ class TestSaveLoadPickle:
         save_pickle({"x": 2}, "model", version="20260413", overwrite=True)
         assert load_pickle("model", "20260413") == {"x": 2}
 
+    def test_concurrent_save_race_no_silent_overwrite(
+        self, tmp_artifact_dir, monkeypatch
+    ):
+        """Codex P2: 并发 save_pickle(overwrite=False) 必须原子。
+
+        模拟两进程 race: A 和 B 同时 save 同 (name, version),B 在 A 的 os.link
+        调用之前抢先把目标文件建好。A 的 os.link 应 raise FileExistsError,
+        而不是靠 pre-check + os.replace 的非原子组合静默覆盖。
+        """
+        name, version = "model", "20260413"
+        target = artifact_path(name, version)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        real_link = os.link
+
+        def racing_link(src, dst, *a, **kw):
+            # 模拟对方进程抢在我们 link 前写了目标文件
+            if not Path(dst).exists():
+                Path(dst).write_bytes(b"peer wrote first")
+            return real_link(src, dst, *a, **kw)
+
+        monkeypatch.setattr(os, "link", racing_link)
+        with pytest.raises(FileExistsError, match="already exists"):
+            save_pickle({"mine": True}, name, version=version)
+        # 对方内容不应被我们覆盖
+        assert target.read_bytes() == b"peer wrote first"
+
     def test_load_missing_raises_notfound(self, tmp_artifact_dir):
         with pytest.raises(NotFoundError):
             load_pickle("nowhere", "20260101")

--- a/tests/small_models/test_contracts.py
+++ b/tests/small_models/test_contracts.py
@@ -1,0 +1,505 @@
+"""m1 contract / model_io / fixtures / schema migration 合约测试。
+
+覆盖:
+  - paths: MODEL_ROOT / ML_SCORE_PARQUET 常量格式
+  - model_io: save/load roundtrip, overwrite, current symlink 覆盖,
+              versions 排序,NotFoundError,InvalidArtifactError,
+              POSIX 下 update_symlink 清理老的 current.txt,
+              Windows fallback 走 current.txt 解析
+  - fixtures: shape / dtype / index 断言
+  - news_events schema 迁移: 4 新列存在,老库升级,幂等,老数据不丢
+"""
+
+from __future__ import annotations
+
+import os
+import pickle
+import sqlite3
+import sys
+from datetime import date
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+_posix_only = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX symlink path only"
+)
+
+from stockbee.news_data.news_store import SqliteNewsProvider
+from stockbee.providers.base import ProviderConfig
+from stockbee.small_models import (
+    InvalidArtifactError,
+    ML_SCORE_PARQUET,
+    MODEL_ROOT,
+    NotFoundError,
+    artifact_path,
+    list_versions,
+    load_pickle,
+    save_pickle,
+    update_symlink,
+)
+from stockbee.small_models import model_io as _model_io
+from stockbee.small_models import paths as small_model_paths
+
+
+# ------------------------------ paths ----------------------------------------
+
+
+class TestPaths:
+    def test_model_root_points_to_data_models(self):
+        assert MODEL_ROOT == Path("data/models")
+
+    def test_ml_score_parquet_under_data_factors(self):
+        assert ML_SCORE_PARQUET == Path("data/factors/ml_score.parquet")
+        assert ML_SCORE_PARQUET.suffix == ".parquet"
+
+
+# ------------------------------ model_io -------------------------------------
+
+
+class TestArtifactPath:
+    def test_current_default(self, tmp_artifact_dir):
+        p = artifact_path("lightgbm")
+        assert p == tmp_artifact_dir / "lightgbm" / "current.pkl"
+
+    def test_versioned(self, tmp_artifact_dir):
+        p = artifact_path("finbert", "20260413")
+        assert p == tmp_artifact_dir / "finbert" / "20260413.pkl"
+
+    def test_rejects_bad_version(self, tmp_artifact_dir):
+        with pytest.raises(ValueError):
+            artifact_path("finbert", "v1")
+
+    def test_rejects_path_traversal(self, tmp_artifact_dir):
+        for bad in ["../etc", "", "..", ".", ".hidden", "a/b", "a\\b", "a\x00b"]:
+            with pytest.raises(ValueError):
+                artifact_path(bad)
+
+    def test_rejects_non_str_name(self, tmp_artifact_dir):
+        with pytest.raises(ValueError):
+            artifact_path(None)  # type: ignore[arg-type]
+
+    def test_rejects_invalid_calendar_date(self, tmp_artifact_dir):
+        for bad in ["20260230", "20260001", "20261332", "00000000"]:
+            with pytest.raises(ValueError, match="valid calendar date|YYYYMMDD"):
+                artifact_path("m", bad)
+
+    def test_rejects_non_str_version(self, tmp_artifact_dir):
+        with pytest.raises(TypeError):
+            artifact_path("m", 20260413)  # type: ignore[arg-type]
+        with pytest.raises(TypeError):
+            artifact_path("m", True)  # type: ignore[arg-type]
+
+
+class TestSaveLoadPickle:
+    def test_roundtrip(self, tmp_artifact_dir):
+        obj = {"weights": [1, 2, 3], "bias": 0.5}
+        target = save_pickle(obj, "lightgbm", version="20260413")
+        assert target.exists()
+        assert target.name == "20260413.pkl"
+        loaded = load_pickle("lightgbm", "20260413")
+        assert loaded == obj
+
+    def test_default_version_is_today(self, tmp_artifact_dir):
+        target = save_pickle({"x": 1}, "finbert")
+        assert target.stem == date.today().strftime("%Y%m%d")
+
+    def test_save_current_literal_rejected(self, tmp_artifact_dir):
+        with pytest.raises(ValueError):
+            save_pickle({"x": 1}, "finbert", version="current")
+
+    def test_default_rejects_overwrite(self, tmp_artifact_dir):
+        save_pickle({"x": 1}, "model", version="20260413")
+        with pytest.raises(FileExistsError):
+            save_pickle({"x": 2}, "model", version="20260413")
+
+    def test_overwrite_true(self, tmp_artifact_dir):
+        save_pickle({"x": 1}, "model", version="20260413")
+        save_pickle({"x": 2}, "model", version="20260413", overwrite=True)
+        assert load_pickle("model", "20260413") == {"x": 2}
+
+    def test_load_missing_raises_notfound(self, tmp_artifact_dir):
+        with pytest.raises(NotFoundError):
+            load_pickle("nowhere", "20260101")
+
+    def test_load_current_missing_raises_notfound(self, tmp_artifact_dir):
+        (tmp_artifact_dir / "finbert").mkdir()
+        with pytest.raises(NotFoundError):
+            load_pickle("finbert", "current")
+
+    def test_corrupt_pickle_raises(self, tmp_artifact_dir):
+        (tmp_artifact_dir / "mdl").mkdir()
+        bad = tmp_artifact_dir / "mdl" / "20260413.pkl"
+        bad.write_bytes(b"not a pickle")
+        with pytest.raises(InvalidArtifactError):
+            load_pickle("mdl", "20260413")
+
+    def test_save_creates_nested_dirs(self, tmp_artifact_dir):
+        assert not (tmp_artifact_dir / "brand_new").exists()
+        save_pickle([1, 2], "brand_new", version="20260413")
+        assert (tmp_artifact_dir / "brand_new" / "20260413.pkl").exists()
+
+
+class TestUpdateSymlink:
+    @_posix_only
+    def test_symlink_points_to_version(self, tmp_artifact_dir):
+        save_pickle({"v": 1}, "finbert", version="20260101")
+        update_symlink("finbert", "20260101")
+        current = tmp_artifact_dir / "finbert" / "current.pkl"
+        assert current.exists()
+        assert load_pickle("finbert", "current") == {"v": 1}
+
+    def test_symlink_switches_between_versions(self, tmp_artifact_dir):
+        save_pickle({"v": 1}, "m", version="20260101")
+        save_pickle({"v": 2}, "m", version="20260202")
+        update_symlink("m", "20260101")
+        assert load_pickle("m", "current") == {"v": 1}
+        update_symlink("m", "20260202")
+        assert load_pickle("m", "current") == {"v": 2}
+
+    def test_missing_version_raises_notfound(self, tmp_artifact_dir):
+        (tmp_artifact_dir / "m").mkdir()
+        with pytest.raises(NotFoundError):
+            update_symlink("m", "20991231")
+
+    def test_rejects_current_literal(self, tmp_artifact_dir):
+        with pytest.raises(ValueError):
+            update_symlink("m", "current")
+
+    @_posix_only
+    def test_posix_clears_old_current_txt(self, tmp_artifact_dir):
+        """POSIX 下若残留 current.txt (Windows 迁回场景),update_symlink 应清理。"""
+        save_pickle({"v": 1}, "x", version="20260101")
+        (tmp_artifact_dir / "x" / "current.txt").write_text("99999999")
+        update_symlink("x", "20260101")
+        assert not (tmp_artifact_dir / "x" / "current.txt").exists()
+        assert load_pickle("x", "current") == {"v": 1}
+
+    def test_osrror_fallback_clears_stale_symlink(
+        self, tmp_artifact_dir, monkeypatch
+    ):
+        """C1: POSIX symlink_to 抛 OSError 时,必须清理旧 symlink 再写 current.txt,
+        否则下次 load_pickle 读到 stale artifact。"""
+        save_pickle({"v": "old"}, "m", version="20260101")
+        save_pickle({"v": "new"}, "m", version="20260202")
+        update_symlink("m", "20260101")  # 建立初始 symlink -> 20260101
+        assert load_pickle("m", "current") == {"v": "old"}
+
+        # 第二次切换:模拟 symlink_to 抛 OSError,强制走回退
+        from stockbee.small_models import model_io as mi
+        orig_symlink_to = Path.symlink_to
+
+        def boom(self, target, *a, **kw):
+            raise OSError("simulated fs restriction")
+
+        monkeypatch.setattr(Path, "symlink_to", boom)
+        update_symlink("m", "20260202")
+
+        # 旧 symlink 必须已被清理,load 走 current.txt 得到新版本
+        current_link = tmp_artifact_dir / "m" / "current.pkl"
+        current_txt = tmp_artifact_dir / "m" / "current.txt"
+        assert not current_link.exists() and not current_link.is_symlink()
+        assert current_txt.exists() and current_txt.read_text().strip() == "20260202"
+        monkeypatch.setattr(Path, "symlink_to", orig_symlink_to)
+        assert load_pickle("m", "current") == {"v": "new"}
+
+    @_posix_only
+    def test_dangling_symlink_falls_back_to_current_txt(
+        self, tmp_artifact_dir
+    ):
+        """H1: symlink target 被外部删除后,load_pickle 应降级到 current.txt。"""
+        save_pickle({"v": 1}, "m", version="20260101")
+        save_pickle({"v": 2}, "m", version="20260202")
+        update_symlink("m", "20260101")
+        # 手写 current.txt 指向 20260202,然后删 20260101 的文件,让 symlink 悬挂
+        (tmp_artifact_dir / "m" / "current.txt").write_text("20260202")
+        (tmp_artifact_dir / "m" / "20260101.pkl").unlink()
+        assert load_pickle("m", "current") == {"v": 2}
+
+    @_posix_only
+    def test_dangling_symlink_without_txt_raises_invalid(
+        self, tmp_artifact_dir
+    ):
+        save_pickle({"v": 1}, "m", version="20260101")
+        update_symlink("m", "20260101")
+        (tmp_artifact_dir / "m" / "20260101.pkl").unlink()
+        with pytest.raises(InvalidArtifactError, match="dangling"):
+            load_pickle("m", "current")
+
+
+class TestWindowsFallback:
+    """OQ3: current.txt 回退路径,模拟无 symlink 环境。"""
+
+    def test_load_current_reads_current_txt(self, tmp_artifact_dir, monkeypatch):
+        save_pickle({"v": 7}, "m", version="20260413")
+        monkeypatch.setattr(_model_io, "_supports_symlink", lambda: False)
+        update_symlink("m", "20260413")
+        current_txt = tmp_artifact_dir / "m" / "current.txt"
+        assert current_txt.exists()
+        assert current_txt.read_text().strip() == "20260413"
+        assert not (tmp_artifact_dir / "m" / "current.pkl").exists()
+        assert load_pickle("m", "current") == {"v": 7}
+
+    def test_corrupt_current_txt_raises(self, tmp_artifact_dir, monkeypatch):
+        (tmp_artifact_dir / "m").mkdir()
+        (tmp_artifact_dir / "m" / "current.txt").write_text("not-a-version")
+        monkeypatch.setattr(_model_io, "_supports_symlink", lambda: False)
+        with pytest.raises(InvalidArtifactError):
+            load_pickle("m", "current")
+
+
+class TestListVersions:
+    def test_empty_when_missing(self, tmp_artifact_dir):
+        assert list_versions("nothing") == []
+
+    def test_descending_order(self, tmp_artifact_dir):
+        for v in ["20260101", "20260505", "20260303"]:
+            save_pickle({"x": v}, "lgbm", version=v)
+        assert list_versions("lgbm") == ["20260505", "20260303", "20260101"]
+
+    def test_excludes_current_symlink(self, tmp_artifact_dir):
+        save_pickle({"x": 1}, "m", version="20260101")
+        update_symlink("m", "20260101")
+        assert list_versions("m") == ["20260101"]
+
+    def test_ignores_non_matching_files(self, tmp_artifact_dir):
+        save_pickle({"x": 1}, "m", version="20260101")
+        (tmp_artifact_dir / "m" / "notes.txt").write_text("hi")
+        (tmp_artifact_dir / "m" / "bad_name.pkl").write_bytes(b"")
+        assert list_versions("m") == ["20260101"]
+
+
+# ------------------------------ fixtures -------------------------------------
+
+
+class TestFixturesShape:
+    def test_ohlcv(self, ohlcv_fixture):
+        df = ohlcv_fixture
+        assert list(df.index.names) == ["date", "ticker"]
+        assert set(df.columns) == {
+            "open", "high", "low", "close", "adj_close", "volume",
+        }
+        assert len(df) == 60 * 2
+        assert df["adj_close"].notna().all()
+        assert (df["high"] >= df["low"]).all()
+
+    def test_alpha158(self, alpha158_fixture):
+        df = alpha158_fixture
+        assert list(df.index.names) == ["date", "ticker"]
+        assert df.shape == (50 * 2, 5)
+        assert {"MA5", "MA10", "STD20", "RSQR20", "KMID"} == set(df.columns)
+
+    def test_news(self, news_fixture):
+        assert len(news_fixture) == 20
+        assert {"timestamp", "headline", "tickers", "g_level"}.issubset(news_fixture.columns)
+        assert all(isinstance(t, list) for t in news_fixture["tickers"])
+
+    def test_embeddings(self, embeddings_fixture):
+        mat, dim = embeddings_fixture
+        assert mat.shape == (12, dim)
+        assert mat.dtype == np.float32
+        norms = np.linalg.norm(mat, axis=1)
+        np.testing.assert_allclose(norms, 1.0, atol=1e-5)
+
+    def test_finbert_golden(self, finbert_golden):
+        assert len(finbert_golden) == 10
+        labels = [r["label"] for r in finbert_golden]
+        assert labels.count("positive") == 4
+        assert labels.count("negative") == 4
+        assert labels.count("neutral") == 2
+
+    def test_tmp_artifact_dir_isolates(self, tmp_artifact_dir):
+        assert tmp_artifact_dir.exists()
+        # import 级别的常量也被 patch 了
+        assert _model_io.MODEL_ROOT == tmp_artifact_dir
+        assert small_model_paths.MODEL_ROOT == tmp_artifact_dir
+
+
+# ------------------------------ schema migration -----------------------------
+
+
+_EXPECTED_NEW_COLS = {
+    "finbert_negative",
+    "finbert_neutral",
+    "finbert_confidence",
+    "fine5_importance",
+}
+
+
+def _open_provider(db_path: Path) -> SqliteNewsProvider:
+    p = SqliteNewsProvider(ProviderConfig(
+        implementation="SqliteNewsProvider",
+        params={"db_path": str(db_path)},
+    ))
+    p._do_initialize()
+    return p
+
+
+def _columns(conn: sqlite3.Connection) -> set[str]:
+    return {row[1] for row in conn.execute("PRAGMA table_info(news_events)").fetchall()}
+
+
+class TestSchemaMigration:
+    def test_not_initialized_raises(self, tmp_path):
+        """L2: _migrate_schema 在未 initialize 时必须 raise,不静默 no-op。"""
+        p = SqliteNewsProvider(ProviderConfig(
+            implementation="SqliteNewsProvider",
+            params={"db_path": str(tmp_path / "x.db")},
+        ))
+        with pytest.raises(RuntimeError, match="not initialized"):
+            p._migrate_schema()
+
+    def test_concurrent_alter_race_tolerated(self, tmp_path, monkeypatch):
+        """H4: A 进程 PRAGMA 判断列缺失后,B 进程已抢先 ALTER;A 的 ALTER 抛
+        duplicate column OperationalError。_migrate_schema 应在重新探测后 skip 不崩。
+
+        用 monkeypatch 让 _columns 第一次返回老 set(列缺失),让 _migrate_schema
+        进入 ALTER 分支;peer 已实际加了列 → ALTER 抛 duplicate column;
+        第二次 _columns 返回真实 set → 识别为"对方已加" → 成功。
+        """
+        db = tmp_path / "race.db"
+        seed = sqlite3.connect(str(db))
+        seed.executescript("""
+            CREATE TABLE news_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL, source TEXT NOT NULL, source_url TEXT,
+                headline TEXT NOT NULL, snippet TEXT,
+                sentiment_score REAL, importance_score REAL, reliability_score REAL,
+                g_level INTEGER NOT NULL DEFAULT 0, analysis TEXT, created_at TEXT NOT NULL
+            );
+            CREATE TABLE news_tickers (
+                news_id INTEGER NOT NULL, ticker TEXT NOT NULL,
+                PRIMARY KEY (news_id, ticker)
+            );
+            CREATE TABLE g3_daily_counts (date TEXT PRIMARY KEY, count INTEGER NOT NULL DEFAULT 0);
+        """)
+        # peer 已加 finbert_negative(模拟对方进程抢先)
+        seed.execute("ALTER TABLE news_events ADD COLUMN finbert_negative REAL")
+        seed.commit()
+        seed.close()
+
+        p = SqliteNewsProvider(ProviderConfig(
+            implementation="SqliteNewsProvider",
+            params={"db_path": str(db)},
+        ))
+        p._conn = sqlite3.connect(str(db))
+
+        real_columns = p._columns
+        call_n = {"n": 0}
+        empty_legacy_cols = {
+            "id", "timestamp", "source", "source_url", "headline", "snippet",
+            "sentiment_score", "importance_score", "reliability_score",
+            "g_level", "analysis", "created_at",
+        }
+
+        def faked(*a, **kw):
+            call_n["n"] += 1
+            # 第一次(探测阶段):撒谎说 finbert_negative 没有 → 触发 ALTER → duplicate column
+            if call_n["n"] == 1:
+                return empty_legacy_cols
+            # 之后走真实探测(识别对方已加 + 后续列)
+            return real_columns(*a, **kw)
+
+        monkeypatch.setattr(p, "_columns", faked)
+        try:
+            p._migrate_schema()  # 不应 crash
+        finally:
+            monkeypatch.undo()
+            cols = _columns(p._conn)
+            assert _EXPECTED_NEW_COLS.issubset(cols)
+            p._do_shutdown()
+
+    def test_fresh_db_has_new_columns(self, tmp_path):
+        p = _open_provider(tmp_path / "fresh.db")
+        try:
+            assert _EXPECTED_NEW_COLS.issubset(_columns(p._conn))
+        finally:
+            p._do_shutdown()
+
+    def test_migration_is_idempotent(self, tmp_path):
+        p = _open_provider(tmp_path / "idem.db")
+        try:
+            p._migrate_schema()
+            p._migrate_schema()
+            cols = _columns(p._conn)
+            assert sum(1 for c in cols if c == "finbert_negative") == 1
+        finally:
+            p._do_shutdown()
+
+    def test_reopen_does_not_break(self, tmp_path):
+        db = tmp_path / "reopen.db"
+        p1 = _open_provider(db)
+        p1.insert_news(
+            headline="seed row",
+            source="reuters",
+            timestamp="2026-03-01T00:00:00+00:00",
+        )
+        p1._do_shutdown()
+        p2 = _open_provider(db)
+        try:
+            assert p2._count_all() == 1
+            assert _EXPECTED_NEW_COLS.issubset(_columns(p2._conn))
+        finally:
+            p2._do_shutdown()
+
+    def test_legacy_db_auto_upgrades_without_data_loss(self, tmp_path):
+        """模拟老库 (缺 4 新列) 开库后自动扩列,旧数据完整。"""
+        db = tmp_path / "legacy.db"
+        legacy_sql = """
+            CREATE TABLE news_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                source TEXT NOT NULL,
+                source_url TEXT,
+                headline TEXT NOT NULL,
+                snippet TEXT,
+                sentiment_score REAL,
+                importance_score REAL,
+                reliability_score REAL,
+                g_level INTEGER NOT NULL DEFAULT 0,
+                analysis TEXT,
+                created_at TEXT NOT NULL
+            );
+            CREATE TABLE news_tickers (
+                news_id INTEGER NOT NULL,
+                ticker TEXT NOT NULL,
+                PRIMARY KEY (news_id, ticker)
+            );
+            CREATE TABLE g3_daily_counts (date TEXT PRIMARY KEY, count INTEGER NOT NULL DEFAULT 0);
+        """
+        conn = sqlite3.connect(str(db))
+        conn.executescript(legacy_sql)
+        conn.execute(
+            """INSERT INTO news_events
+               (timestamp, source, headline, sentiment_score, created_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            ("2026-03-01T00:00:00+00:00", "reuters", "legacy headline", 0.8, "2026-03-01T00:00:00+00:00"),
+        )
+        conn.commit()
+        conn.close()
+
+        p = _open_provider(db)
+        try:
+            cols = _columns(p._conn)
+            assert _EXPECTED_NEW_COLS.issubset(cols)
+            cur = p._conn.execute(
+                "SELECT headline, sentiment_score, finbert_negative FROM news_events"
+            )
+            row = cur.fetchone()
+            assert row[0] == "legacy headline"
+            assert row[1] == pytest.approx(0.8)
+            assert row[2] is None  # 新列默认 NULL
+        finally:
+            p._do_shutdown()
+
+    def test_new_columns_are_real_type(self, tmp_path):
+        p = _open_provider(tmp_path / "types.db")
+        try:
+            info = p._conn.execute("PRAGMA table_info(news_events)").fetchall()
+            types = {row[1]: row[2] for row in info}
+            for col in _EXPECTED_NEW_COLS:
+                assert types[col].upper() == "REAL", f"{col} type is {types[col]}"
+        finally:
+            p._do_shutdown()

--- a/tests/small_models/test_finbert_scorer.py
+++ b/tests/small_models/test_finbert_scorer.py
@@ -1,0 +1,396 @@
+"""m2a FinBERTScorer 测试。
+
+覆盖:
+- mock 模式 (device="mock"): 不加载 HF, 确定性关键词路由
+- singleton: get_default_scorer / reset_default_scorer
+- API 形状: score_texts 返回 list[dict{positive,negative,neutral,confidence}]
+- softmax sum / confidence = max 不变式
+- 输入边界: 空列表 / 非 list / batch_size 非法 / 长文本截断
+- lazy load: 空列表不触发 transformers import
+- device 解析: None/cpu/cuda/mps/mock/invalid
+- 真实模型 (@pytest.mark.perf, 默认 skip): finbert_golden 准确率 / 性能 gate / batch 一致性
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from stockbee.small_models import finbert_scorer as fbs
+from stockbee.small_models.finbert_scorer import (
+    FinBERTScorer,
+    _mock_score,
+    get_default_scorer,
+    reset_default_scorer,
+)
+
+_RUN_REAL = bool(os.getenv("RUN_PERF_TESTS"))
+_real_only = pytest.mark.skipif(
+    not _RUN_REAL,
+    reason="set RUN_PERF_TESTS=1 to run tests that load real FinBERT weights",
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton_between_tests():
+    """每个测试独立 singleton,避免测试间状态泄漏。"""
+    reset_default_scorer()
+    yield
+    reset_default_scorer()
+
+
+# ----------------------------------------------------------------------------
+# Mock 模式基础 API
+# ----------------------------------------------------------------------------
+
+
+class TestMockMode:
+    def test_construct_mock_no_hf_load(self):
+        """device='mock' 构造不触发 transformers import。"""
+        s = FinBERTScorer(device="mock")
+        assert s.device == "mock"
+        # 内部状态: 既没加载 model 也没加载 tokenizer
+        assert s._model is None
+        assert s._tokenizer is None
+
+    def test_mock_score_shape(self):
+        s = FinBERTScorer(device="mock")
+        out = s.score_texts(["earnings beat estimates", "layoffs announced"])
+        assert len(out) == 2
+        for row in out:
+            assert set(row.keys()) == {"positive", "negative", "neutral", "confidence"}
+
+    def test_mock_softmax_invariant(self):
+        s = FinBERTScorer(device="mock")
+        out = s.score_texts([
+            "beats earnings",
+            "stock crashed",
+            "company reports tomorrow",
+        ])
+        for row in out:
+            total = row["positive"] + row["negative"] + row["neutral"]
+            assert total == pytest.approx(1.0, abs=1e-6)
+            expected_conf = max(row["positive"], row["negative"], row["neutral"])
+            assert row["confidence"] == pytest.approx(expected_conf, abs=1e-9)
+
+    def test_mock_positive_routing(self):
+        s = FinBERTScorer(device="mock")
+        [row] = s.score_texts(["company beats earnings and raises guidance"])
+        assert row["positive"] > row["negative"]
+        assert row["positive"] > row["neutral"]
+
+    def test_mock_negative_routing(self):
+        s = FinBERTScorer(device="mock")
+        [row] = s.score_texts(["company announces massive layoffs and fraud investigation"])
+        assert row["negative"] > row["positive"]
+        assert row["negative"] > row["neutral"]
+
+    def test_mock_neutral_routing(self):
+        s = FinBERTScorer(device="mock")
+        [row] = s.score_texts(["company will report earnings next Tuesday at 4pm"])
+        # 无明确正/负关键词 → neutral 占优
+        assert row["neutral"] >= row["positive"]
+        assert row["neutral"] >= row["negative"]
+
+    def test_mock_accuracy_on_golden(self, finbert_golden):
+        """mock 在 golden 集上精确准确率 (regression guard against 关键词 list 误改)。
+
+        当前关键词表下 mock 应该打中 10/10;若任一关键词被改动导致 miss,
+        本测试立即失败 (优于 loose 70% 阈值隐藏退化)。
+        """
+        s = FinBERTScorer(device="mock")
+        texts = [row["text"] for row in finbert_golden]
+        out = s.score_texts(texts)
+        predictions = [
+            max(("positive", "negative", "neutral"), key=lambda k: row[k])
+            for row in out
+        ]
+        truths = [row["label"] for row in finbert_golden]
+        mismatches = [
+            (i, finbert_golden[i]["text"], p, t)
+            for i, (p, t) in enumerate(zip(predictions, truths))
+            if p != t
+        ]
+        assert not mismatches, (
+            f"mock heuristic regressed on golden: {mismatches}"
+        )
+
+    def test_mock_mixed_keywords_falls_back_to_neutral(self):
+        """同时含正/负关键词 → 落 neutral 分支。"""
+        s = FinBERTScorer(device="mock")
+        [row] = s.score_texts(["company beats estimates but warns of layoffs"])
+        assert row["neutral"] >= row["positive"]
+        assert row["neutral"] >= row["negative"]
+
+
+# ----------------------------------------------------------------------------
+# 输入/参数边界
+# ----------------------------------------------------------------------------
+
+
+class TestInputBoundaries:
+    def test_empty_list_returns_empty_no_load(self):
+        """空列表短路返回,不尝试加载模型。"""
+        s = FinBERTScorer()  # 非 mock,也不应加载
+        assert s.score_texts([]) == []
+        assert s._model is None
+
+    def test_non_list_raises(self):
+        s = FinBERTScorer(device="mock")
+        with pytest.raises(TypeError):
+            s.score_texts("single string")  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("bad", [None, "", 0, (), {"x": 1}])
+    def test_falsy_non_list_rejected_not_silently_empty(self, bad):
+        """回归测试: 空字符串/None 等 falsy 非 list 值必须 raise TypeError,
+        不能走 `not texts` 短路当空列表返回。"""
+        s = FinBERTScorer(device="mock")
+        with pytest.raises(TypeError):
+            s.score_texts(bad)  # type: ignore[arg-type]
+
+    def test_non_str_element_raises(self):
+        s = FinBERTScorer(device="mock")
+        with pytest.raises(TypeError):
+            s.score_texts(["ok", 123])  # type: ignore[list-item]
+
+    def test_invalid_batch_size(self):
+        s = FinBERTScorer(device="mock")
+        with pytest.raises(ValueError):
+            s.score_texts(["x"], batch_size=0)
+
+    def test_whitespace_only(self):
+        s = FinBERTScorer(device="mock")
+        [row] = s.score_texts(["   \n\t  "])
+        total = row["positive"] + row["negative"] + row["neutral"]
+        assert total == pytest.approx(1.0, abs=1e-6)
+
+
+# ----------------------------------------------------------------------------
+# device 解析
+# ----------------------------------------------------------------------------
+
+
+class TestDeviceResolution:
+    def test_explicit_cpu_valid(self):
+        torch_stub = _make_torch_stub(cuda_available=True, mps_available=True)
+        assert FinBERTScorer._resolve_device(torch_stub, "cpu") == "cpu"
+
+    def test_explicit_cuda_valid(self):
+        torch_stub = _make_torch_stub(cuda_available=False, mps_available=False)
+        assert FinBERTScorer._resolve_device(torch_stub, "cuda") == "cuda"
+
+    def test_auto_prefers_cuda(self):
+        torch_stub = _make_torch_stub(cuda_available=True, mps_available=True)
+        assert FinBERTScorer._resolve_device(torch_stub, None) == "cuda"
+
+    def test_auto_falls_back_mps(self):
+        torch_stub = _make_torch_stub(cuda_available=False, mps_available=True)
+        assert FinBERTScorer._resolve_device(torch_stub, None) == "mps"
+
+    def test_auto_cpu_when_no_accel(self):
+        torch_stub = _make_torch_stub(cuda_available=False, mps_available=False)
+        assert FinBERTScorer._resolve_device(torch_stub, None) == "cpu"
+
+    def test_invalid_device_string(self):
+        torch_stub = _make_torch_stub()
+        with pytest.raises(ValueError):
+            FinBERTScorer._resolve_device(torch_stub, "tpu")
+
+
+def _make_torch_stub(cuda_available: bool = False, mps_available: bool = False):
+    stub = MagicMock()
+    stub.cuda.is_available.return_value = cuda_available
+    stub.backends.mps.is_available.return_value = mps_available
+    return stub
+
+
+# ----------------------------------------------------------------------------
+# Singleton
+# ----------------------------------------------------------------------------
+
+
+class TestSingleton:
+    def test_get_default_scorer_identity(self):
+        a = get_default_scorer()
+        b = get_default_scorer()
+        assert a is b
+
+    def test_reset_creates_new_instance(self):
+        a = get_default_scorer()
+        reset_default_scorer()
+        b = get_default_scorer()
+        assert a is not b
+
+    def test_reset_is_idempotent(self):
+        reset_default_scorer()  # 空状态 reset 不报错
+        reset_default_scorer()
+
+
+# ----------------------------------------------------------------------------
+# HF 加载失败 → 明确错误
+# ----------------------------------------------------------------------------
+
+
+class TestImportFailure:
+    """_ensure_loaded 的 import 失败路径都应 raise RuntimeError 明确提示,
+    不裸 ImportError。用户可参考消息装依赖或切 device='mock'。"""
+
+    def test_ensure_loaded_raises_when_both_missing(self):
+        """torch + transformers 都缺 → RuntimeError 提示安装。"""
+        s = FinBERTScorer()
+        with patch.dict("sys.modules", {"transformers": None, "torch": None}):
+            with pytest.raises(RuntimeError, match="transformers"):
+                s._ensure_loaded()
+
+    def test_ensure_loaded_raises_when_only_transformers_missing(self):
+        """只缺 transformers 也走同一错误分支。"""
+        s = FinBERTScorer()
+        with patch.dict("sys.modules", {"transformers": None}):
+            with pytest.raises(RuntimeError, match="transformers"):
+                s._ensure_loaded()
+
+
+# ----------------------------------------------------------------------------
+# __repr__ / 属性
+# ----------------------------------------------------------------------------
+
+
+class TestRepr:
+    def test_mock_repr(self):
+        s = FinBERTScorer(device="mock")
+        r = repr(s)
+        assert "FinBERTScorer" in r
+        assert "mock" in r
+        assert "loaded=True" in r
+
+    def test_unloaded_repr(self):
+        s = FinBERTScorer()
+        r = repr(s)
+        assert "loaded=False" in r
+        assert "unloaded" in r
+
+    def test_custom_model_name_in_repr(self):
+        s = FinBERTScorer(device="mock", model_name="custom/finbert-ish")
+        assert "custom/finbert-ish" in repr(s)
+
+
+# ----------------------------------------------------------------------------
+# _mock_score 工具函数直测
+# ----------------------------------------------------------------------------
+
+
+class TestMockScoreFunction:
+    def test_positive_shape(self):
+        out = _mock_score("beats earnings estimates")
+        assert out["positive"] == 0.70
+        assert out["confidence"] == 0.70
+
+    def test_negative_shape(self):
+        out = _mock_score("company reports massive loss and layoffs")
+        assert out["negative"] == 0.70
+        assert out["confidence"] == 0.70
+
+    def test_neutral_shape(self):
+        out = _mock_score("board approves routine share buyback")
+        assert out["neutral"] == 0.60
+        assert out["confidence"] == 0.60
+
+
+# ----------------------------------------------------------------------------
+# 真实 FinBERT 加载 (@pytest.mark.perf, 默认 skip)
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.perf
+@_real_only
+class TestFinBERTRealModel:
+    """需要 RUN_PERF_TESTS=1 + 网络下载 ~440MB ProsusAI/finbert。"""
+
+    def test_real_accuracy_on_golden(self, finbert_golden):
+        """真实模型在 finbert_golden 10 条上 argmax 准确率 >= 8/10。"""
+        reset_default_scorer()
+        scorer = FinBERTScorer()
+        texts = [row["text"] for row in finbert_golden]
+        out = scorer.score_texts(texts, batch_size=8)
+        correct = 0
+        for scored, truth in zip(out, finbert_golden):
+            pred = max(("positive", "negative", "neutral"), key=lambda k: scored[k])
+            if pred == truth["label"]:
+                correct += 1
+        assert correct >= 8, f"accuracy {correct}/10 < 8/10"
+
+    def test_batch_consistency(self, finbert_golden):
+        """batch=1 / batch=4 / batch=32 对同输入结果一致 (tol 1e-4)。"""
+        reset_default_scorer()
+        scorer = FinBERTScorer()
+        texts = [row["text"] for row in finbert_golden]
+        out_b1 = scorer.score_texts(texts, batch_size=1)
+        out_b4 = scorer.score_texts(texts, batch_size=4)
+        out_b32 = scorer.score_texts(texts, batch_size=32)
+        for a, b, c in zip(out_b1, out_b4, out_b32):
+            for k in ("positive", "negative", "neutral"):
+                assert a[k] == pytest.approx(b[k], abs=1e-4)
+                assert b[k] == pytest.approx(c[k], abs=1e-4)
+
+    def test_real_softmax_invariant(self):
+        reset_default_scorer()
+        scorer = FinBERTScorer()
+        out = scorer.score_texts(["company beats earnings"])
+        row = out[0]
+        total = row["positive"] + row["negative"] + row["neutral"]
+        assert total == pytest.approx(1.0, abs=1e-4)
+        assert row["confidence"] == pytest.approx(
+            max(row["positive"], row["negative"], row["neutral"]), abs=1e-6
+        )
+
+    def test_long_text_truncation_no_crash(self):
+        """远超 128 token 的文本,tokenizer truncation=True 不报错。"""
+        reset_default_scorer()
+        scorer = FinBERTScorer()
+        long_text = "earnings beat " * 200  # 远超 128 token
+        out = scorer.score_texts([long_text])
+        assert len(out) == 1
+        row = out[0]
+        assert 0.0 <= row["positive"] <= 1.0
+
+
+@pytest.mark.perf
+@_real_only
+class TestFinBERTPerfGate:
+    """PRD §3.3 硬约束: batch=32, max_length=128 推理 <100ms GPU / <300ms CPU。
+
+    采样 3 warm-up + 10 中位数,降低冷启动/GC 噪声。
+    """
+
+    @staticmethod
+    def _percentile(data: list[float], p: float) -> float:
+        data_sorted = sorted(data)
+        k = max(0, min(len(data_sorted) - 1, int(len(data_sorted) * p)))
+        return data_sorted[k]
+
+    def test_batch32_latency_gate(self):
+        import time
+
+        reset_default_scorer()
+        scorer = FinBERTScorer()
+        texts = [
+            "earnings beat estimates by a wide margin; guidance raised." for _ in range(32)
+        ]
+        # warm-up
+        for _ in range(3):
+            scorer.score_texts(texts, batch_size=32)
+        samples = []
+        for _ in range(10):
+            t0 = time.perf_counter()
+            scorer.score_texts(texts, batch_size=32)
+            samples.append((time.perf_counter() - t0) * 1000.0)
+        median_ms = self._percentile(samples, 0.5)
+
+        dev = scorer.device
+        tolerance_ms = 100.0 if dev == "cuda" else 300.0
+        assert median_ms < tolerance_ms, (
+            f"FinBERT batch=32 median {median_ms:.1f}ms exceeds "
+            f"{tolerance_ms:.0f}ms on device={dev}"
+        )

--- a/tests/small_models/test_finbert_scorer.py
+++ b/tests/small_models/test_finbert_scorer.py
@@ -235,7 +235,11 @@ class TestSingleton:
 
 class TestImportFailure:
     """_ensure_loaded 的 import 失败路径都应 raise RuntimeError 明确提示,
-    不裸 ImportError。用户可参考消息装依赖或切 device='mock'。"""
+    不裸 ImportError。用户可参考消息装依赖或切 device='mock'。
+
+    注意: 两个测试都把 torch 和 transformers 同时 patch 为 None,避免真实加载
+    torch (macOS 上 torch 的 libomp 和 lightgbm 的 libomp 在同进程冲突会 abort)。
+    """
 
     def test_ensure_loaded_raises_when_both_missing(self):
         """torch + transformers 都缺 → RuntimeError 提示安装。"""
@@ -244,10 +248,10 @@ class TestImportFailure:
             with pytest.raises(RuntimeError, match="transformers"):
                 s._ensure_loaded()
 
-    def test_ensure_loaded_raises_when_only_transformers_missing(self):
-        """只缺 transformers 也走同一错误分支。"""
+    def test_ensure_loaded_raises_when_transformers_missing(self):
+        """transformers 缺失 → 同一错误分支 (torch 同样 patch 掉以防实际加载)。"""
         s = FinBERTScorer()
-        with patch.dict("sys.modules", {"transformers": None}):
+        with patch.dict("sys.modules", {"transformers": None, "torch": None}):
             with pytest.raises(RuntimeError, match="transformers"):
                 s._ensure_loaded()
 

--- a/tests/small_models/test_fine5.py
+++ b/tests/small_models/test_fine5.py
@@ -1,0 +1,604 @@
+"""m5 Fin-E5 Embedding Scorer + Importance Baseline 测试。
+
+覆盖:
+- FinE5Scorer API: encode / cosine_sim / cosine_dedup
+- mock encode 确定性
+- cosine_dedup 传递闭包 + 空输入 + threshold 边界
+- baseline_importance 公式: 值域 [0, 1], 手算 golden, NaN 传播
+- backfill_importance: 只写 NULL 行, since 过滤, 批次分页, 空 DB
+- 真实 e5-large-v2 (@pytest.mark.perf): encode shape, batch 一致性
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from stockbee.small_models.fine5_scorer import (
+    FinE5Scorer,
+    _l2_normalize,
+    _mock_encode,
+)
+from stockbee.small_models.importance_baseline import (
+    backfill_importance,
+    baseline_importance,
+)
+
+_RUN_REAL = bool(os.getenv("RUN_PERF_TESTS"))
+_real_only = pytest.mark.skipif(
+    not _RUN_REAL,
+    reason="set RUN_PERF_TESTS=1 to load real e5-large-v2 weights",
+)
+
+
+# ============================================================================
+# FinE5Scorer — mock 模式
+# ============================================================================
+
+
+class TestFinE5Mock:
+    def test_construct_mock_no_hf_load(self):
+        s = FinE5Scorer(device="mock")
+        assert s.device == "mock"
+        assert s._model is None
+        assert s._tokenizer is None
+
+    def test_embedding_dim_default_mock(self):
+        s = FinE5Scorer(device="mock")
+        assert s.embedding_dim == 1024  # mock 默认
+
+    def test_encode_shape(self):
+        s = FinE5Scorer(device="mock")
+        emb = s.encode(["text one", "text two", "text three"])
+        assert emb.shape == (3, 1024)
+        assert emb.dtype == np.float32
+
+    def test_encode_l2_normalized(self):
+        s = FinE5Scorer(device="mock")
+        emb = s.encode(["foo", "bar"])
+        norms = np.linalg.norm(emb, axis=1)
+        assert np.allclose(norms, 1.0, atol=1e-5)
+
+    def test_encode_deterministic(self):
+        s = FinE5Scorer(device="mock")
+        e1 = s.encode(["same text"])
+        e2 = s.encode(["same text"])
+        assert np.allclose(e1, e2)
+
+    def test_encode_different_texts_different_vectors(self):
+        s = FinE5Scorer(device="mock")
+        emb = s.encode(["text A", "text B wholly different"])
+        # 高维随机向量 cosine ~ 0
+        assert not np.allclose(emb[0], emb[1])
+
+    def test_encode_empty_returns_empty_no_load(self):
+        s = FinE5Scorer()  # 非 mock 也应短路
+        out = s.encode([])
+        assert out.shape[0] == 0
+        assert s._model is None
+
+    def test_encode_non_list_rejected(self):
+        s = FinE5Scorer(device="mock")
+        with pytest.raises(TypeError):
+            s.encode("single")  # type: ignore[arg-type]
+
+    def test_encode_invalid_batch_size(self):
+        s = FinE5Scorer(device="mock")
+        with pytest.raises(ValueError):
+            s.encode(["x"], batch_size=0)
+
+    def test_encode_invalid_max_length(self):
+        s = FinE5Scorer(device="mock")
+        with pytest.raises(ValueError):
+            s.encode(["x"], max_length=0)
+
+
+# ============================================================================
+# cosine_sim
+# ============================================================================
+
+
+class TestCosineSim:
+    def test_self_similarity_is_identity(self):
+        s = FinE5Scorer(device="mock")
+        emb = s.encode(["a", "b", "c"])
+        sim = s.cosine_sim(emb)
+        assert sim.shape == (3, 3)
+        # 对角 ≈ 1
+        assert np.allclose(np.diag(sim), 1.0, atol=1e-5)
+        # 对称
+        assert np.allclose(sim, sim.T, atol=1e-5)
+
+    def test_cross_matrix_shape(self):
+        s = FinE5Scorer(device="mock")
+        a = s.encode(["a1", "a2", "a3"])
+        b = s.encode(["b1", "b2"])
+        sim = s.cosine_sim(a, b)
+        assert sim.shape == (3, 2)
+
+    def test_shape_mismatch_raises(self):
+        s = FinE5Scorer(device="mock")
+        with pytest.raises(ValueError):
+            s.cosine_sim(np.zeros((3, 10)), np.zeros((2, 8)))
+
+    def test_1d_input_raises(self):
+        s = FinE5Scorer(device="mock")
+        with pytest.raises(ValueError):
+            s.cosine_sim(np.zeros(10))
+
+
+# ============================================================================
+# cosine_dedup — 重点: 传递闭包
+# ============================================================================
+
+
+def _vec_near(base: np.ndarray, angle_frac: float) -> np.ndarray:
+    """给定 base 单位向量,返回与之 cosine ≈ cos(angle_frac*π/2) 的向量。"""
+    # 构造正交扰动
+    rng = np.random.default_rng(0)
+    perp = rng.standard_normal(len(base)).astype(np.float32)
+    perp -= (perp @ base) * base
+    perp /= np.linalg.norm(perp)
+    # cosine theta = cos(angle)
+    theta = angle_frac * (np.pi / 2.0)
+    v = np.cos(theta) * base + np.sin(theta) * perp
+    return (v / np.linalg.norm(v)).astype(np.float32)
+
+
+class TestCosineDedup:
+    def test_two_near_texts_one_cluster(self):
+        """两条高相似向量 → dedup 保留 1 个 representative。"""
+        s = FinE5Scorer(device="mock")
+        base = np.zeros(32, dtype=np.float32)
+        base[0] = 1.0
+        v1 = base.copy()
+        v2 = _vec_near(base, 0.05)  # cosine ≈ cos(4.5°) ≈ 0.9969
+        emb = np.stack([v1, v2])
+        keep = s.cosine_dedup(emb, threshold=0.99)
+        assert keep == [0]
+
+    def test_unrelated_texts_stay_separate(self):
+        s = FinE5Scorer(device="mock")
+        dim = 32
+        rng = np.random.default_rng(42)
+        emb = rng.standard_normal((3, dim)).astype(np.float32)
+        emb = _l2_normalize(emb)
+        keep = s.cosine_dedup(emb, threshold=0.99)
+        assert keep == [0, 1, 2]
+
+    def test_transitive_closure(self):
+        """A~B, B~C, 但 A-C 直接 < threshold → 传递闭包仍同组 (union-find)。"""
+        s = FinE5Scorer(device="mock")
+        dim = 64
+        base = np.zeros(dim, dtype=np.float32)
+        base[0] = 1.0
+        A = base.copy()
+        B = _vec_near(base, 0.18)
+        C = _vec_near(B, 0.18)
+        emb = np.stack([A, B, C])
+
+        sim = s.cosine_sim(emb)
+        # 选一个 threshold 使 A-B 和 B-C 都 >= threshold,且 A-C < threshold
+        # 保证本测试专门走"传递闭包"分支,而非普通三元合并
+        threshold = min(sim[0, 1], sim[1, 2]) - 1e-4
+        assert sim[0, 1] >= threshold
+        assert sim[1, 2] >= threshold
+        assert sim[0, 2] < threshold, (
+            f"测试设计失效: A-C {sim[0,2]:.4f} 应低于 threshold {threshold:.4f}"
+        )
+        keep_transitive = s.cosine_dedup(emb, threshold=threshold)
+        assert keep_transitive == [0], (
+            f"传递闭包失败: sim={sim} keep={keep_transitive}"
+        )
+
+    def test_threshold_exact_equality_merges(self):
+        """sim == threshold 时使用 >= 合并 (不漏)。"""
+        s = FinE5Scorer(device="mock")
+        dim = 8
+        base = np.zeros(dim, dtype=np.float32)
+        base[0] = 1.0
+        # 构造 cosine 恰好 = 0.8 的两向量: v = 0.8 * base + 0.6 * perp
+        perp = np.zeros(dim, dtype=np.float32)
+        perp[1] = 1.0
+        v = 0.8 * base + 0.6 * perp
+        v = (v / np.linalg.norm(v)).astype(np.float32)
+        emb = np.stack([base, v])
+        sim = s.cosine_sim(emb)
+        assert sim[0, 1] == pytest.approx(0.8, abs=1e-5)
+        keep = s.cosine_dedup(emb, threshold=0.8)
+        assert keep == [0], "相等即合并 (>= threshold),不应漏合"
+        # 略高于 sim → 不合并
+        keep_strict = s.cosine_dedup(emb, threshold=0.81)
+        assert keep_strict == [0, 1]
+
+    def test_empty_input(self):
+        s = FinE5Scorer(device="mock")
+        assert s.cosine_dedup(np.zeros((0, 10))) == []
+
+    def test_1d_embeds_raises(self):
+        s = FinE5Scorer(device="mock")
+        with pytest.raises(ValueError):
+            s.cosine_dedup(np.zeros(10))
+
+    def test_threshold_out_of_range(self):
+        s = FinE5Scorer(device="mock")
+        with pytest.raises(ValueError):
+            s.cosine_dedup(np.ones((2, 4), dtype=np.float32), threshold=1.5)
+
+    def test_threshold_boundary_at_zero_merges_nonnegative_pairs(self):
+        """threshold=0 → 所有正 cosine 对合并 (mock 向量高维几乎正交,可能部分合并)。"""
+        s = FinE5Scorer(device="mock")
+        emb = s.encode(["a", "b", "c"])
+        keep = s.cosine_dedup(emb, threshold=0.0)
+        # 至少合并到 1 组 (不大于 3)
+        assert 1 <= len(keep) <= 3
+
+    def test_threshold_one_keeps_all_unless_identical(self):
+        """threshold=1.0 → 几乎不合并 (除非完全相同)。"""
+        s = FinE5Scorer(device="mock")
+        emb = s.encode(["a", "b"])
+        keep = s.cosine_dedup(emb, threshold=1.0 - 1e-9)
+        # "a" 和 "b" mock 出的向量不会一模一样
+        assert len(keep) == 2
+
+
+# ============================================================================
+# Device resolution (mirrors FinBERT)
+# ============================================================================
+
+
+class TestDeviceResolution:
+    def test_mock_repr(self):
+        s = FinE5Scorer(device="mock")
+        assert "FinE5Scorer" in repr(s)
+        assert "mock" in repr(s)
+
+    def test_unloaded_repr(self):
+        s = FinE5Scorer()
+        assert "unloaded" in repr(s)
+
+    def test_invalid_device(self):
+        from stockbee.small_models.fine5_scorer import _resolve_device
+        from unittest.mock import MagicMock
+
+        stub = MagicMock()
+        with pytest.raises(ValueError):
+            _resolve_device(stub, "tpu")
+
+
+# ============================================================================
+# baseline_importance — 公式 + 值域 + NaN
+# ============================================================================
+
+
+class TestBaselineImportance:
+    @staticmethod
+    def _df(**cols):
+        return pd.DataFrame(cols)
+
+    def test_value_range_in_0_1(self):
+        df = self._df(
+            count_30d=[0, 5, 10, 20, 100],
+            sentiment_score=[0.0, 0.25, 0.5, 0.75, 1.0],
+            reliability_score=[0.0, 0.5, 1.0, 1.2, -0.3],
+        )
+        s = baseline_importance(df)
+        assert (s >= 0.0).all()
+        assert (s <= 1.0).all()
+
+    def test_high_extreme_positive(self):
+        """高 count + 极端情绪 (sent=1.0) + 高 reliability → 接近 1。"""
+        df = self._df(
+            count_30d=[20],
+            sentiment_score=[1.0],
+            reliability_score=[1.0],
+        )
+        assert baseline_importance(df).iloc[0] == pytest.approx(1.0, abs=1e-6)
+
+    def test_high_extreme_negative(self):
+        """sent=0.0 同样极端。"""
+        df = self._df(
+            count_30d=[20],
+            sentiment_score=[0.0],
+            reliability_score=[1.0],
+        )
+        assert baseline_importance(df).iloc[0] == pytest.approx(1.0, abs=1e-6)
+
+    def test_neutral_sentiment_zero(self):
+        """sent=0.5 → importance=0 (无论 count/reliability)。"""
+        df = self._df(
+            count_30d=[100],
+            sentiment_score=[0.5],
+            reliability_score=[1.0],
+        )
+        assert baseline_importance(df).iloc[0] == 0.0
+
+    def test_low_count_low_score(self):
+        df = self._df(
+            count_30d=[0],
+            sentiment_score=[1.0],
+            reliability_score=[1.0],
+        )
+        assert baseline_importance(df).iloc[0] == 0.0
+
+    def test_manual_golden(self):
+        """count=5 (factor=0.5), sent=0.8 (factor=0.6), rel=0.5 → 0.5*0.6*0.5 = 0.15。"""
+        df = self._df(
+            count_30d=[5],
+            sentiment_score=[0.8],
+            reliability_score=[0.5],
+        )
+        assert baseline_importance(df).iloc[0] == pytest.approx(0.15, abs=1e-9)
+
+    def test_reliability_negative_clipped_to_zero(self):
+        df = self._df(
+            count_30d=[10],
+            sentiment_score=[1.0],
+            reliability_score=[-0.5],
+        )
+        assert baseline_importance(df).iloc[0] == 0.0
+
+    def test_count_saturation(self):
+        """count >= 10 和 count = 1000 产出相同 (满饱和)。"""
+        a = self._df(count_30d=[10], sentiment_score=[1.0], reliability_score=[1.0])
+        b = self._df(count_30d=[1000], sentiment_score=[1.0], reliability_score=[1.0])
+        assert baseline_importance(a).iloc[0] == baseline_importance(b).iloc[0]
+
+    def test_nan_in_count_30d_propagates(self):
+        df = self._df(
+            count_30d=[np.nan, 10],
+            sentiment_score=[0.8, 0.8],
+            reliability_score=[0.9, 0.9],
+        )
+        out = baseline_importance(df)
+        assert np.isnan(out.iloc[0])
+        assert not np.isnan(out.iloc[1])
+
+    def test_nan_in_sentiment_propagates(self):
+        df = self._df(
+            count_30d=[10, 10],
+            sentiment_score=[np.nan, 0.8],
+            reliability_score=[0.9, 0.9],
+        )
+        out = baseline_importance(df)
+        assert np.isnan(out.iloc[0])
+        assert not np.isnan(out.iloc[1])
+
+    def test_nan_in_reliability_propagates(self):
+        df = self._df(
+            count_30d=[10, 10],
+            sentiment_score=[0.8, 0.8],
+            reliability_score=[np.nan, 0.9],
+        )
+        out = baseline_importance(df)
+        assert np.isnan(out.iloc[0])
+        assert not np.isnan(out.iloc[1])
+
+    def test_missing_column_raises(self):
+        df = self._df(
+            count_30d=[10],
+            sentiment_score=[0.8],
+            # reliability_score 缺失
+        )
+        with pytest.raises(ValueError, match="reliability_score"):
+            baseline_importance(df)
+
+
+# ============================================================================
+# backfill_importance — SQLite 集成
+# ============================================================================
+
+
+@pytest.fixture
+def populated_news_store(tmp_path, monkeypatch):
+    """新建临时 SqliteNewsProvider, 插入 5 条新闻 (不同 ticker/时间) 并初始化。"""
+    from stockbee.news_data.news_store import SqliteNewsProvider
+    from stockbee.providers.config import ProviderConfig
+
+    db_path = tmp_path / "news.db"
+    cfg = ProviderConfig(implementation="test", params={"db_path": str(db_path)})
+    store = SqliteNewsProvider(cfg)
+    store.initialize()
+
+    base = datetime(2026, 3, 1, 9, 30, tzinfo=timezone.utc)
+    # 5 条: 2 AAPL 近期 + 2 MSFT 近期 + 1 旧 AAPL
+    events = [
+        {
+            "headline": "AAPL beats earnings",
+            "source": "reuters",
+            "timestamp": base.isoformat(),
+            "tickers": ["AAPL"],
+            "sentiment_score": 0.9,
+            "reliability_score": 0.8,
+        },
+        {
+            "headline": "AAPL new product",
+            "source": "bloomberg",
+            "timestamp": (base + timedelta(hours=6)).isoformat(),
+            "tickers": ["AAPL"],
+            "sentiment_score": 0.7,
+            "reliability_score": 0.9,
+        },
+        {
+            "headline": "MSFT cloud revenue",
+            "source": "reuters",
+            "timestamp": (base + timedelta(hours=12)).isoformat(),
+            "tickers": ["MSFT"],
+            "sentiment_score": 0.85,
+            "reliability_score": 0.7,
+        },
+        {
+            "headline": "MSFT cost cuts",
+            "source": "bloomberg",
+            "timestamp": (base + timedelta(hours=18)).isoformat(),
+            "tickers": ["MSFT"],
+            "sentiment_score": 0.3,
+            "reliability_score": 0.6,
+        },
+        {
+            "headline": "AAPL ancient news",
+            "source": "reuters",
+            "timestamp": (base - timedelta(days=60)).isoformat(),
+            "tickers": ["AAPL"],
+            "sentiment_score": 0.6,
+            "reliability_score": 0.5,
+        },
+    ]
+    store.insert_news_batch(events)
+    yield store
+    store.shutdown()
+
+
+class TestBackfillImportance:
+    def test_writes_null_rows(self, populated_news_store):
+        updated = backfill_importance(populated_news_store, batch=100)
+        assert updated == 5
+        # 再次跑应 0 (都已写)
+        updated2 = backfill_importance(populated_news_store, batch=100)
+        assert updated2 == 0
+
+    def test_does_not_overwrite_non_null(self, populated_news_store):
+        # 手动在一条上预置非空值
+        conn = populated_news_store._conn
+        conn.execute(
+            "UPDATE news_events SET fine5_importance = 0.777 WHERE id = 1"
+        )
+        conn.commit()
+        backfill_importance(populated_news_store, batch=100)
+        row = conn.execute(
+            "SELECT fine5_importance FROM news_events WHERE id = 1"
+        ).fetchone()
+        assert row[0] == pytest.approx(0.777, abs=1e-9)
+
+    def test_since_filter(self, populated_news_store):
+        # since = base - 30d → ancient news (60 days old) 被排除
+        since = "2026-02-15T00:00:00+00:00"
+        updated = backfill_importance(
+            populated_news_store, since=since, batch=100
+        )
+        # 5 条中 1 条在 since 之前 → 只处理 4 条
+        assert updated == 4
+
+    def test_since_filter_naive_tz_treated_as_utc(self, populated_news_store):
+        """review H1: 无 tz 的 since 字符串自动按 UTC 处理。"""
+        updated = backfill_importance(
+            populated_news_store, since="2026-02-15T00:00:00", batch=100
+        )
+        assert updated == 4
+
+    def test_since_filter_non_utc_tz_converted(self, populated_news_store):
+        """review H1: 非 UTC tz 的 since 转成 UTC 再与 DB 字符串比较。"""
+        # 2026-02-15 00:00:00 -05:00  等价  2026-02-15 05:00:00 UTC
+        # 5 条新闻里 "ancient" 是 base - 60d (~2026-01-01 UTC), 在此 since 之前
+        # 近期 4 条 (base ~ 2026-03-01 UTC) 在 since 之后
+        updated = backfill_importance(
+            populated_news_store,
+            since="2026-02-15T00:00:00-05:00",
+            batch=100,
+        )
+        assert updated == 4
+
+    def test_batch_pagination(self, populated_news_store):
+        u1 = backfill_importance(populated_news_store, batch=2)
+        u2 = backfill_importance(populated_news_store, batch=2)
+        u3 = backfill_importance(populated_news_store, batch=2)
+        assert u1 + u2 + u3 == 5
+        assert u1 == 2 and u2 == 2 and u3 == 1
+
+    def test_empty_db(self, tmp_path):
+        from stockbee.news_data.news_store import SqliteNewsProvider
+        from stockbee.providers.config import ProviderConfig
+
+        cfg = ProviderConfig(implementation="t", params={"db_path": str(tmp_path / "x.db")})
+        store = SqliteNewsProvider(cfg)
+        store.initialize()
+        assert backfill_importance(store) == 0
+        store.shutdown()
+
+    def test_skip_rows_without_sentiment(self, populated_news_store):
+        """sentiment_score 为 NULL 的行不处理。"""
+        conn = populated_news_store._conn
+        conn.execute("UPDATE news_events SET sentiment_score = NULL WHERE id = 1")
+        conn.commit()
+        updated = backfill_importance(populated_news_store, batch=100)
+        assert updated == 4  # 5 条中 1 条缺 sentiment → 跳过
+
+    def test_invalid_batch(self, populated_news_store):
+        with pytest.raises(ValueError):
+            backfill_importance(populated_news_store, batch=0)
+
+    def test_store_not_initialized(self, tmp_path):
+        from stockbee.news_data.news_store import SqliteNewsProvider
+        from stockbee.providers.config import ProviderConfig
+
+        cfg = ProviderConfig(implementation="t", params={"db_path": str(tmp_path / "x.db")})
+        store = SqliteNewsProvider(cfg)
+        # 不 initialize
+        with pytest.raises(RuntimeError, match="initialize"):
+            backfill_importance(store)
+
+
+# ============================================================================
+# 内部工具直测
+# ============================================================================
+
+
+class TestInternalHelpers:
+    def test_l2_normalize_zero_vector_safe(self):
+        x = np.array([[0.0, 0.0], [1.0, 0.0]], dtype=np.float32)
+        n = _l2_normalize(x)
+        # 零行原样保留 (除数 fallback=1)
+        assert np.allclose(n[0], 0.0)
+        assert np.allclose(n[1], [1.0, 0.0])
+
+    def test_mock_encode_same_text_same_vector(self):
+        e1 = _mock_encode(["x"], 32)
+        e2 = _mock_encode(["x"], 32)
+        assert np.allclose(e1, e2)
+
+    def test_mock_encode_l2_normalized(self):
+        e = _mock_encode(["a", "b", "c"], 64)
+        assert np.allclose(np.linalg.norm(e, axis=1), 1.0, atol=1e-5)
+
+
+# ============================================================================
+# 真实 e5-large-v2 (@pytest.mark.perf)
+# ============================================================================
+
+
+@pytest.mark.perf
+@_real_only
+class TestFinE5RealModel:
+    def test_encode_hidden_size_dynamic(self):
+        """embedding_dim 从 model.config 动态读,而非硬编码。"""
+        scorer = FinE5Scorer()
+        dim = scorer.embedding_dim
+        assert dim == 1024  # e5-large-v2 实际值
+
+    def test_batch_consistency(self):
+        scorer = FinE5Scorer()
+        texts = [
+            "company beats earnings estimates",
+            "stock crashes on bad news",
+            "board approves buyback",
+        ]
+        e_b1 = scorer.encode(texts, batch_size=1)
+        e_b16 = scorer.encode(texts, batch_size=16)
+        for a, b in zip(e_b1, e_b16):
+            assert np.allclose(a, b, atol=1e-4)
+
+    def test_similar_texts_high_cosine(self):
+        scorer = FinE5Scorer()
+        emb = scorer.encode([
+            "Apple beats earnings by 12%",
+            "Apple reports strong earnings beat",
+            "Company announces massive layoffs",
+        ])
+        sim = scorer.cosine_sim(emb)
+        # 前两条相关,应比与第三条更高
+        assert sim[0, 1] > sim[0, 2]
+        assert sim[0, 1] > sim[1, 2]

--- a/tests/small_models/test_integration.py
+++ b/tests/small_models/test_integration.py
@@ -1,0 +1,809 @@
+"""02-small-models m6 跨模块集成测试。
+
+参考 04-factor-storage m7 模式 (~18 cases, ~520 行)。单元测试已覆盖单模块正确性;
+本 milestone 做组合 / 边界 / 冲突验证。
+
+分组:
+  A. Contracts + artifact 流转: model_io 跨 m2a / m3 / m4 / m5 共享 + 跨模型版本 list
+  B. FinBERT 端到端: news → g2 → DB → LocalSentimentProvider 查询 / backfill / singleton identity
+  C. LightGBM 端到端: train → artifact → scorer → parquet → LocalFactorProvider 自动发现
+  D. evaluate_ml_score wire: oracle IC ≈ 1 + shift=5 不污染 get_ic_report
+  E. 列冲突并存: sentiment_score / finbert_* / fine5_importance / importance_score 并存
+  F. 性能回归 (@pytest.mark.perf, RUN_PERF_TESTS=1 opt-in)
+  G. Edge cases: 尾部 label 缺失 / 空 news DB / 100K 行 chunked commit smoke
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+import tracemalloc
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from stockbee.factor_data.local_provider import LocalFactorProvider
+from stockbee.factor_data.parquet_factor import ParquetFactorStore
+from stockbee.news_data.g2_classifier import G2Classifier, G2Config
+from stockbee.news_data.news_store import SqliteNewsProvider
+from stockbee.news_data.sync import NewsDataSyncer
+from stockbee.providers.base import ProviderConfig
+from stockbee.providers.registry import ProviderRegistry
+from stockbee.small_models import model_io
+from stockbee.small_models.finbert_scorer import (
+    FinBERTScorer,
+    get_default_scorer,
+    reset_default_scorer,
+)
+from stockbee.small_models.importance_baseline import backfill_importance
+from stockbee.small_models.lightgbm_scorer import (
+    LightGBMScorer,
+    ML_SCORE_COLUMN,
+    ML_SCORE_GROUP,
+    evaluate_ml_score,
+)
+from stockbee.small_models.lightgbm_trainer import (
+    MODEL_NAME as LGBM_MODEL_NAME,
+    train_and_save,
+)
+from stockbee.small_models.local_sentiment_provider import LocalSentimentProvider
+
+_RUN_PERF = bool(os.getenv("RUN_PERF_TESTS"))
+_perf_skip = pytest.mark.skipif(not _RUN_PERF, reason="set RUN_PERF_TESTS=1")
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    reset_default_scorer()
+    yield
+    reset_default_scorer()
+
+
+# ============================================================================
+# Helpers: 复用 m3 / m4 / m5 测试里的 mock provider, 这里本地定义避免跨文件导入
+# ============================================================================
+
+
+class _MockBooster:
+    def __init__(self, feature_names, coefs=None):
+        self._names = list(feature_names)
+        self._coefs = np.array(
+            coefs if coefs is not None else [1.0] * len(feature_names),
+            dtype=float,
+        )
+
+    def feature_name(self):
+        return list(self._names)
+
+    def predict(self, X):
+        return np.asarray(X, dtype=float) @ self._coefs
+
+
+class _FakeFactorProvider:
+    def __init__(self, factor_df, expression, precomp=None):
+        self.factor_df = factor_df
+        self._expr = expression
+        self._precomp = precomp or []
+
+    def get_factors(self, tickers, factor_names, start, end):
+        return self.factor_df[list(factor_names)]
+
+    def list_factors(self):
+        return (
+            [{"name": n, "type": "expression"} for n in self._expr]
+            + [{"name": n, "type": "precomputed"} for n in self._precomp]
+        )
+
+
+class _FakeMarketDataProvider:
+    def __init__(self, bars):
+        self.bars = bars
+
+    def get_daily_bars(self, tickers, start, end, fields=None):
+        return self.bars
+
+
+def _make_ohlcv(n_days=100, tickers=("AAPL", "MSFT"), seed=42):
+    rng = np.random.default_rng(seed)
+    dates = pd.bdate_range("2026-01-02", periods=n_days)
+    idx = pd.MultiIndex.from_product(
+        [dates, list(tickers)], names=["date", "ticker"]
+    )
+    n = len(idx)
+    base = 100.0 + rng.standard_normal(n) * 2.0
+    return pd.DataFrame(
+        {
+            "open": base,
+            "high": base * 1.01,
+            "low": base * 0.99,
+            "close": base,
+            "adj_close": base,
+            "volume": rng.integers(1_000_000, 5_000_000, n),
+        },
+        index=idx,
+    )
+
+
+def _make_factor_df(n_days=100, tickers=("AAPL", "MSFT"), cols=("f1", "f2", "f3"), seed=0):
+    rng = np.random.default_rng(seed)
+    dates = pd.bdate_range("2026-01-02", periods=n_days)
+    idx = pd.MultiIndex.from_product(
+        [dates, list(tickers)], names=["date", "ticker"]
+    )
+    return pd.DataFrame(
+        rng.standard_normal((len(idx), len(cols))),
+        index=idx,
+        columns=list(cols),
+    )
+
+
+# ============================================================================
+# A. Contracts + artifact 流转
+# ============================================================================
+
+
+class TestGroupA_ArtifactIsolation:
+    def test_model_io_shared_across_submodules(self, tmp_artifact_dir):
+        """m2a / m3 / m4 / m5 全部走同一 model_io API,artifact 互不冲突。"""
+        # 存 4 种不同 name 的 artifact
+        for name, payload in [
+            ("finbert", {"dummy": "scorer_state"}),
+            ("lightgbm", _MockBooster(["f1", "f2"], [1.0, 2.0])),
+            ("fine5", {"dummy": "encoder"}),
+            ("baseline_rule", {"coef": 0.5}),
+        ]:
+            p = model_io.save_pickle(payload, name, version="20260420")
+            assert p.exists()
+            model_io.update_symlink(name, "20260420")
+            loaded = model_io.load_pickle(name, version="current")
+            assert loaded is not None
+
+        # 每个目录下 versions 列表独立
+        for name in ("finbert", "lightgbm", "fine5", "baseline_rule"):
+            versions = model_io.list_versions(name)
+            assert versions == ["20260420"]
+
+    def test_concurrent_update_symlink_safe(self, tmp_artifact_dir):
+        """两线程并发 update_symlink 不会死锁/文件破坏。"""
+        # 先建两个版本
+        for v in ("20260418", "20260419"):
+            model_io.save_pickle({"v": v}, "shared", version=v)
+
+        errors: list[Exception] = []
+
+        def flip(v):
+            try:
+                for _ in range(20):
+                    model_io.update_symlink("shared", v)
+            except Exception as e:  # noqa: BLE001
+                errors.append(e)
+
+        t1 = threading.Thread(target=flip, args=("20260418",))
+        t2 = threading.Thread(target=flip, args=("20260419",))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+        assert not errors
+        # 最终能加载 current
+        loaded = model_io.load_pickle("shared", version="current")
+        assert loaded in ({"v": "20260418"}, {"v": "20260419"})
+
+
+# ============================================================================
+# B. FinBERT 端到端
+# ============================================================================
+
+
+class TestGroupB_FinBertE2E:
+    def _make_news_store(self, tmp_path):
+        cfg = ProviderConfig(
+            implementation="t", params={"db_path": str(tmp_path / "news.db")}
+        )
+        store = SqliteNewsProvider(cfg)
+        store.initialize()
+        return store
+
+    def _attach_mock_scorer_to_g2(self, g2, label="positive", score=0.9):
+        other = (1.0 - score) / 2.0
+
+        class _S:
+            def score_texts(self, texts, batch_size=32):
+                out = []
+                for _ in texts:
+                    probs = {
+                        "positive": other,
+                        "negative": other,
+                        "neutral": other,
+                    }
+                    probs[label] = score
+                    probs["confidence"] = max(
+                        probs["positive"], probs["negative"], probs["neutral"]
+                    )
+                    out.append(probs)
+                return out
+
+        g2._scorer = _S()
+        g2._scorer_available = True
+
+    def test_news_to_g2_to_db_to_provider_readback(self, tmp_path):
+        """news → g2 (用 mock scorer) → 写 DB → LocalSentimentProvider.get_ticker_sentiment 读出。"""
+        store = self._make_news_store(tmp_path)
+        # 插 g_level=1 记录
+        news_ids = []
+        for i in range(3):
+            nid = store.insert_news(
+                headline=f"AAPL beats earnings {i}",
+                source=f"src{i}",
+                timestamp=(datetime.now(timezone.utc) - timedelta(hours=i)).isoformat(),
+                tickers=["AAPL"],
+                g_level=1,
+            )
+            news_ids.append(nid)
+
+        # sync._run_g2 写 finbert_* 列
+        g2 = G2Classifier(G2Config(use_finbert=True))
+        self._attach_mock_scorer_to_g2(g2, "positive", 0.85)
+        syncer = NewsDataSyncer(sources=[], store=store, g1=None, g2=g2, g3=None)
+        items = [
+            ({"headline": f"AAPL beats earnings {i}", "snippet": None}, nid)
+            for i, nid in enumerate(news_ids)
+        ]
+        syncer._run_g2(items)
+
+        # provider 读回加权
+        provider = LocalSentimentProvider(
+            scorer=FinBERTScorer(device="mock"), news_store=store
+        )
+        provider.initialize()
+        out = provider.get_ticker_sentiment("AAPL", lookback_days=7)
+        assert out["count"] == 3.0
+        # mock scorer 全部输出 positive=0.85, 加权 positive 应 ≈ 0.85
+        assert out["positive"] == pytest.approx(0.85, abs=1e-4)
+        provider.shutdown()
+        store.shutdown()
+
+    def test_backfill_noop_after_g2_wrote(self, tmp_path):
+        """g2 已写 finbert_confidence 的行, backfill 应 0 更新。"""
+        store = self._make_news_store(tmp_path)
+        news_id = store.insert_news(
+            headline="AAPL beats",
+            source="r",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            tickers=["AAPL"],
+            g_level=1,
+        )
+        g2 = G2Classifier(G2Config(use_finbert=True))
+        self._attach_mock_scorer_to_g2(g2, "positive", 0.9)
+        syncer = NewsDataSyncer(sources=[], store=store, g1=None, g2=g2, g3=None)
+        syncer._run_g2([({"headline": "AAPL beats", "snippet": None}, news_id)])
+
+        provider = LocalSentimentProvider(
+            scorer=FinBERTScorer(device="mock"), news_store=store
+        )
+        provider.initialize()
+        n = provider.backfill()
+        assert n == 0, "g2 已写的行不应被 backfill 覆盖"
+        provider.shutdown()
+        store.shutdown()
+
+    def test_g2_and_provider_share_same_singleton(self, tmp_path):
+        """P3 identity 断言: g2._ensure_scorer() 和 get_default_scorer() 同实例。"""
+        store = self._make_news_store(tmp_path)
+        reset_default_scorer()
+        provider = LocalSentimentProvider(news_store=store)
+        provider.initialize()
+        g2 = G2Classifier(G2Config(use_finbert=True))
+        g2._ensure_scorer()
+        assert provider._scorer is g2._scorer
+        provider.shutdown()
+        store.shutdown()
+
+
+# ============================================================================
+# C. LightGBM 端到端
+# ============================================================================
+
+
+class TestGroupC_LightGBME2E:
+    def test_train_to_save_to_scorer_to_parquet(self, tmp_path, tmp_artifact_dir):
+        """m3 train_and_save → m4 LightGBMScorer → m4 predict_and_save → parquet。"""
+        import lightgbm as lgb
+
+        factor_df = _make_factor_df(n_days=60, cols=("f1", "f2", "f3"))
+        bars = _make_ohlcv(n_days=60)
+        fp = _FakeFactorProvider(factor_df, ["f1", "f2", "f3"])
+        mdp = _FakeMarketDataProvider(bars)
+
+        # m3: 训练 + 保存
+        artifact = train_and_save(
+            fp, mdp,
+            tickers=["AAPL", "MSFT"],
+            start=date(2026, 1, 2),
+            end=date(2026, 3, 13),
+            factor_names=["f1", "f2", "f3"],
+            version="20260420",
+            num_rounds=20,
+            early_stop=5,
+        )
+        assert artifact.exists()
+        # m4: 加载 + 推理 + 落盘
+        scorer = LightGBMScorer(version="20260420")
+        parquet_dir = tmp_path / "factors"
+        store = ParquetFactorStore(data_path=parquet_dir)
+        out_path = scorer.predict_and_save(
+            fp,
+            tickers=["AAPL", "MSFT"],
+            start=date(2026, 1, 2),
+            end=date(2026, 3, 13),
+            store=store,
+        )
+        assert out_path.exists()
+        # 回读非空
+        read_back = store.read_factors(ML_SCORE_GROUP)
+        assert not read_back.empty
+        assert ML_SCORE_COLUMN in read_back.columns
+
+    def test_factor_provider_reads_ml_score_after_save(self, tmp_path, tmp_artifact_dir):
+        """LocalFactorProvider.get_factors(["ml_score"]) 能拿回 m4 落盘的数据。"""
+        # 预造 ml_score.parquet
+        ml_scores = _make_factor_df(cols=(ML_SCORE_COLUMN,))
+        parquet_dir = tmp_path / "factors"
+        ParquetFactorStore(data_path=parquet_dir).write_factors(
+            ML_SCORE_GROUP, ml_scores
+        )
+
+        cfg = ProviderConfig(
+            implementation="t",
+            params={"precomputed_path": str(parquet_dir)},
+        )
+        lfp = LocalFactorProvider(cfg)
+        mdp = _FakeMarketDataProvider(_make_ohlcv())
+        lfp.market_data = mdp
+        lfp.initialize()
+        try:
+            got = lfp.get_factors(
+                ["AAPL", "MSFT"],
+                [ML_SCORE_COLUMN],
+                start=date(2026, 1, 2),
+                end=date(2026, 3, 13),
+            )
+            assert not got.empty
+            assert ML_SCORE_COLUMN in got.columns
+        finally:
+            lfp.shutdown()
+
+    def test_mixed_routing_expression_and_precomputed(self, tmp_path, tmp_artifact_dir):
+        """get_factors(["MA5", "ml_score"]) 路由正确, 列序保留。"""
+        parquet_dir = tmp_path / "factors"
+        ml_scores = _make_factor_df(cols=(ML_SCORE_COLUMN,))
+        ParquetFactorStore(data_path=parquet_dir).write_factors(
+            ML_SCORE_GROUP, ml_scores
+        )
+        cfg = ProviderConfig(
+            implementation="t",
+            params={"precomputed_path": str(parquet_dir)},
+        )
+        lfp = LocalFactorProvider(cfg)
+        lfp.market_data = _FakeMarketDataProvider(_make_ohlcv())
+        lfp.initialize()
+        try:
+            result = lfp.get_factors(
+                ["AAPL", "MSFT"],
+                ["MA5", ML_SCORE_COLUMN],
+                start=date(2026, 1, 2),
+                end=date(2026, 2, 14),
+            )
+            assert list(result.columns) == ["MA5", ML_SCORE_COLUMN]
+        finally:
+            lfp.shutdown()
+
+    def test_list_factors_includes_ml_score(self, tmp_path, tmp_artifact_dir):
+        parquet_dir = tmp_path / "factors"
+        ml_scores = _make_factor_df(cols=(ML_SCORE_COLUMN,))
+        ParquetFactorStore(data_path=parquet_dir).write_factors(
+            ML_SCORE_GROUP, ml_scores
+        )
+        cfg = ProviderConfig(
+            implementation="t",
+            params={"precomputed_path": str(parquet_dir)},
+        )
+        lfp = LocalFactorProvider(cfg)
+        lfp.market_data = _FakeMarketDataProvider(_make_ohlcv())
+        lfp.initialize()
+        try:
+            factors = lfp.list_factors()
+            match = [f for f in factors if f["name"] == ML_SCORE_COLUMN]
+            assert len(match) == 1
+            assert match[0]["type"] == "precomputed"
+        finally:
+            lfp.shutdown()
+
+
+# ============================================================================
+# D. evaluate_ml_score wire
+# ============================================================================
+
+
+class TestGroupD_EvaluateWire:
+    @staticmethod
+    def _make_bars_and_ml_score(shift: int, n_days: int = 250, seed: int = 0):
+        rng = np.random.default_rng(seed)
+        tickers = ["AAPL", "MSFT"]
+        dates = pd.bdate_range("2026-01-02", periods=n_days)
+        idx = pd.MultiIndex.from_product(
+            [dates, tickers], names=["date", "ticker"]
+        ).sortlevel()[0]
+        bars_dict = {}
+        for t in tickers:
+            prices = 100.0 * np.exp(np.cumsum(rng.normal(0.001, 0.01, n_days)))
+            for d, p in zip(dates, prices):
+                bars_dict[(d, t)] = p
+        bars = pd.DataFrame(
+            {"adj_close": [bars_dict[i] for i in idx]}, index=idx
+        )
+        close = bars["adj_close"]
+        fwd = close.groupby(level="ticker").shift(-shift) / close - 1
+        ml_score = pd.DataFrame({ML_SCORE_COLUMN: fwd.to_numpy()}, index=idx)
+        return bars, ml_score, tickers
+
+    def test_oracle_ic_saturates_at_one_when_shift_matches(self):
+        """oracle (ml_score = fwd_ret_{shift}) + evaluate_ml_score(shift) → IC ≈ 1。"""
+        bars, ml_score, tickers = self._make_bars_and_ml_score(shift=5)
+        fp = _FakeFactorProvider(ml_score, expression=[], precomp=[ML_SCORE_COLUMN])
+        mdp = _FakeMarketDataProvider(bars)
+        out = evaluate_ml_score(
+            fp, mdp,
+            universe=tickers,
+            start=date(2026, 1, 2),
+            end=date(2026, 11, 30),
+            shift=5,
+            window=252,
+        )
+        assert out["ic_mean"] > 0.9
+
+    def test_shift_mismatch_drops_ic_below_saturation(self):
+        """control: oracle 用 shift=5 构造, 但 evaluate_ml_score(shift=1) → IC
+        远低于 1 (非 tautology)。若本测试依然 IC≈1,说明 shift 参数没真正影响
+        前向对齐,是 bug。"""
+        bars, ml_score, tickers = self._make_bars_and_ml_score(shift=5)
+        fp = _FakeFactorProvider(ml_score, expression=[], precomp=[ML_SCORE_COLUMN])
+        mdp = _FakeMarketDataProvider(bars)
+        out = evaluate_ml_score(
+            fp, mdp,
+            universe=tickers,
+            start=date(2026, 1, 2),
+            end=date(2026, 11, 30),
+            shift=1,  # 与 oracle 构造 shift=5 不匹配
+            window=252,
+        )
+        # shift 错配 → IC 应显著低于 1.0 (经验上 < 0.5 for random walk)
+        assert out["ic_mean"] < 0.6, (
+            f"shift 错配 IC={out['ic_mean']:.3f} 未降低,说明 shift 参数未真正传到 compute_ic"
+        )
+
+    def test_evaluate_ml_score_does_not_run_factor_storage_ic_report(self, tmp_path):
+        """D2 runtime 断言: 调用 evaluate_ml_score 后, LocalFactorProvider
+        get_ic_report 路径未被触动; _IC_SHIFT 常量值保持 1 (spec freeze)。"""
+        from stockbee.factor_data.local_provider import _IC_SHIFT
+
+        # runtime 先跑一次 evaluate_ml_score
+        bars, ml_score, tickers = self._make_bars_and_ml_score(shift=5)
+        fp = _FakeFactorProvider(ml_score, expression=[], precomp=[ML_SCORE_COLUMN])
+        mdp = _FakeMarketDataProvider(bars)
+        evaluate_ml_score(
+            fp, mdp,
+            universe=tickers,
+            start=date(2026, 1, 2),
+            end=date(2026, 11, 30),
+            shift=5,
+            window=252,
+        )
+        # 然后再确认 factor-storage 常量完好
+        from stockbee.factor_data.local_provider import _IC_SHIFT as ic_shift_after
+        assert ic_shift_after == 1
+        assert _IC_SHIFT == 1
+
+
+# ============================================================================
+# E. 列冲突并存 (sentiment_score / finbert_* / fine5_importance / importance_score)
+# ============================================================================
+
+
+class TestGroupE_ColumnCoexistence:
+    def test_sentiment_score_and_finbert_cols_coexist_via_g2_production(
+        self, tmp_path
+    ):
+        """走 g2 → sync._run_g2 生产路径, 读回 DB 验证:
+        sentiment_score (= FinBERT positive softmax) + finbert_negative +
+        finbert_neutral ≈ 1.0 是 g2 实际写入的不变式 (非手工种子)。"""
+        cfg = ProviderConfig(
+            implementation="t", params={"db_path": str(tmp_path / "n.db")}
+        )
+        store = SqliteNewsProvider(cfg)
+        store.initialize()
+        news_id = store.insert_news(
+            headline="AAPL beats earnings by wide margin",
+            source="r",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            tickers=["AAPL"],
+            g_level=1,
+        )
+        # mock scorer: positive=0.70, negative=0.20, neutral=0.10 (sum=1)
+        class _S:
+            def score_texts(self, texts, batch_size=32):
+                return [
+                    {
+                        "positive": 0.70,
+                        "negative": 0.20,
+                        "neutral": 0.10,
+                        "confidence": 0.70,
+                    }
+                    for _ in texts
+                ]
+
+        g2 = G2Classifier(G2Config(use_finbert=True))
+        g2._scorer = _S()
+        g2._scorer_available = True
+        syncer = NewsDataSyncer(sources=[], store=store, g1=None, g2=g2, g3=None)
+        syncer._run_g2(
+            [({"headline": "AAPL beats earnings by wide margin", "snippet": None}, news_id)]
+        )
+
+        row = store._conn.execute(
+            "SELECT sentiment_score, finbert_negative, finbert_neutral, finbert_confidence "
+            "FROM news_events WHERE id = ?",
+            (news_id,),
+        ).fetchone()
+        # g2 production path 写入的 4 列:
+        #   sentiment_score = positive softmax = 0.70
+        #   finbert_negative = 0.20
+        #   finbert_neutral = 0.10
+        #   finbert_confidence = max = 0.70
+        # 三 softmax 分量 sum ≈ 1.0 (从 scorer 出来就是)
+        # round(pos, 3) + round(neg, 3) + round(neu, 3) 也应 ≈ 1.0
+        assert row[0] == pytest.approx(0.70, abs=1e-3)
+        assert row[1] == pytest.approx(0.20, abs=1e-3)
+        assert row[2] == pytest.approx(0.10, abs=1e-3)
+        assert row[0] + row[1] + row[2] == pytest.approx(1.0, abs=1e-3)
+        assert row[3] == pytest.approx(
+            max(row[0], row[1], row[2]), abs=1e-3
+        )
+        store.shutdown()
+
+    def test_fine5_importance_and_importance_score_parallel(self, tmp_path):
+        """fine5_importance (m5 写) 与 importance_score (g2 规则写) 并存,独立查询。"""
+        cfg = ProviderConfig(
+            implementation="t", params={"db_path": str(tmp_path / "n.db")}
+        )
+        store = SqliteNewsProvider(cfg)
+        store.initialize()
+        store.insert_news(
+            headline="AAPL news",
+            source="r",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            tickers=["AAPL"],
+            sentiment_score=0.9,
+            importance_score=0.6,  # g2 规则
+            reliability_score=0.8,
+        )
+        # m5 backfill 写 fine5_importance
+        n = backfill_importance(store, batch=100)
+        assert n == 1
+        row = store._conn.execute(
+            "SELECT importance_score, fine5_importance FROM news_events WHERE id=1"
+        ).fetchone()
+        assert row[0] == pytest.approx(0.6, abs=1e-6)
+        assert row[1] is not None  # m5 baseline 写入
+        assert row[0] != row[1]  # 两列不同,独立来源
+        store.shutdown()
+
+    def test_legacy_rows_without_finbert_backfilled(self, tmp_path):
+        """老数据只有 sentiment_score, 无 finbert_*; LocalSentimentProvider.backfill 补齐。"""
+        cfg = ProviderConfig(
+            implementation="t", params={"db_path": str(tmp_path / "n.db")}
+        )
+        store = SqliteNewsProvider(cfg)
+        store.initialize()
+        # 模拟老数据: 只有 sentiment_score, finbert_* 都 NULL
+        store.insert_news(
+            headline="legacy news",
+            source="r",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            tickers=["AAPL"],
+            sentiment_score=0.65,
+            # 不传 finbert_* → 留 NULL
+        )
+        # 确认 NULL
+        row = store._conn.execute(
+            "SELECT finbert_confidence FROM news_events WHERE id=1"
+        ).fetchone()
+        assert row[0] is None
+
+        provider = LocalSentimentProvider(
+            scorer=FinBERTScorer(device="mock"), news_store=store
+        )
+        provider.initialize()
+        n = provider.backfill()
+        assert n == 1
+
+        row2 = store._conn.execute(
+            "SELECT sentiment_score, finbert_confidence FROM news_events WHERE id=1"
+        ).fetchone()
+        assert row2[0] == 0.65  # 老 sentiment_score 未被 backfill 覆盖
+        assert row2[1] is not None  # finbert_confidence 已补
+        provider.shutdown()
+        store.shutdown()
+
+
+# ============================================================================
+# G. Edge cases
+# ============================================================================
+
+
+class TestGroupG_EdgeCases:
+    def test_universe_tail_label_missing_does_not_crash_train(
+        self, tmp_path, tmp_artifact_dir
+    ):
+        """数据尾部 5 天 label 为 NaN (B3 公式必然),train_lightgbm 自动 drop 不爆。"""
+        factor_df = _make_factor_df(n_days=30, cols=("f1", "f2"))
+        bars = _make_ohlcv(n_days=30)
+        fp = _FakeFactorProvider(factor_df, ["f1", "f2"])
+        mdp = _FakeMarketDataProvider(bars)
+        # train_and_save 内部 forward_return_5d 对 30 天数据尾部 5 天 NaN,
+        # train_lightgbm 自动 drop 后仍应训练成功
+        artifact = train_and_save(
+            fp, mdp,
+            tickers=["AAPL", "MSFT"],
+            start=date(2026, 1, 2),
+            end=date(2026, 2, 14),
+            factor_names=["f1", "f2"],
+            version="20260420",
+            num_rounds=20,
+            early_stop=5,
+        )
+        assert artifact.exists()
+
+    def test_empty_news_db_backfill_returns_zero(self, tmp_path):
+        """空 DB backfill 不 raise,返回 0。"""
+        cfg = ProviderConfig(
+            implementation="t", params={"db_path": str(tmp_path / "empty.db")}
+        )
+        store = SqliteNewsProvider(cfg)
+        store.initialize()
+        provider = LocalSentimentProvider(
+            scorer=FinBERTScorer(device="mock"), news_store=store
+        )
+        provider.initialize()
+        assert provider.backfill() == 0
+        provider.shutdown()
+        store.shutdown()
+
+    def test_backfill_chunked_pagination_and_memory_smoke(self, tmp_path):
+        """10K 条新闻分批 backfill: 验证 chunked pagination 正确性 +
+        tracemalloc 峰值内存随批次非累积式增长 (OOM smoke, review M3)。"""
+        cfg = ProviderConfig(
+            implementation="t", params={"db_path": str(tmp_path / "big.db")}
+        )
+        store = SqliteNewsProvider(cfg)
+        store.initialize()
+        now = datetime.now(timezone.utc)
+        events = [
+            {
+                "headline": f"news {i}",
+                "source": f"s{i % 10}",
+                "timestamp": (now + timedelta(seconds=i)).isoformat(),
+                "tickers": ["AAPL"],
+            }
+            for i in range(10_000)
+        ]
+        store.insert_news_batch(events)
+
+        provider = LocalSentimentProvider(
+            scorer=FinBERTScorer(device="mock"), news_store=store
+        )
+        provider.initialize()
+
+        tracemalloc.start()
+        try:
+            chunk_peaks: list[int] = []
+            total = 0
+            for _ in range(12):
+                tracemalloc.reset_peak()
+                n = provider.backfill(limit=1000)
+                _, peak = tracemalloc.get_traced_memory()
+                chunk_peaks.append(peak)
+                total += n
+                if n == 0:
+                    break
+            assert total == 10_000
+            # 正确性: 确实分批发生 (每批最多 1000)
+            assert len(chunk_peaks) >= 10
+            # OOM smoke: 后续 chunk 峰值不应超过首 chunk 峰值 × 3
+            # (非累积式内存增长; chunked commit 释放前批)
+            first_peak = max(chunk_peaks[:3]) or 1
+            worst_later = max(chunk_peaks[3:] or [0])
+            assert worst_later < 3 * first_peak, (
+                f"分批后峰值失控: 首 3 批最高 {first_peak} 字节, "
+                f"后续最高 {worst_later} 字节 → 可能存在累积引用"
+            )
+        finally:
+            tracemalloc.stop()
+            provider.shutdown()
+            store.shutdown()
+
+    def test_finbert_mock_fallback_when_scorer_unavailable(self):
+        """get_default_scorer 不可用时 g2 降级规则 (模拟 transformers 未装场景)。
+        (m4 perf FP OOM 等价性不验证, 只断言 fallback invoked,
+        per spec m6 G 组策略)。"""
+        g2 = G2Classifier(G2Config(use_finbert=True))
+        g2._scorer = None
+        g2._scorer_available = False
+        r = g2.classify("Stock crash amid massive layoffs")
+        assert not r.used_finbert
+        assert r.sentiment == "negative"  # 规则引擎抓到 crash + layoffs
+        assert r.finbert_negative is None
+
+
+# ============================================================================
+# F. 性能回归 (opt-in)
+# ============================================================================
+
+
+@pytest.mark.perf
+@_perf_skip
+class TestGroupF_PerfRegression:
+    @staticmethod
+    def _percentile(samples, p):
+        s = sorted(samples)
+        k = max(0, min(len(s) - 1, int(len(s) * p)))
+        return s[k]
+
+    def test_finbert_batch32_latency(self):
+        reset_default_scorer()
+        scorer = FinBERTScorer()
+        texts = ["earnings beat estimates by a wide margin"] * 32
+        for _ in range(3):
+            scorer.score_texts(texts, batch_size=32)
+        samples = []
+        for _ in range(10):
+            t0 = time.perf_counter()
+            scorer.score_texts(texts, batch_size=32)
+            samples.append((time.perf_counter() - t0) * 1000.0)
+        med = self._percentile(samples, 0.5)
+        tol = 100.0 if scorer.device == "cuda" else 300.0
+        assert med < tol, f"FinBERT b32 median {med:.1f}ms > {tol:.0f}ms"
+
+    def test_lightgbm_1000_rows_latency(self, tmp_artifact_dir):
+        import lightgbm as lgb
+
+        rng = np.random.default_rng(1)
+        X = rng.standard_normal((1000, 158))
+        y = X @ rng.standard_normal(158)
+        ds = lgb.Dataset(
+            X, label=y, feature_name=[f"f{i}" for i in range(158)]
+        )
+        booster = lgb.train(
+            {"objective": "regression", "verbose": -1, "seed": 42},
+            ds,
+            num_boost_round=50,
+        )
+        s = LightGBMScorer(booster=booster)
+        idx = pd.MultiIndex.from_product(
+            [pd.bdate_range("2026-01-02", periods=1000), ["AAPL"]],
+            names=["date", "ticker"],
+        )[:1000]
+        df = pd.DataFrame(X, index=idx, columns=[f"f{i}" for i in range(158)])
+        for _ in range(3):
+            s.predict(df)
+        samples = []
+        for _ in range(10):
+            t0 = time.perf_counter()
+            s.predict(df)
+            samples.append((time.perf_counter() - t0) * 1000.0)
+        med = self._percentile(samples, 0.5)
+        assert med < 150.0, f"LightGBM 1000×158 median {med:.1f}ms > 150ms"

--- a/tests/small_models/test_lightgbm_infer.py
+++ b/tests/small_models/test_lightgbm_infer.py
@@ -1,0 +1,639 @@
+"""m4 LightGBMScorer 推理 + ml_score 落盘 + evaluate_ml_score 测试。
+
+覆盖:
+- LightGBMScorer.predict:
+    * shape / MultiIndex 保持
+    * booster.feature_name 自动对齐,缺列报错
+    * 空 df → raise
+    * NaN 行输出 NaN 不 drop (保索引对齐)
+- predict_and_save:
+    * 落盘 parquet 文件存在
+    * merge-write 幂等 (同日重跑不爆)
+    * tickers 为空 → raise
+    * 未训练 booster (feature_name=[]) + 显式 factor_names
+- LocalFactorProvider 自动发现:
+    * 写入 ml_score.parquet 后 list_factors() 含 {"name":"ml_score", "type":"precomputed"}
+    * get_factors(["MA5", "ml_score", "RESI60"]) 路由正确, 列序保留
+- evaluate_ml_score:
+    * oracle: ml_score = fwd_ret_5d 构造 → IC ≈ 1
+    * shift=5 传递
+    * universe 为空 → raise
+    * 无 ml_score 数据 → raise
+- artifact 不存在 → NotFoundError
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import time
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from stockbee.factor_data.parquet_factor import ParquetFactorStore
+from stockbee.small_models import model_io
+from stockbee.small_models.lightgbm_scorer import (
+    LightGBMScorer,
+    ML_SCORE_COLUMN,
+    ML_SCORE_GROUP,
+    evaluate_ml_score,
+)
+
+
+# ============================================================================
+# Mock booster / providers
+# ============================================================================
+
+
+class _MockBooster:
+    """模拟 lgb.Booster, 按 feature_name 顺序给每列一个固定系数做线性预测。"""
+
+    def __init__(self, feature_names: list[str], coefs: list[float] | None = None):
+        self._names = list(feature_names)
+        self._coefs = np.array(
+            coefs if coefs is not None else [1.0] * len(feature_names),
+            dtype=float,
+        )
+
+    def feature_name(self) -> list[str]:
+        return list(self._names)
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        X = np.asarray(X, dtype=float)
+        return X @ self._coefs
+
+
+class _FakeFactorProvider:
+    def __init__(self, factor_df: pd.DataFrame, expression: list[str], precomp: list[str] | None = None):
+        self.factor_df = factor_df
+        self._expr = expression
+        self._precomp = precomp or []
+        self.calls: list[dict[str, Any]] = []
+
+    def get_factors(self, tickers, factor_names, start, end):
+        self.calls.append(
+            {
+                "tickers": list(tickers),
+                "factor_names": list(factor_names),
+                "start": start,
+                "end": end,
+            }
+        )
+        return self.factor_df[list(factor_names)]
+
+    def list_factors(self):
+        return (
+            [{"name": n, "type": "expression"} for n in self._expr]
+            + [{"name": n, "type": "precomputed"} for n in self._precomp]
+        )
+
+
+class _FakeMarketDataProvider:
+    def __init__(self, bars: pd.DataFrame):
+        self.bars = bars
+
+    def get_daily_bars(self, tickers, start, end, fields=None):
+        return self.bars
+
+
+def _fake_mdp_from_dates(
+    dates: pd.DatetimeIndex, tickers: list[str]
+) -> _FakeMarketDataProvider:
+    """构造最小 OHLCV MultiIndex(date, ticker),供 Alpha158 计算 MA5 等。"""
+    rng = np.random.default_rng(42)
+    idx = pd.MultiIndex.from_product([dates, tickers], names=["date", "ticker"])
+    n = len(idx)
+    base_prices = 100.0 + rng.standard_normal(n) * 2.0
+    bars = pd.DataFrame(
+        {
+            "open": base_prices,
+            "high": base_prices * 1.01,
+            "low": base_prices * 0.99,
+            "close": base_prices,
+            "adj_close": base_prices,
+            "volume": rng.integers(1_000_000, 5_000_000, n),
+        },
+        index=idx,
+    )
+    return _FakeMarketDataProvider(bars)
+
+
+@pytest.fixture
+def factor_frame():
+    """50 天 × 2 tickers × 3 特征 MultiIndex."""
+    rng = np.random.default_rng(42)
+    dates = pd.bdate_range("2026-01-02", periods=50)
+    idx = pd.MultiIndex.from_product(
+        [dates, ["AAPL", "MSFT"]], names=["date", "ticker"]
+    )
+    return pd.DataFrame(
+        rng.standard_normal((len(idx), 3)),
+        index=idx,
+        columns=["f1", "f2", "f3"],
+    )
+
+
+@pytest.fixture
+def mock_booster():
+    # 线性: ml_score = 0.5*f1 - 0.3*f2 + 0.1*f3
+    return _MockBooster(["f1", "f2", "f3"], [0.5, -0.3, 0.1])
+
+
+@pytest.fixture
+def scorer(mock_booster):
+    return LightGBMScorer(booster=mock_booster)
+
+
+# ============================================================================
+# LightGBMScorer.predict
+# ============================================================================
+
+
+class TestPredict:
+    def test_shape_and_multiindex_preserved(self, scorer, factor_frame):
+        preds = scorer.predict(factor_frame)
+        assert isinstance(preds, pd.Series)
+        assert preds.index.equals(factor_frame.index)
+        assert preds.name == ML_SCORE_COLUMN
+        assert len(preds) == len(factor_frame)
+
+    def test_linear_coefficients_applied(self, scorer, factor_frame):
+        """输出 = 0.5*f1 - 0.3*f2 + 0.1*f3 (mock booster)。"""
+        preds = scorer.predict(factor_frame)
+        expected = (
+            0.5 * factor_frame["f1"] - 0.3 * factor_frame["f2"] + 0.1 * factor_frame["f3"]
+        )
+        assert np.allclose(preds.to_numpy(), expected.to_numpy(), atol=1e-9)
+
+    def test_missing_feature_column_raises(self, scorer, factor_frame):
+        bad = factor_frame.drop(columns=["f2"])
+        with pytest.raises(ValueError, match="缺 booster 需要的特征"):
+            scorer.predict(bad)
+
+    def test_extra_columns_are_ignored(self, scorer, factor_frame):
+        """多给一列 → 按 feature_name 只取子集。"""
+        extra = factor_frame.copy()
+        extra["noise"] = 99.0
+        preds = scorer.predict(extra)
+        assert preds.index.equals(factor_frame.index)
+
+    def test_empty_df_raises(self, scorer):
+        empty = pd.DataFrame(
+            index=pd.MultiIndex.from_arrays(
+                [[], []], names=["date", "ticker"]
+            )
+        )
+        with pytest.raises(ValueError):
+            scorer.predict(empty)
+
+    def test_nan_row_outputs_nan(self, scorer, factor_frame):
+        """特征全 NaN 的行 → 预测值 NaN (索引保留供 join)。mock booster 路径。"""
+        row = factor_frame.index[5]
+        factor_frame.loc[row, :] = np.nan
+        preds = scorer.predict(factor_frame)
+        assert math.isnan(preds.loc[row])
+        # 其他行仍正常
+        other = factor_frame.index[6]
+        assert not math.isnan(preds.loc[other])
+
+    def test_nan_row_outputs_nan_with_real_lightgbm(self, tmp_path, factor_frame):
+        """review C1 回归: 真实 lgb.Booster 对 all-NaN 行会返 default 方向的数值,
+        而非 NaN; predict 层必须显式 mask → 确保和 docstring / mock 语义一致。
+        """
+        import lightgbm as lgb
+
+        # 用 factor_frame 造 label 训练一个 real booster (3 特征)
+        rng = np.random.default_rng(0)
+        label = (
+            0.5 * factor_frame["f1"]
+            - 0.3 * factor_frame["f2"]
+            + 0.1 * factor_frame["f3"]
+            + 0.1 * rng.standard_normal(len(factor_frame))
+        )
+        ds = lgb.Dataset(
+            factor_frame.to_numpy(),
+            label=label.to_numpy(),
+            feature_name=list(factor_frame.columns),
+        )
+        booster = lgb.train(
+            {"objective": "regression", "verbose": -1, "seed": 42},
+            ds,
+            num_boost_round=20,
+        )
+        s = LightGBMScorer(booster=booster)
+
+        # 让第 3 行全 NaN
+        bad_idx = factor_frame.index[3]
+        fd = factor_frame.copy()
+        fd.loc[bad_idx, :] = np.nan
+        preds = s.predict(fd)
+        assert math.isnan(preds.loc[bad_idx]), (
+            "real booster 的 all-NaN 行必须被 predict 层显式置 NaN (review C1)"
+        )
+        # 其他行非 NaN
+        assert not math.isnan(preds.loc[factor_frame.index[4]])
+
+    def test_booster_without_feature_name_raises(self):
+        """review H2: booster.feature_name() 为空 → predict 直接报错。"""
+        s = LightGBMScorer(booster=_MockBooster([], [1.0]))
+        df = pd.DataFrame(
+            [[1.0, 2.0]],
+            index=pd.MultiIndex.from_tuples(
+                [(pd.Timestamp("2026-01-02"), "AAPL")], names=["date", "ticker"]
+            ),
+            columns=["f1", "f2"],
+        )
+        with pytest.raises(ValueError, match="feature_name"):
+            s.predict(df)
+
+    def test_column_order_strict(self, scorer, factor_frame):
+        """列顺序打乱传入 → predict 按 booster feature_name 自动对齐,结果等于有序输入。"""
+        shuffled = factor_frame[["f3", "f1", "f2"]]
+        preds_shuffled = scorer.predict(shuffled)
+        preds_ordered = scorer.predict(factor_frame)
+        assert np.allclose(preds_shuffled.to_numpy(), preds_ordered.to_numpy())
+
+    def test_non_multiindex_raises(self, scorer):
+        df = pd.DataFrame([[1.0, 2.0, 3.0]], columns=["f1", "f2", "f3"])
+        with pytest.raises(ValueError, match="MultiIndex"):
+            scorer.predict(df)
+
+
+# ============================================================================
+# predict_and_save
+# ============================================================================
+
+
+class TestPredictAndSave:
+    def test_writes_parquet_file(self, tmp_path, scorer, factor_frame):
+        fp = _FakeFactorProvider(factor_frame, ["f1", "f2", "f3"])
+        store = ParquetFactorStore(data_path=tmp_path / "factors")
+        out = scorer.predict_and_save(
+            fp,
+            tickers=["AAPL", "MSFT"],
+            start=date(2026, 1, 2),
+            end=date(2026, 3, 13),
+            store=store,
+        )
+        assert out.exists()
+        assert out.name == f"{ML_SCORE_GROUP}.parquet"
+
+    def test_merge_write_idempotent(self, tmp_path, scorer, factor_frame):
+        """同日重跑 merge-write: 路径稳定 + 数据相等 (真正的幂等语义)。"""
+        fp = _FakeFactorProvider(factor_frame, ["f1", "f2", "f3"])
+        store = ParquetFactorStore(data_path=tmp_path / "factors")
+        kwargs = dict(
+            tickers=["AAPL", "MSFT"],
+            start=date(2026, 1, 2),
+            end=date(2026, 3, 13),
+            store=store,
+        )
+        out1 = scorer.predict_and_save(fp, **kwargs)
+        read1 = store.read_factors(ML_SCORE_GROUP).sort_index()
+        out2 = scorer.predict_and_save(fp, **kwargs)
+        read2 = store.read_factors(ML_SCORE_GROUP).sort_index()
+        assert out1 == out2
+        pd.testing.assert_frame_equal(read1, read2)
+
+    def test_factor_names_defaults_to_booster_features(
+        self, tmp_path, scorer, factor_frame
+    ):
+        fp = _FakeFactorProvider(factor_frame, ["f1", "f2", "f3"])
+        store = ParquetFactorStore(data_path=tmp_path / "factors")
+        scorer.predict_and_save(
+            fp,
+            tickers=["AAPL", "MSFT"],
+            start=date(2026, 1, 2),
+            end=date(2026, 3, 13),
+            store=store,
+        )
+        assert fp.calls[-1]["factor_names"] == ["f1", "f2", "f3"]
+
+    def test_empty_tickers_raises(self, scorer, factor_frame):
+        fp = _FakeFactorProvider(factor_frame, ["f1", "f2", "f3"])
+        with pytest.raises(ValueError, match="tickers"):
+            scorer.predict_and_save(
+                fp,
+                tickers=[],
+                start=date(2026, 1, 2),
+                end=date(2026, 3, 13),
+            )
+
+    def test_booster_without_feature_name_requires_explicit_names(
+        self, tmp_path, factor_frame
+    ):
+        """无 feature_name 的 booster → predict_and_save 要求显式 factor_names。"""
+        s = LightGBMScorer(booster=_MockBooster([], [1.0, 1.0, 1.0]))
+        fp = _FakeFactorProvider(factor_frame, ["f1", "f2", "f3"])
+        with pytest.raises(ValueError, match="feature_name"):
+            s.predict_and_save(
+                fp,
+                tickers=["AAPL"],
+                start=date(2026, 1, 2),
+                end=date(2026, 3, 13),
+            )
+
+    def test_mixed_routing_preserves_column_order(self, tmp_path):
+        """review C3: get_factors(["MA5", "ml_score", "RESI60"]) 列序 + 路由正确。
+        用 LocalFactorProvider 验证 expression + precomputed 混合。"""
+        from stockbee.factor_data.local_provider import LocalFactorProvider
+        from stockbee.providers.base import ProviderConfig
+
+        # 先用 m4 落 ml_score.parquet
+        rng = np.random.default_rng(1)
+        dates = pd.bdate_range("2026-01-02", periods=30)
+        idx = pd.MultiIndex.from_product(
+            [dates, ["AAPL", "MSFT"]], names=["date", "ticker"]
+        )
+        ml_score_df = pd.DataFrame(
+            {"ml_score": rng.standard_normal(len(idx))}, index=idx
+        )
+        data_path = tmp_path / "factors"
+        store = ParquetFactorStore(data_path=data_path)
+        store.write_factors(ML_SCORE_GROUP, ml_score_df)
+
+        # LocalFactorProvider 路由 expression (MA5) + precomputed (ml_score)
+        cfg = ProviderConfig(
+            implementation="test",
+            params={"precomputed_path": str(data_path)},
+        )
+        lfp = LocalFactorProvider(cfg)
+        # 注入 mock market_data 给 expression engine
+        mock_mdp = _fake_mdp_from_dates(dates, ["AAPL", "MSFT"])
+        lfp.market_data = mock_mdp
+        lfp.initialize()
+
+        try:
+            result = lfp.get_factors(
+                ["AAPL", "MSFT"],
+                ["MA5", "ml_score"],
+                start=date(2026, 1, 2),
+                end=date(2026, 2, 12),
+            )
+            # 列序严格按请求
+            assert list(result.columns) == ["MA5", "ml_score"]
+            # ml_score 列来自 parquet
+            assert result["ml_score"].notna().any()
+        finally:
+            lfp.shutdown()
+
+    def test_factor_provider_empty_raises(self, tmp_path, scorer):
+        empty = pd.DataFrame(
+            index=pd.MultiIndex.from_arrays([[], []], names=["date", "ticker"]),
+            columns=["f1", "f2", "f3"],
+        )
+        fp = _FakeFactorProvider(empty, ["f1", "f2", "f3"])
+        with pytest.raises(ValueError, match="返回空"):
+            scorer.predict_and_save(
+                fp,
+                tickers=["AAPL"],
+                start=date(2026, 1, 2),
+                end=date(2026, 3, 13),
+                store=ParquetFactorStore(data_path=tmp_path / "x"),
+            )
+
+
+# ============================================================================
+# artifact 加载 (via model_io)
+# ============================================================================
+
+
+class TestArtifactLoading:
+    def test_missing_artifact_raises(self, tmp_artifact_dir):
+        """version 不存在 → NotFoundError。"""
+        with pytest.raises(model_io.NotFoundError):
+            LightGBMScorer(version="99990101")
+
+    def test_load_via_model_io_roundtrip(self, tmp_artifact_dir, mock_booster):
+        """save_pickle → LightGBMScorer 加载成功, feature_names 一致。"""
+        model_io.save_pickle(mock_booster, "lightgbm", version="20260420")
+        s = LightGBMScorer(version="20260420")
+        assert s.feature_names == ["f1", "f2", "f3"]
+
+
+# ============================================================================
+# LocalFactorProvider 自动发现 ml_score (D2 对 factor-storage 零改动)
+# ============================================================================
+
+
+class TestAutoDiscovery:
+    def test_list_factors_includes_ml_score_after_save(
+        self, tmp_path, scorer, factor_frame, monkeypatch
+    ):
+        """写入 ml_score.parquet 后, LocalFactorProvider.list_factors 自动包含它。"""
+        from stockbee.factor_data.local_provider import LocalFactorProvider
+        from stockbee.providers.base import ProviderConfig
+
+        # 把 precomputed 指向 tmp_path/factors, ml_score.parquet 落这里
+        data_path = tmp_path / "factors"
+        cfg = ProviderConfig(
+            implementation="test",
+            params={"precomputed_path": str(data_path)},
+        )
+        lfp = LocalFactorProvider(cfg)
+        lfp.initialize()
+
+        # 用 m4 predict_and_save 落盘
+        fp = _FakeFactorProvider(factor_frame, ["f1", "f2", "f3"])
+        store = ParquetFactorStore(data_path=data_path)
+        scorer.predict_and_save(
+            fp,
+            tickers=["AAPL", "MSFT"],
+            start=date(2026, 1, 2),
+            end=date(2026, 3, 13),
+            store=store,
+        )
+
+        # 刷新索引: 走公开 refresh API (避免依赖 _precomputed_index_built 私有字段)
+        if hasattr(lfp, "refresh_precomputed_index"):
+            lfp.refresh_precomputed_index()
+        else:
+            lfp._precomputed_index = {}
+            lfp._precomputed_index_built = False
+        factors = lfp.list_factors()
+        ml_score_entries = [f for f in factors if f["name"] == ML_SCORE_COLUMN]
+        assert len(ml_score_entries) == 1
+        entry = ml_score_entries[0]
+        # spec 锁定最小契约: name + type (允许额外键如 group)
+        assert entry["name"] == ML_SCORE_COLUMN
+        assert entry["type"] == "precomputed"
+        lfp.shutdown()
+
+
+# ============================================================================
+# evaluate_ml_score (D2)
+# ============================================================================
+
+
+class TestEvaluateMLScore:
+    def _oracle_setup(self, shift: int = 5):
+        """构造 prices 让 ml_score = fwd_return_{shift}(adj_close) → IC 应 ≈ 1。"""
+        rng = np.random.default_rng(0)
+        n_days = 250
+        tickers = ["AAPL", "MSFT"]
+        dates = pd.bdate_range("2026-01-02", periods=n_days)
+        idx = pd.MultiIndex.from_product([dates, tickers], names=["date", "ticker"])
+
+        # adj_close 随机游走
+        rows = []
+        for ticker in tickers:
+            base = 100.0
+            returns = rng.normal(0.001, 0.01, size=n_days)
+            prices = base * np.exp(np.cumsum(returns))
+            rows.append(prices)
+        prices_arr = np.stack(rows, axis=1).ravel(order="C")
+        # 注意: idx 是 [(d1,A),(d1,M),(d2,A)...] 顺序; 需重排
+        bars = pd.DataFrame(index=idx)
+        bars["adj_close"] = np.nan
+        for i, ticker in enumerate(tickers):
+            bars.loc[(slice(None), ticker), "adj_close"] = (
+                np.stack(rows, axis=1)[:, i]
+            )
+        # 计算 fwd_return shift 天做 ml_score (shift-6 模拟无前看完美 oracle)
+        close = bars["adj_close"]
+        fwd_ret = close.groupby(level="ticker").shift(-shift) / close - 1
+        ml_score = pd.DataFrame({ML_SCORE_COLUMN: fwd_ret.to_numpy()}, index=idx)
+        return bars, ml_score
+
+    def test_oracle_ic_near_1(self):
+        """完美 oracle (ml_score = fwd_ret_5d) → IC 应 ≥ 0.99。"""
+        bars, ml_score = self._oracle_setup(shift=5)
+        fp = _FakeFactorProvider(ml_score, expression=[], precomp=[ML_SCORE_COLUMN])
+        mdp = _FakeMarketDataProvider(bars)
+        out = evaluate_ml_score(
+            fp,
+            mdp,
+            universe=["AAPL", "MSFT"],
+            start=date(2026, 1, 2),
+            end=date(2026, 11, 30),
+            shift=5,
+            window=252,
+        )
+        assert "ic_mean" in out
+        # 接近 1 (允许 float 噪声; Spearman rank 理论 = 1)
+        assert out["ic_mean"] > 0.9, f"oracle IC {out['ic_mean']:.3f} 不够高"
+
+    def test_empty_universe_raises(self):
+        with pytest.raises(ValueError, match="universe"):
+            evaluate_ml_score(
+                _FakeFactorProvider(pd.DataFrame(), expression=[]),
+                _FakeMarketDataProvider(pd.DataFrame()),
+                universe=[],
+                start=date(2026, 1, 1),
+                end=date(2026, 2, 1),
+            )
+
+    def test_empty_factor_returns_raises(self):
+        empty = pd.DataFrame(
+            index=pd.MultiIndex.from_arrays([[], []], names=["date", "ticker"]),
+            columns=[ML_SCORE_COLUMN],
+        )
+        fp = _FakeFactorProvider(empty, expression=[], precomp=[ML_SCORE_COLUMN])
+        mdp = _FakeMarketDataProvider(pd.DataFrame())
+        with pytest.raises(ValueError, match="ml_score"):
+            evaluate_ml_score(
+                fp,
+                mdp,
+                universe=["AAPL"],
+                start=date(2026, 1, 1),
+                end=date(2026, 2, 1),
+            )
+
+    def test_shift_parameter_propagated(self, monkeypatch):
+        """验证 shift=5 透传到 ic_evaluator.compute。"""
+        import stockbee.small_models.lightgbm_scorer as mod
+
+        captured: dict[str, Any] = {}
+        real_compute = mod.compute_ic
+
+        def spy(factor_df, prices_df, shift=1, window=252):
+            captured["shift"] = shift
+            captured["window"] = window
+            return {"ic_mean": 0.0, "ic_std": 0.0, "icir": 0.0}
+
+        monkeypatch.setattr(mod, "compute_ic", spy)
+        bars, ml_score = self._oracle_setup(shift=5)
+        fp = _FakeFactorProvider(ml_score, expression=[], precomp=[ML_SCORE_COLUMN])
+        mdp = _FakeMarketDataProvider(bars)
+        evaluate_ml_score(
+            fp,
+            mdp,
+            universe=["AAPL"],
+            start=date(2026, 1, 2),
+            end=date(2026, 11, 30),
+            shift=5,
+            window=100,
+        )
+        assert captured == {"shift": 5, "window": 100}
+
+    def test_invalid_shift(self):
+        fp = _FakeFactorProvider(pd.DataFrame(), expression=[])
+        mdp = _FakeMarketDataProvider(pd.DataFrame())
+        with pytest.raises(ValueError):
+            evaluate_ml_score(
+                fp,
+                mdp,
+                universe=["AAPL"],
+                start=date(2026, 1, 1),
+                end=date(2026, 2, 1),
+                shift=0,
+            )
+
+
+# ============================================================================
+# Perf gate (review C2): PRD §3.3 LightGBM 推理 <50ms GPU / <150ms CPU
+# ============================================================================
+
+
+@pytest.mark.perf
+@pytest.mark.skipif(
+    not os.getenv("RUN_PERF_TESTS"),
+    reason="set RUN_PERF_TESTS=1 to enable perf gate",
+)
+class TestLightGBMPerfGate:
+    def _percentile(self, samples: list[float], p: float) -> float:
+        s = sorted(samples)
+        k = max(0, min(len(s) - 1, int(len(s) * p)))
+        return s[k]
+
+    def test_1000_rows_158_cols_under_150ms(self):
+        """真实 lgb booster 批推理 1000 rows × 158 cols,
+        中位数 < 150ms (CPU,spec tolerance)。"""
+        import lightgbm as lgb
+
+        rng = np.random.default_rng(7)
+        n_rows = 1000
+        n_cols = 158
+        X = rng.standard_normal((n_rows, n_cols))
+        y = X @ rng.standard_normal(n_cols)
+        feat_names = [f"f{i}" for i in range(n_cols)]
+        ds = lgb.Dataset(X, label=y, feature_name=feat_names)
+        booster = lgb.train(
+            {"objective": "regression", "verbose": -1, "seed": 42},
+            ds,
+            num_boost_round=50,
+        )
+        s = LightGBMScorer(booster=booster)
+        idx = pd.MultiIndex.from_product(
+            [pd.bdate_range("2026-01-02", periods=n_rows), ["AAPL"]],
+            names=["date", "ticker"],
+        )[: n_rows]
+        fd = pd.DataFrame(X, index=idx[: n_rows], columns=feat_names)
+
+        for _ in range(3):  # warm-up
+            s.predict(fd)
+        samples = []
+        for _ in range(10):
+            t0 = time.perf_counter()
+            s.predict(fd)
+            samples.append((time.perf_counter() - t0) * 1000.0)
+        median_ms = self._percentile(samples, 0.5)
+        # spec tolerance: GPU <50ms / CPU <150ms; 测试用宽松 CPU 门槛
+        assert median_ms < 150.0, (
+            f"LightGBM 1000×158 predict 中位 {median_ms:.1f}ms > 150ms"
+        )

--- a/tests/small_models/test_lightgbm_train.py
+++ b/tests/small_models/test_lightgbm_train.py
@@ -1,0 +1,638 @@
+"""m3 LightGBM Trainer + label_utils 单元测试。
+
+覆盖:
+- forward_return_5d (B3 决策):
+    * 常数价 → label = 0
+    * 线性上升 → label > 0 单调
+    * 尾部 horizon 天 NaN (位置正确)
+    * 停牌 (中间 NaN) 传播正确
+    * ticker 隔离
+    * 手算 golden
+    * 输入形态: Series vs DataFrame["adj_close"]
+    * 错误输入: 非 MultiIndex / 缺 ticker level / horizon<1
+- walk_forward_splits:
+    * 严格无前看 (train.max < test.min)
+    * step 滑动正确
+    * train+test 长度不足 → 报错
+    * 非法参数
+- train_lightgbm:
+    * 线性 label (0.5*f1 - 0.3*f2) → 训练后 valid IC > 0.5
+    * NaN 行自动 drop
+    * seed 固定 → 结果复现
+    * artifact pickle roundtrip (m1 model_io)
+    * 空 factor_df / 空 label → raise
+- train_and_save E2E:
+    * fake 的 FactorProvider + MarketDataProvider → artifact 落盘
+    * promote_current=True → update_symlink 指向新版本
+    * promote_current=False → 仅保存,不动 current
+    * factor_names 未指定 → 走 list_factors() 过滤 expression
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+from scipy import stats
+
+from stockbee.small_models import label_utils
+from stockbee.small_models import model_io
+from stockbee.small_models.label_utils import forward_return_5d
+from stockbee.small_models.lightgbm_trainer import (
+    DEFAULT_PARAMS,
+    MODEL_NAME,
+    train_and_save,
+    train_lightgbm,
+    walk_forward_splits,
+)
+
+
+# ============================================================================
+# label_utils.forward_return_5d
+# ============================================================================
+
+
+class TestForwardReturn5d:
+    def _make_prices(self, data: dict[str, list[float]]) -> pd.Series:
+        """data: {ticker: [price_day0, price_day1, ...]}"""
+        lengths = {len(v) for v in data.values()}
+        assert len(lengths) == 1, "每个 ticker 价格长度必须一致"
+        n_days = lengths.pop()
+        dates = pd.bdate_range("2026-01-02", periods=n_days)
+        rows = []
+        for d_idx, d in enumerate(dates):
+            for ticker, prices in data.items():
+                rows.append((d, ticker, prices[d_idx]))
+        df = pd.DataFrame(rows, columns=["date", "ticker", "adj_close"])
+        return df.set_index(["date", "ticker"])["adj_close"].sort_index()
+
+    def test_constant_price_zero_label(self):
+        s = self._make_prices({"A": [100.0] * 10})
+        label = forward_return_5d(s)
+        # 前 5 天 = 0, 后 5 天 NaN
+        vals = label.xs("A", level="ticker").to_numpy()
+        assert np.allclose(vals[:5], 0.0)
+        assert np.isnan(vals[5:]).all()
+
+    def test_linear_rising_prices_positive_monotonic(self):
+        """adj_close 线性上升 → 前瞻 5 天收益率均值恒正,接近常量。"""
+        prices = [100.0 + i for i in range(15)]
+        s = self._make_prices({"A": prices})
+        label = forward_return_5d(s)
+        valid = label.dropna().to_numpy()
+        assert (valid > 0).all()
+
+    def test_tail_nan_positions(self):
+        """尾部最后 horizon 天应为 NaN (B3 公式不可避免)。"""
+        s = self._make_prices({"A": [100.0 + i for i in range(15)]})
+        label = forward_return_5d(s, horizon=5)
+        vals = label.xs("A", level="ticker")
+        assert vals.iloc[-5:].isna().all()
+        assert not vals.iloc[:-5].isna().any()
+
+    def test_suspended_stock_nan_propagation(self):
+        """中间 NaN 价 → 周围 label 受 rolling 污染成 NaN,非异常。"""
+        prices = [100.0 + i for i in range(15)]
+        prices[5] = float("nan")
+        s = self._make_prices({"A": prices})
+        label = forward_return_5d(s, horizon=5)
+        vals = label.xs("A", level="ticker").to_numpy()
+        # rolling(5).mean() 碰到 NaN 输出 NaN,shift 后影响范围更大
+        # 最少 index=5 附近必须是 NaN (间接验证传播而不 crash)
+        assert np.isnan(vals).sum() >= 5
+
+    def test_ticker_isolation(self):
+        """A 尾部 NaN 不影响 B 的前段 label。"""
+        s = self._make_prices({
+            "A": [100.0] * 10,
+            "B": [200.0 + i * 0.5 for i in range(10)],
+        })
+        label = forward_return_5d(s, horizon=5)
+        a_vals = label.xs("A", level="ticker").to_numpy()
+        b_vals = label.xs("B", level="ticker").to_numpy()
+        assert np.allclose(a_vals[:5], 0.0)
+        assert (b_vals[:5] > 0).all()
+        assert np.isnan(a_vals[5:]).all()
+        assert np.isnan(b_vals[5:]).all()
+
+    def test_manual_golden_b3_formula(self):
+        """手算 golden: prices=[100,101,102,103,104,105,106,107,108,109] horizon=5。
+
+        label[0] = mean(r1..r5) 其中 ri = price[i]/price[i-1] - 1
+        r1=0.01, r2=1/101, r3=1/102, r4=1/103, r5=1/104
+        """
+        prices = [100.0 + i for i in range(10)]
+        s = self._make_prices({"A": prices})
+        label = forward_return_5d(s, horizon=5)
+        ri = [1.0 / (100 + i) for i in range(9)]  # r_k = (p_k - p_{k-1})/p_{k-1} = 1/p_{k-1}
+        expected_l0 = sum(ri[:5]) / 5.0
+        got = label.xs("A", level="ticker").iloc[0]
+        assert got == pytest.approx(expected_l0, rel=1e-9)
+
+    def test_dataframe_adj_close_column(self, ohlcv_fixture):
+        """DataFrame 含 adj_close 列也可直接传入。"""
+        label = forward_return_5d(ohlcv_fixture, horizon=5)
+        assert label.name == label_utils.LABEL_NAME
+        assert label.index.equals(ohlcv_fixture.index.sort_values())
+        # 每个 ticker 尾部 5 天 NaN
+        for ticker in ohlcv_fixture.index.get_level_values("ticker").unique():
+            vals = label.xs(ticker, level="ticker")
+            assert vals.iloc[-5:].isna().all()
+
+    def test_invalid_horizon_zero(self):
+        s = self._make_prices({"A": [100.0] * 10})
+        with pytest.raises(ValueError):
+            forward_return_5d(s, horizon=0)
+
+    def test_invalid_horizon_negative(self):
+        s = self._make_prices({"A": [100.0] * 10})
+        with pytest.raises(ValueError):
+            forward_return_5d(s, horizon=-1)
+
+    def test_dataframe_missing_adj_close_column(self):
+        df = pd.DataFrame(
+            {"close": [1.0, 2.0]},
+            index=pd.MultiIndex.from_tuples(
+                [(pd.Timestamp("2026-01-02"), "A"), (pd.Timestamp("2026-01-03"), "A")],
+                names=["date", "ticker"],
+            ),
+        )
+        with pytest.raises(ValueError, match="adj_close"):
+            forward_return_5d(df)
+
+    def test_single_index_rejected(self):
+        s = pd.Series([100.0, 101.0], index=[0, 1])
+        with pytest.raises(ValueError, match="MultiIndex"):
+            forward_return_5d(s)
+
+    def test_multiindex_missing_ticker_level(self):
+        idx = pd.MultiIndex.from_tuples(
+            [(pd.Timestamp("2026-01-02"), "X"), (pd.Timestamp("2026-01-03"), "X")],
+            names=["date", "other"],
+        )
+        s = pd.Series([100.0, 101.0], index=idx)
+        with pytest.raises(ValueError, match="ticker"):
+            forward_return_5d(s)
+
+    def test_wrong_input_type(self):
+        with pytest.raises(TypeError):
+            forward_return_5d([100.0, 101.0])  # type: ignore[arg-type]
+
+
+# ============================================================================
+# walk_forward_splits
+# ============================================================================
+
+
+class TestWalkForwardSplits:
+    def test_no_look_ahead(self):
+        dates = pd.bdate_range("2024-01-01", periods=400)
+        for train_d, test_d in walk_forward_splits(dates, train_size=252, test_size=21, step=21):
+            assert train_d.max() < test_d.min()
+
+    def test_step_slides(self):
+        dates = pd.bdate_range("2024-01-01", periods=350)
+        splits = list(walk_forward_splits(dates, train_size=252, test_size=21, step=21))
+        assert len(splits) >= 2
+        # 相邻 train_dates 起点相差 step
+        first_train_start = splits[0][0][0]
+        second_train_start = splits[1][0][0]
+        assert (second_train_start - first_train_start).days >= 21  # 工作日,粗略检查
+
+    def test_last_window_does_not_overflow(self):
+        dates = pd.bdate_range("2024-01-01", periods=300)
+        splits = list(walk_forward_splits(dates, train_size=252, test_size=21, step=21))
+        assert splits, "至少一个窗"
+        last_train, last_test = splits[-1]
+        # 最后一窗完整,不越界
+        assert len(last_train) == 252
+        assert len(last_test) == 21
+
+    def test_insufficient_dates_raises(self):
+        dates = pd.bdate_range("2024-01-01", periods=100)
+        with pytest.raises(ValueError):
+            list(walk_forward_splits(dates, train_size=252, test_size=21, step=21))
+
+    def test_zero_train_size_rejected(self):
+        dates = pd.bdate_range("2024-01-01", periods=300)
+        with pytest.raises(ValueError):
+            list(walk_forward_splits(dates, train_size=0, test_size=21, step=21))
+
+    def test_zero_step_rejected(self):
+        dates = pd.bdate_range("2024-01-01", periods=300)
+        with pytest.raises(ValueError):
+            list(walk_forward_splits(dates, train_size=252, test_size=21, step=0))
+
+    def test_duplicate_dates_deduped(self):
+        """重复日期应去重再切; split 数量等同无重复输入。"""
+        dates_uniq = pd.bdate_range("2024-01-01", periods=300)
+        dates_dup = pd.DatetimeIndex(list(dates_uniq) * 2)
+        splits_uniq = list(
+            walk_forward_splits(dates_uniq, train_size=252, test_size=21, step=21)
+        )
+        splits_dup = list(
+            walk_forward_splits(dates_dup, train_size=252, test_size=21, step=21)
+        )
+        assert splits_dup  # 非空
+        assert len(splits_dup) == len(splits_uniq), (
+            "dedup 后切分数应等同无重复输入"
+        )
+        assert splits_dup[0][0].is_unique  # train_dates 内部唯一
+
+
+# ============================================================================
+# train_lightgbm
+# ============================================================================
+
+
+def _make_fake_factor_label(
+    n_days: int = 100,
+    tickers: tuple[str, ...] = ("AAPL", "MSFT"),
+    noise: float = 0.1,
+    seed: int = 42,
+) -> tuple[pd.DataFrame, pd.Series]:
+    """生成 linear 关系的 (factor_df, label_sr)。
+
+    label = 0.5*f1 - 0.3*f2 + noise * N(0,1)
+    """
+    rng = np.random.default_rng(seed)
+    dates = pd.bdate_range("2024-01-01", periods=n_days)
+    idx = pd.MultiIndex.from_product([dates, tickers], names=["date", "ticker"])
+    f1 = rng.standard_normal(len(idx))
+    f2 = rng.standard_normal(len(idx))
+    f3 = rng.standard_normal(len(idx))  # 无信号列
+    label = 0.5 * f1 - 0.3 * f2 + noise * rng.standard_normal(len(idx))
+    factor_df = pd.DataFrame(
+        {"f1": f1, "f2": f2, "f3_noise": f3},
+        index=idx,
+    )
+    label_sr = pd.Series(label, index=idx, name="label")
+    return factor_df, label_sr
+
+
+class TestTrainLightGBM:
+    def test_linear_label_recovered_high_ic(self):
+        """线性 label 训练后 valid IC > 0.5 (强信号,模型必须抓住)。"""
+        factor_df, label_sr = _make_fake_factor_label(n_days=150, noise=0.1)
+        booster = train_lightgbm(factor_df, label_sr, num_rounds=200, early_stop=30)
+        # 自交叉预测: 对 test set 的 Spearman IC
+        n = len(factor_df)
+        valid_n = max(1, int(n * 0.2))
+        test_part = factor_df.sort_index(level="date").iloc[n - valid_n :]
+        test_label = label_sr.reindex(test_part.index)
+        pred = booster.predict(test_part.to_numpy())
+        ic, _ = stats.spearmanr(pred, test_label.to_numpy())
+        assert ic > 0.5, f"valid Spearman IC {ic:.3f} <= 0.5"
+
+    def test_nan_rows_dropped(self):
+        """部分行 NaN 应被 drop, 不引入 bias (不 crash)。"""
+        factor_df, label_sr = _make_fake_factor_label(n_days=100)
+        # 在 f1 和 label 引入散点 NaN
+        factor_df.iloc[::7, 0] = np.nan
+        label_sr.iloc[::11] = np.nan
+        booster = train_lightgbm(factor_df, label_sr, num_rounds=30, early_stop=10)
+        assert booster is not None
+
+    def test_seed_reproducible(self):
+        factor_df, label_sr = _make_fake_factor_label(n_days=80, noise=0.2)
+        b1 = train_lightgbm(factor_df, label_sr, num_rounds=30, early_stop=10)
+        b2 = train_lightgbm(factor_df, label_sr, num_rounds=30, early_stop=10)
+        # 同样输入 + 同 seed → 预测一致 (到 1e-6)
+        X = factor_df.dropna().to_numpy()[:50]
+        p1 = b1.predict(X)
+        p2 = b2.predict(X)
+        assert np.allclose(p1, p2, atol=1e-6)
+
+    def test_pickle_roundtrip_with_model_io(self, tmp_artifact_dir: Path):
+        """save_pickle + load_pickle 还原 booster,预测一致。"""
+        from stockbee.small_models.model_io import load_pickle, save_pickle
+
+        factor_df, label_sr = _make_fake_factor_label(n_days=80)
+        booster = train_lightgbm(factor_df, label_sr, num_rounds=30, early_stop=10)
+        path = save_pickle(booster, "lightgbm_test", version="20260420")
+        assert path.exists()
+        loaded = load_pickle("lightgbm_test", version="20260420")
+        X = factor_df.dropna().to_numpy()[:30]
+        p_orig = booster.predict(X)
+        p_load = loaded.predict(X)
+        assert np.allclose(p_orig, p_load)
+
+    def test_empty_factor_df_raises(self):
+        empty = pd.DataFrame(
+            index=pd.MultiIndex.from_arrays(
+                [[], []], names=["date", "ticker"]
+            )
+        )
+        label = pd.Series(dtype=float)
+        with pytest.raises(ValueError):
+            train_lightgbm(empty, label)
+
+    def test_all_nan_raises(self):
+        """全 NaN drop 后无样本。"""
+        dates = pd.bdate_range("2024-01-01", periods=20)
+        idx = pd.MultiIndex.from_product(
+            [dates, ["AAPL"]], names=["date", "ticker"]
+        )
+        factor_df = pd.DataFrame(
+            {"f1": [np.nan] * len(idx)}, index=idx
+        )
+        label_sr = pd.Series([np.nan] * len(idx), index=idx)
+        with pytest.raises(ValueError, match="drop NaN"):
+            train_lightgbm(factor_df, label_sr)
+
+    def test_custom_params_override(self):
+        factor_df, label_sr = _make_fake_factor_label(n_days=60)
+        # 手动调低 learning_rate, 验证 params 传入 (booster.params 保留最终有效 params)
+        booster = train_lightgbm(
+            factor_df,
+            label_sr,
+            params={"learning_rate": 0.001},
+            num_rounds=10,
+            early_stop=5,
+        )
+        # LightGBM 有时把 params 回显为字符串, float() 兜底
+        assert float(booster.params.get("learning_rate")) == pytest.approx(0.001)
+
+    def test_early_stop_triggers_on_noisy_label(self):
+        """噪声大的 label → booster 在 num_rounds 用尽前早停。"""
+        factor_df, label_sr = _make_fake_factor_label(
+            n_days=120, noise=5.0, seed=1
+        )
+        booster = train_lightgbm(
+            factor_df,
+            label_sr,
+            num_rounds=200,
+            early_stop=10,
+        )
+        # best_iteration < num_rounds 说明早停被触发 (-1 / 0 也算非正常完成)
+        best_iter = getattr(booster, "best_iteration", 0)
+        assert best_iter < 200, (
+            f"early stop 应触发, best_iter={best_iter} 未小于 num_rounds"
+        )
+
+    def test_no_index_overlap_error_message(self):
+        """review H3: factor_df 和 label_sr 索引无交集 → 明确错误信息。"""
+        dates_a = pd.bdate_range("2024-01-01", periods=30)
+        dates_b = pd.bdate_range("2025-01-01", periods=30)
+        idx_a = pd.MultiIndex.from_product(
+            [dates_a, ["AAPL"]], names=["date", "ticker"]
+        )
+        idx_b = pd.MultiIndex.from_product(
+            [dates_b, ["AAPL"]], names=["date", "ticker"]
+        )
+        factor_df = pd.DataFrame({"f1": np.random.randn(30)}, index=idx_a)
+        label_sr = pd.Series(np.random.randn(30), index=idx_b)
+        with pytest.raises(ValueError, match="无交集"):
+            train_lightgbm(factor_df, label_sr)
+
+    def test_uneven_panel_split_by_unique_date(self):
+        """review H1: 不等长 ticker panel (listings/delistings) 下,
+        同一天的 ticker 不会被劈开到 train + valid 之间。
+
+        构造: AAPL 60 天, MSFT 只有后 40 天。按行索引切会把最后一天的
+        AAPL 划 train、MSFT 划 valid,产生日内 look-ahead。
+        按 unique date 切则不会。
+        """
+        rng = np.random.default_rng(42)
+        n_a = 60
+        n_b = 40
+        dates = pd.bdate_range("2024-01-01", periods=n_a)
+        rows = []
+        for i, d in enumerate(dates):
+            rows.append((d, "AAPL", rng.standard_normal()))
+            if i >= n_a - n_b:
+                rows.append((d, "MSFT", rng.standard_normal()))
+        df = pd.DataFrame(rows, columns=["date", "ticker", "f1"])
+        factor_df = df.set_index(["date", "ticker"])
+        label_sr = pd.Series(
+            rng.standard_normal(len(factor_df)),
+            index=factor_df.index,
+            name="label",
+        )
+        # 训练不报错 (切分成功且每边非空)
+        booster = train_lightgbm(
+            factor_df, label_sr, num_rounds=20, early_stop=5
+        )
+        assert booster is not None
+
+
+# ============================================================================
+# train_and_save (E2E with fake providers)
+# ============================================================================
+
+
+@dataclass
+class _FakeFactorProvider:
+    factor_df: pd.DataFrame
+    expression_names: list[str]
+    precomputed_names: list[str] = None  # type: ignore[assignment]
+
+    def get_factors(
+        self,
+        tickers: list[str],
+        factor_names: list[str],
+        start: date,
+        end: date,
+    ) -> pd.DataFrame:
+        # 忽略 tickers/start/end,直接返回整段 (测试用 fixture 已对齐)
+        return self.factor_df[factor_names]
+
+    def list_factors(self) -> list[dict[str, str]]:
+        out = [{"name": n, "type": "expression"} for n in self.expression_names]
+        for n in self.precomputed_names or []:
+            out.append({"name": n, "type": "precomputed"})
+        return out
+
+
+@dataclass
+class _FakeMarketDataProvider:
+    bars: pd.DataFrame
+
+    def get_daily_bars(
+        self,
+        tickers: list[str],
+        start: date,
+        end: date,
+        fields: list[str] | None = None,
+    ) -> pd.DataFrame:
+        return self.bars
+
+
+@pytest.fixture
+def fake_train_providers(ohlcv_fixture):
+    """用 conftest.ohlcv_fixture 派生 factor_df + label providers。"""
+    # 用 OHLCV 的 adj_close pct_change 做几个朴素因子
+    close = ohlcv_fixture["adj_close"]
+    rng = np.random.default_rng(0)
+    f1 = close.groupby(level="ticker").pct_change().fillna(0.0)
+    f2 = close.groupby(level="ticker").rolling(5).mean().droplevel(0).sort_index()
+    f2 = f2.reindex(ohlcv_fixture.index).bfill()
+    f3 = pd.Series(
+        rng.standard_normal(len(ohlcv_fixture)),
+        index=ohlcv_fixture.index,
+        name="f3",
+    )
+    factor_df = pd.DataFrame(
+        {"f1": f1.values, "f2": f2.values, "f3": f3.values},
+        index=ohlcv_fixture.index,
+    )
+    return _FakeFactorProvider(
+        factor_df=factor_df,
+        expression_names=["f1", "f2", "f3"],
+        precomputed_names=["ml_score"],  # 用来验证 train_and_save 会过滤掉
+    ), _FakeMarketDataProvider(bars=ohlcv_fixture)
+
+
+class TestTrainAndSave:
+    def test_e2e_saves_artifact(self, fake_train_providers, tmp_artifact_dir):
+        fp, mdp = fake_train_providers
+        path = train_and_save(
+            fp,
+            mdp,
+            tickers=["AAPL", "MSFT"],
+            start=date(2026, 1, 2),
+            end=date(2026, 3, 31),
+            factor_names=["f1", "f2", "f3"],
+            version="20260420",
+            num_rounds=30,
+            early_stop=10,
+        )
+        assert path.exists()
+        assert path.name == "20260420.pkl"
+        # 版本目录下应有 current.pkl (POSIX symlink) 或 current.txt (Windows fallback)
+        current_pkl = path.parent / "current.pkl"
+        current_txt = path.parent / "current.txt"
+        assert current_pkl.exists() or current_txt.exists(), (
+            "promote_current=True 应建立 current.pkl symlink 或 current.txt"
+        )
+
+    def test_e2e_promote_current_updates_symlink(
+        self, fake_train_providers, tmp_artifact_dir
+    ):
+        fp, mdp = fake_train_providers
+        train_and_save(
+            fp,
+            mdp,
+            tickers=["AAPL", "MSFT"],
+            start=date(2026, 1, 2),
+            end=date(2026, 3, 31),
+            factor_names=["f1", "f2", "f3"],
+            version="20260420",
+            num_rounds=20,
+            early_stop=10,
+            promote_current=True,
+        )
+        # load_pickle("current") 应拿到同一 booster
+        loaded = model_io.load_pickle(MODEL_NAME, version="current")
+        assert loaded is not None
+
+    def test_e2e_no_promote_leaves_current_untouched(
+        self, fake_train_providers, tmp_artifact_dir
+    ):
+        fp, mdp = fake_train_providers
+        train_and_save(
+            fp,
+            mdp,
+            tickers=["AAPL", "MSFT"],
+            start=date(2026, 1, 2),
+            end=date(2026, 3, 31),
+            factor_names=["f1", "f2", "f3"],
+            version="20260420",
+            num_rounds=20,
+            early_stop=10,
+            promote_current=False,
+        )
+        with pytest.raises(model_io.NotFoundError):
+            model_io.load_pickle(MODEL_NAME, version="current")
+
+    def test_e2e_factor_names_none_uses_list_factors_expression(
+        self, fake_train_providers, tmp_artifact_dir
+    ):
+        """factor_names=None → 走 list_factors, 过滤 type=expression (ml_score 被跳过)。"""
+        fp, mdp = fake_train_providers
+        called_with: dict[str, Any] = {}
+        orig_get_factors = fp.get_factors
+
+        def track(tickers, factor_names, start, end):
+            called_with["factor_names"] = list(factor_names)
+            return orig_get_factors(tickers, factor_names, start, end)
+
+        fp.get_factors = track  # type: ignore[method-assign]
+        train_and_save(
+            fp,
+            mdp,
+            tickers=["AAPL", "MSFT"],
+            start=date(2026, 1, 2),
+            end=date(2026, 3, 31),
+            factor_names=None,
+            version="20260420",
+            num_rounds=10,
+            early_stop=5,
+            promote_current=False,
+        )
+        assert called_with["factor_names"] == ["f1", "f2", "f3"]
+        assert "ml_score" not in called_with["factor_names"]
+
+    def test_empty_tickers_rejected(self, fake_train_providers, tmp_artifact_dir):
+        fp, mdp = fake_train_providers
+        with pytest.raises(ValueError, match="tickers"):
+            train_and_save(
+                fp,
+                mdp,
+                tickers=[],
+                start=date(2026, 1, 2),
+                end=date(2026, 3, 31),
+                version="20260420",
+            )
+
+    def test_same_day_retrain_requires_overwrite(
+        self, fake_train_providers, tmp_artifact_dir
+    ):
+        """review H2: 默认 overwrite=False, 同版本重训应 FileExistsError。"""
+        fp, mdp = fake_train_providers
+        kwargs = dict(
+            tickers=["AAPL", "MSFT"],
+            start=date(2026, 1, 2),
+            end=date(2026, 3, 31),
+            factor_names=["f1", "f2", "f3"],
+            version="20260420",
+            num_rounds=10,
+            early_stop=5,
+            promote_current=False,
+        )
+        train_and_save(fp, mdp, **kwargs)
+        with pytest.raises(FileExistsError):
+            train_and_save(fp, mdp, **kwargs)
+        # 传 overwrite=True 允许同版本覆盖
+        train_and_save(fp, mdp, overwrite=True, **kwargs)
+
+    def test_missing_adj_close_raises(self, fake_train_providers, tmp_artifact_dir):
+        fp, mdp = fake_train_providers
+        # 构造缺 adj_close 的 bars
+        bars_bad = mdp.bars.drop(columns=["adj_close"])
+        mdp_bad = _FakeMarketDataProvider(bars=bars_bad)
+        with pytest.raises(ValueError, match="adj_close"):
+            train_and_save(
+                fp,
+                mdp_bad,
+                tickers=["AAPL", "MSFT"],
+                start=date(2026, 1, 2),
+                end=date(2026, 3, 31),
+                factor_names=["f1", "f2", "f3"],
+                version="20260420",
+            )
+
+
+# ============================================================================
+# DEFAULT_PARAMS 不可变检查 (防止意外 mutation)
+# ============================================================================
+
+
+def test_default_params_has_regression_objective():
+    assert DEFAULT_PARAMS["objective"] == "regression"
+    assert "seed" in DEFAULT_PARAMS

--- a/tests/small_models/test_sentiment_provider.py
+++ b/tests/small_models/test_sentiment_provider.py
@@ -1,0 +1,579 @@
+"""m2b LocalSentimentProvider + g2 P3 重构测试。
+
+覆盖:
+- score_texts 透传 scorer (identity 断言)
+- get_ticker_sentiment:
+    * 空结果 → zeros + count=0
+    * 加权均值公式手算
+    * lookback_days 过滤
+    * 多 ticker 共享新闻
+    * NaN confidence 跳过
+    * Σconf=0 → zeros
+- backfill:
+    * 只写 finbert_confidence IS NULL
+    * 不覆盖 sentiment_score (g2 写)
+    * since 过滤
+    * limit 分页
+    * 空 DB
+- g2 重构后与 m2b 共享同一 FinBERTScorer singleton
+- register_default: ProviderRegistry 注册 + 实例创建
+- PROVIDER 初始化校验
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from stockbee.news_data.news_store import SqliteNewsProvider
+from stockbee.providers.base import ProviderConfig
+from stockbee.providers.registry import ProviderRegistry
+from stockbee.small_models import finbert_scorer as fbs
+from stockbee.small_models.finbert_scorer import (
+    FinBERTScorer,
+    get_default_scorer,
+    reset_default_scorer,
+)
+from stockbee.small_models.local_sentiment_provider import LocalSentimentProvider
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    reset_default_scorer()
+    yield
+    reset_default_scorer()
+
+
+@pytest.fixture
+def news_store_with_rows(tmp_path):
+    """带 3 条新闻的 news_store: 2 AAPL 近期 + 1 MSFT 近期 (都有 finbert_*)。"""
+    cfg = ProviderConfig(
+        implementation="test", params={"db_path": str(tmp_path / "news.db")}
+    )
+    store = SqliteNewsProvider(cfg)
+    store.initialize()
+    base = datetime.now(timezone.utc) - timedelta(days=1)
+    events = [
+        {
+            "headline": "AAPL beats earnings",
+            "source": "reuters",
+            "timestamp": base.isoformat(),
+            "tickers": ["AAPL"],
+            "sentiment_score": 0.9,
+            "finbert_negative": 0.05,
+            "finbert_neutral": 0.05,
+            "finbert_confidence": 0.9,
+        },
+        {
+            "headline": "AAPL new product launch",
+            "source": "bloomberg",
+            "timestamp": (base + timedelta(hours=1)).isoformat(),
+            "tickers": ["AAPL"],
+            "sentiment_score": 0.7,
+            "finbert_negative": 0.10,
+            "finbert_neutral": 0.20,
+            "finbert_confidence": 0.7,
+        },
+        {
+            "headline": "MSFT cloud growth",
+            "source": "reuters",
+            "timestamp": (base + timedelta(hours=2)).isoformat(),
+            "tickers": ["MSFT"],
+            "sentiment_score": 0.8,
+            "finbert_negative": 0.10,
+            "finbert_neutral": 0.10,
+            "finbert_confidence": 0.8,
+        },
+    ]
+    store.insert_news_batch(events)
+    yield store
+    store.shutdown()
+
+
+@pytest.fixture
+def provider(news_store_with_rows):
+    """注入 mock FinBERTScorer + news_store 的已初始化 provider。"""
+    scorer = FinBERTScorer(device="mock")
+    p = LocalSentimentProvider(
+        scorer=scorer, news_store=news_store_with_rows
+    )
+    p.initialize()
+    yield p
+    p.shutdown()
+
+
+# ============================================================================
+# score_texts 透传
+# ============================================================================
+
+
+class TestScoreTextsPassthrough:
+    def test_passthrough_identity(self, provider):
+        """provider.score_texts 和注入的 scorer.score_texts 结果一致。"""
+        texts = ["earnings beat estimates", "company announces layoffs"]
+        from_provider = provider.score_texts(texts)
+        from_scorer = provider._scorer.score_texts(texts)
+        assert from_provider == from_scorer
+
+    def test_shared_scorer_default_singleton(self, news_store_with_rows):
+        """默认不注入 scorer → 走 m2a get_default_scorer singleton。"""
+        reset_default_scorer()
+        p = LocalSentimentProvider(news_store=news_store_with_rows)
+        p.initialize()
+        assert p._scorer is get_default_scorer()
+        p.shutdown()
+
+    def test_require_initialized(self, news_store_with_rows):
+        """未 initialize 时 score_texts raise。"""
+        p = LocalSentimentProvider(
+            scorer=FinBERTScorer(device="mock"), news_store=news_store_with_rows
+        )
+        with pytest.raises(RuntimeError, match="not initialized"):
+            p.score_texts(["x"])
+
+
+# ============================================================================
+# get_ticker_sentiment
+# ============================================================================
+
+
+class TestGetTickerSentiment:
+    def test_empty_result_zeros(self, provider):
+        out = provider.get_ticker_sentiment("NOSUCH", lookback_days=7)
+        assert out == {
+            "positive": 0.0,
+            "negative": 0.0,
+            "neutral": 0.0,
+            "confidence": 0.0,
+            "count": 0.0,
+        }
+
+    def test_weighted_mean_formula(self, provider):
+        """手算 AAPL 的加权均值:
+        row1: pos=0.9 conf=0.9 → contrib 0.81 to positive
+        row2: pos=0.7 conf=0.7 → contrib 0.49
+        sum_conf = 1.6
+        weighted_positive = 1.3 / 1.6 = 0.8125
+
+        confidence (H1): max(聚合后 positive/negative/neutral) = 0.8125
+        """
+        out = provider.get_ticker_sentiment("AAPL", lookback_days=7)
+        assert out["count"] == 2.0
+        # positive: (0.9*0.9 + 0.7*0.7) / (0.9 + 0.7) = 1.3 / 1.6 = 0.8125
+        assert out["positive"] == pytest.approx(0.8125, abs=1e-4)
+        # negative: (0.05*0.9 + 0.10*0.7) / 1.6 = 0.115 / 1.6 = 0.071875
+        assert out["negative"] == pytest.approx(0.071875, abs=1e-4)
+        # neutral: (0.05*0.9 + 0.20*0.7) / 1.6 = 0.185 / 1.6 = 0.115625
+        assert out["neutral"] == pytest.approx(0.115625, abs=1e-4)
+        # confidence = max(0.8125, 0.0719, 0.1156) = 0.8125 (与 FinBERTScorer 单行
+        # confidence = max 三项的语义对齐)
+        assert out["confidence"] == pytest.approx(0.8125, abs=1e-4)
+
+    def test_lookback_filter_excludes_old(self, provider, news_store_with_rows):
+        """插一条 100 天前的 AAPL, lookback=7 应排除。"""
+        old = datetime.now(timezone.utc) - timedelta(days=100)
+        news_store_with_rows.insert_news(
+            headline="AAPL ancient news",
+            source="reuters",
+            timestamp=old.isoformat(),
+            tickers=["AAPL"],
+            sentiment_score=0.3,
+            finbert_negative=0.5,
+            finbert_neutral=0.2,
+            finbert_confidence=0.5,
+        )
+        out = provider.get_ticker_sentiment("AAPL", lookback_days=7)
+        # 仍然只算近期 2 条
+        assert out["count"] == 2.0
+
+    def test_multi_ticker_shared_news(self, news_store_with_rows):
+        """一条新闻带多个 ticker → 对每个 ticker 都可查到。"""
+        shared_time = datetime.now(timezone.utc) - timedelta(hours=1)
+        news_store_with_rows.insert_news(
+            headline="Both AAPL and MSFT up on AI boom",
+            source="reuters",
+            timestamp=shared_time.isoformat(),
+            tickers=["AAPL", "MSFT"],
+            sentiment_score=0.75,
+            finbert_negative=0.1,
+            finbert_neutral=0.15,
+            finbert_confidence=0.75,
+        )
+        scorer = FinBERTScorer(device="mock")
+        p = LocalSentimentProvider(scorer=scorer, news_store=news_store_with_rows)
+        p.initialize()
+        aapl = p.get_ticker_sentiment("AAPL", lookback_days=7)
+        msft = p.get_ticker_sentiment("MSFT", lookback_days=7)
+        # AAPL: 原 2 条 + 新 1 条 = 3
+        assert aapl["count"] == 3.0
+        # MSFT: 原 1 条 + 新 1 条 = 2
+        assert msft["count"] == 2.0
+        p.shutdown()
+
+    def test_nan_confidence_skipped(self, news_store_with_rows):
+        """finbert_confidence NaN / NULL 行被跳过。"""
+        bad_time = datetime.now(timezone.utc) - timedelta(hours=3)
+        conn = news_store_with_rows._conn
+        news_store_with_rows.insert_news(
+            headline="AAPL with null conf",
+            source="reuters",
+            timestamp=bad_time.isoformat(),
+            tickers=["AAPL"],
+            sentiment_score=0.5,
+            # 不传 finbert_* → 三列都是 NULL
+        )
+        scorer = FinBERTScorer(device="mock")
+        p = LocalSentimentProvider(scorer=scorer, news_store=news_store_with_rows)
+        p.initialize()
+        out = p.get_ticker_sentiment("AAPL", lookback_days=7)
+        # 依然 2 条 (null conf 被 SQL WHERE IS NOT NULL 过滤)
+        assert out["count"] == 2.0
+        p.shutdown()
+
+    def test_zero_confidence_rows_return_zeros(self, tmp_path):
+        """所有 AAPL 行 conf=0 → Σconf=0 → zeros 完整 dict + count=0 (不 raise)。"""
+        cfg = ProviderConfig(
+            implementation="t", params={"db_path": str(tmp_path / "n.db")}
+        )
+        store = SqliteNewsProvider(cfg)
+        store.initialize()
+        store.insert_news(
+            headline="AAPL zero conf",
+            source="reuters",
+            timestamp=(datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
+            tickers=["AAPL"],
+            sentiment_score=0.5,
+            finbert_negative=0.3,
+            finbert_neutral=0.3,
+            finbert_confidence=0.0,
+        )
+        scorer = FinBERTScorer(device="mock")
+        p = LocalSentimentProvider(scorer=scorer, news_store=store)
+        p.initialize()
+        out = p.get_ticker_sentiment("AAPL", lookback_days=7)
+        assert out == {
+            "positive": 0.0,
+            "negative": 0.0,
+            "neutral": 0.0,
+            "confidence": 0.0,
+            "count": 0.0,
+        }
+        p.shutdown()
+        store.shutdown()
+
+    def test_invalid_ticker(self, provider):
+        with pytest.raises(ValueError):
+            provider.get_ticker_sentiment("", lookback_days=7)
+        with pytest.raises(ValueError):
+            provider.get_ticker_sentiment(None)  # type: ignore[arg-type]
+
+    def test_invalid_lookback(self, provider):
+        with pytest.raises(ValueError):
+            provider.get_ticker_sentiment("AAPL", lookback_days=-1)
+
+    def test_ticker_case_insensitive(self, provider):
+        """lowercase "aapl" 应匹配 uppercase "AAPL" 的新闻 (大写规范)。"""
+        assert provider.get_ticker_sentiment("aapl")["count"] == 2.0
+
+
+# ============================================================================
+# backfill
+# ============================================================================
+
+
+class TestBackfill:
+    def test_only_writes_null_rows(self, tmp_path):
+        """只更新 finbert_confidence IS NULL; 已有值不覆盖。"""
+        cfg = ProviderConfig(
+            implementation="t", params={"db_path": str(tmp_path / "n.db")}
+        )
+        store = SqliteNewsProvider(cfg)
+        store.initialize()
+        # 2 条需回填 + 1 条已有值
+        store.insert_news(
+            headline="needs backfill 1",
+            source="reuters",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            tickers=["AAPL"],
+        )
+        store.insert_news(
+            headline="needs backfill 2",
+            source="bloomberg",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            tickers=["AAPL"],
+        )
+        # 这条预置值
+        store.insert_news(
+            headline="already scored",
+            source="reuters",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            tickers=["AAPL"],
+            sentiment_score=0.5,
+            finbert_negative=0.1,
+            finbert_neutral=0.2,
+            finbert_confidence=0.7,
+        )
+        scorer = FinBERTScorer(device="mock")
+        p = LocalSentimentProvider(scorer=scorer, news_store=store)
+        p.initialize()
+
+        updated = p.backfill()
+        assert updated == 2
+
+        # 已有值未动
+        row = store._conn.execute(
+            "SELECT finbert_negative, finbert_neutral, finbert_confidence "
+            "FROM news_events WHERE headline = 'already scored'"
+        ).fetchone()
+        assert row == (0.1, 0.2, 0.7)
+        p.shutdown()
+        store.shutdown()
+
+    def test_does_not_touch_sentiment_score(self, tmp_path):
+        """backfill 只写 3 个 finbert_* 列, sentiment_score 不改。"""
+        cfg = ProviderConfig(
+            implementation="t", params={"db_path": str(tmp_path / "n.db")}
+        )
+        store = SqliteNewsProvider(cfg)
+        store.initialize()
+        store.insert_news(
+            headline="beats earnings big",
+            source="reuters",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            tickers=["AAPL"],
+            sentiment_score=0.42,  # 预置的 g2 所写 sentiment_score
+        )
+        scorer = FinBERTScorer(device="mock")
+        p = LocalSentimentProvider(scorer=scorer, news_store=store)
+        p.initialize()
+        p.backfill()
+        row = store._conn.execute(
+            "SELECT sentiment_score, finbert_confidence FROM news_events WHERE id=1"
+        ).fetchone()
+        assert row[0] == 0.42  # 原值保留
+        assert row[1] is not None  # backfill 已写
+        p.shutdown()
+        store.shutdown()
+
+    def test_since_filter(self, tmp_path):
+        cfg = ProviderConfig(
+            implementation="t", params={"db_path": str(tmp_path / "n.db")}
+        )
+        store = SqliteNewsProvider(cfg)
+        store.initialize()
+        now = datetime.now(timezone.utc)
+        store.insert_news(
+            headline="old news",
+            source="reuters",
+            timestamp=(now - timedelta(days=100)).isoformat(),
+            tickers=["AAPL"],
+        )
+        store.insert_news(
+            headline="recent news",
+            source="bloomberg",
+            timestamp=now.isoformat(),
+            tickers=["AAPL"],
+        )
+        scorer = FinBERTScorer(device="mock")
+        p = LocalSentimentProvider(scorer=scorer, news_store=store)
+        p.initialize()
+        since = now - timedelta(days=30)
+        updated = p.backfill(since=since)
+        assert updated == 1  # 只有 recent
+        p.shutdown()
+        store.shutdown()
+
+    def test_limit_pagination(self, tmp_path):
+        cfg = ProviderConfig(
+            implementation="t", params={"db_path": str(tmp_path / "n.db")}
+        )
+        store = SqliteNewsProvider(cfg)
+        store.initialize()
+        now = datetime.now(timezone.utc)
+        for i in range(5):
+            store.insert_news(
+                headline=f"news {i}",
+                source=f"src{i}",
+                timestamp=(now + timedelta(minutes=i)).isoformat(),
+                tickers=["AAPL"],
+            )
+        scorer = FinBERTScorer(device="mock")
+        p = LocalSentimentProvider(scorer=scorer, news_store=store)
+        p.initialize()
+        u1 = p.backfill(limit=2)
+        u2 = p.backfill(limit=2)
+        u3 = p.backfill(limit=2)
+        assert u1 + u2 + u3 == 5
+        assert u1 == 2 and u2 == 2 and u3 == 1
+        p.shutdown()
+        store.shutdown()
+
+    def test_empty_db(self, tmp_path):
+        cfg = ProviderConfig(
+            implementation="t", params={"db_path": str(tmp_path / "empty.db")}
+        )
+        store = SqliteNewsProvider(cfg)
+        store.initialize()
+        scorer = FinBERTScorer(device="mock")
+        p = LocalSentimentProvider(scorer=scorer, news_store=store)
+        p.initialize()
+        assert p.backfill() == 0
+        p.shutdown()
+        store.shutdown()
+
+    def test_invalid_limit(self, provider):
+        with pytest.raises(ValueError):
+            provider.backfill(limit=0)
+
+    def test_require_news_store(self):
+        """没注入 news_store 调用 backfill → raise。"""
+        p = LocalSentimentProvider(scorer=FinBERTScorer(device="mock"))
+        p.initialize()
+        with pytest.raises(RuntimeError, match="news_store"):
+            p.backfill()
+
+
+# ============================================================================
+# P3: g2 和 m2b 共享同一 FinBERTScorer singleton
+# ============================================================================
+
+
+class TestP3SharedSingleton:
+    def test_g2_and_provider_use_same_scorer(self, news_store_with_rows):
+        """g2_classifier + LocalSentimentProvider 都经 get_default_scorer() → 同一实例。"""
+        from stockbee.news_data.g2_classifier import G2Classifier, G2Config
+
+        reset_default_scorer()
+        # provider 默认注入 singleton
+        p = LocalSentimentProvider(news_store=news_store_with_rows)
+        p.initialize()
+        # g2 也取同一 singleton
+        g2 = G2Classifier(G2Config(use_finbert=True))
+        g2._ensure_scorer()
+        assert p._scorer is g2._scorer, (
+            "P3 重构后 g2 和 LocalSentimentProvider 必须复用 FinBERTScorer singleton"
+        )
+        p.shutdown()
+
+
+# ============================================================================
+# sync.py _run_g2 writes finbert_* (CRITICAL review fix)
+# ============================================================================
+
+
+class TestSyncPipelineWritesFinBERTColumns:
+    """review CRITICAL: _run_g2 必须把 G2Result.finbert_negative/neutral/confidence
+    持久化到 DB,否则 LocalSentimentProvider.get_ticker_sentiment 永远读不到数据。"""
+
+    def test_run_g2_writes_finbert_columns_to_db(self, tmp_path):
+        from stockbee.news_data.g2_classifier import G2Classifier, G2Config
+        from stockbee.news_data.sync import NewsDataSyncer
+
+        cfg = ProviderConfig(
+            implementation="t", params={"db_path": str(tmp_path / "n.db")}
+        )
+        store = SqliteNewsProvider(cfg)
+        store.initialize()
+        # 插 1 条,g_level=1
+        news_id = store.insert_news(
+            headline="Apple beats earnings by wide margin",
+            source="reuters",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            tickers=["AAPL"],
+            g_level=1,
+        )
+        assert news_id is not None
+
+        g2 = G2Classifier(G2Config(use_finbert=True))
+        # 注入 mock scorer (复用 test_news_data 的辅助不够, 本地简化)
+        class _S:
+            def score_texts(self, texts, batch_size=32):
+                return [
+                    {
+                        "positive": 0.88, "negative": 0.05,
+                        "neutral": 0.07, "confidence": 0.88,
+                    }
+                    for _ in texts
+                ]
+        g2._scorer = _S()
+        g2._scorer_available = True
+
+        # 构造 syncer 的最小依赖 (sources + g3 可为空 [])
+        syncer = NewsDataSyncer(sources=[], store=store, g1=None, g2=g2, g3=None)
+        event = {"headline": "Apple beats earnings by wide margin", "snippet": None}
+        syncer._run_g2([(event, news_id)])
+
+        row = store._conn.execute(
+            "SELECT finbert_negative, finbert_neutral, finbert_confidence "
+            "FROM news_events WHERE id = ?",
+            (news_id,),
+        ).fetchone()
+        assert row is not None
+        # 三列都非 NULL,和 mock scorer 一致
+        assert row[0] == pytest.approx(0.05, abs=1e-4)
+        assert row[1] == pytest.approx(0.07, abs=1e-4)
+        assert row[2] == pytest.approx(0.88, abs=1e-4)
+        store.shutdown()
+
+    def test_run_g2_rule_fallback_does_not_write_finbert(self, tmp_path):
+        """use_finbert=False / scorer 不可用 → G2Result.used_finbert=False,
+        sync 传 finbert_confidence=None → 列保持 NULL。"""
+        from stockbee.news_data.g2_classifier import G2Classifier, G2Config
+        from stockbee.news_data.sync import NewsDataSyncer
+
+        cfg = ProviderConfig(
+            implementation="t", params={"db_path": str(tmp_path / "n.db")}
+        )
+        store = SqliteNewsProvider(cfg)
+        store.initialize()
+        news_id = store.insert_news(
+            headline="Generic headline",
+            source="reuters",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            tickers=["AAPL"],
+            g_level=1,
+        )
+        g2 = G2Classifier(G2Config(use_finbert=False))
+        syncer = NewsDataSyncer(sources=[], store=store, g1=None, g2=g2, g3=None)
+        event = {"headline": "Generic headline", "snippet": None}
+        syncer._run_g2([(event, news_id)])
+
+        row = store._conn.execute(
+            "SELECT finbert_negative, finbert_neutral, finbert_confidence "
+            "FROM news_events WHERE id = ?",
+            (news_id,),
+        ).fetchone()
+        assert row == (None, None, None)
+        store.shutdown()
+
+
+# ============================================================================
+# register_default
+# ============================================================================
+
+
+class TestRegisterDefault:
+    def test_registers_class_and_instance(self, news_store_with_rows):
+        reg = ProviderRegistry()
+        instance = LocalSentimentProvider.register_default(
+            reg, news_store=news_store_with_rows
+        )
+        assert isinstance(instance, LocalSentimentProvider)
+        # 类已注册
+        assert "LocalSentimentProvider" in reg._classes
+        # 实例按 "SentimentProvider" 抽象名注册
+        assert reg._instances.get("SentimentProvider") is instance
+        # 实例已初始化
+        assert instance.is_initialized
+        # review H3: cache 被注入 (与 registry.create() 行为一致)
+        assert instance.cache is reg.cache
+        instance.shutdown()
+
+    def test_registry_get(self, news_store_with_rows):
+        reg = ProviderRegistry()
+        LocalSentimentProvider.register_default(reg, news_store=news_store_with_rows)
+        fetched = reg.get("SentimentProvider")
+        assert isinstance(fetched, LocalSentimentProvider)
+        fetched.shutdown()

--- a/tests/test_news_data.py
+++ b/tests/test_news_data.py
@@ -793,12 +793,43 @@ def g2_rules() -> G2Classifier:
 
 
 def _mock_finbert_pipeline(label: str = "positive", score: float = 0.92):
-    """构造一个 mock FinBERT pipeline，单条和批量都返回固定结果。"""
+    """m2b 前的 mock 保留 (未使用,保留签名防下游意外 import)。"""
     def pipeline_fn(text_or_texts, **kwargs):
         if isinstance(text_or_texts, list):
             return [{"label": label, "score": score}] * len(text_or_texts)
         return [{"label": label, "score": score}]
     return pipeline_fn
+
+
+class _MockFinBERTScorer:
+    """模拟 m2a FinBERTScorer.score_texts → list[dict(3-way softmax + confidence)]。
+
+    P3 重构后 g2 经 _scorer.score_texts 拿 softmax,测试用这个 mock 避免加载 HF。
+    """
+
+    def __init__(self, label: str = "positive", score: float = 0.92, raise_on_call: bool = False):
+        self._label = label
+        self._score = score
+        self._raise = raise_on_call
+        # 另一个类别分 (1 - score) / 2, 保证 3 项 sum ≈ 1
+        self._other = max(0.0, (1.0 - score) / 2.0)
+
+    def score_texts(self, texts, batch_size: int = 32):
+        if self._raise:
+            raise RuntimeError("mock scorer failure")
+        out = []
+        for _ in texts:
+            probs = {"positive": self._other, "negative": self._other, "neutral": self._other}
+            probs[self._label] = self._score
+            probs["confidence"] = max(probs["positive"], probs["negative"], probs["neutral"])
+            out.append(probs)
+        return out
+
+
+def _attach_mock_scorer(g2, mock_scorer):
+    """把 mock scorer 直接注入 g2 实例,跳过 lazy load 分支。"""
+    g2._scorer = mock_scorer
+    g2._scorer_available = True
 
 
 # =========================================================================
@@ -980,56 +1011,57 @@ class TestG2Urgency:
 class TestG2FinBERT:
 
     def test_finbert_positive(self):
+        """P3 重构后: sentiment_score = FinBERT positive softmax, 不再 0.5+conf/2。"""
         g2 = G2Classifier(G2Config(use_finbert=True))
-        g2._pipeline = _mock_finbert_pipeline("positive", 0.92)
-        g2._finbert_available = True
+        _attach_mock_scorer(g2, _MockFinBERTScorer("positive", 0.92))
         r = g2.classify("Apple beats earnings expectations by wide margin")
         assert r.sentiment == "positive"
         assert r.used_finbert
-        assert r.confidence == 0.92
-        # score = 0.5 + 0.92/2 = 0.96
-        assert r.sentiment_score == pytest.approx(0.96, abs=0.01)
+        assert r.confidence == pytest.approx(0.92, abs=1e-6)
+        assert r.sentiment_score == pytest.approx(0.92, abs=1e-6)
+        # 3-way softmax 可读
+        assert r.finbert_negative is not None
+        assert r.finbert_neutral is not None
 
     def test_finbert_negative(self):
         g2 = G2Classifier(G2Config(use_finbert=True))
-        g2._pipeline = _mock_finbert_pipeline("negative", 0.85)
-        g2._finbert_available = True
+        _attach_mock_scorer(g2, _MockFinBERTScorer("negative", 0.85))
         r = g2.classify("Company reports massive quarterly loss today")
         assert r.sentiment == "negative"
         assert r.used_finbert
-        # score = 0.5 - 0.85/2 = 0.075
-        assert r.sentiment_score < 0.5
+        # P3: sentiment_score = positive softmax 很小
+        assert r.sentiment_score < 0.2
+        assert r.finbert_negative == pytest.approx(0.85, abs=1e-6)
 
     def test_finbert_neutral(self):
         g2 = G2Classifier(G2Config(use_finbert=True))
-        g2._pipeline = _mock_finbert_pipeline("neutral", 0.70)
-        g2._finbert_available = True
+        _attach_mock_scorer(g2, _MockFinBERTScorer("neutral", 0.70))
         r = g2.classify("Company announces quarterly results review")
         assert r.sentiment == "neutral"
-        assert r.sentiment_score == 0.5
+        assert r.finbert_neutral == pytest.approx(0.70, abs=1e-6)
 
     def test_finbert_fallback_on_failure(self):
-        """FinBERT 推理异常时降级到规则引擎。"""
+        """FinBERTScorer 推理异常时降级到规则引擎。"""
         g2 = G2Classifier(G2Config(use_finbert=True))
-        g2._finbert_available = True
-        g2._pipeline = MagicMock(side_effect=RuntimeError("model error"))
+        _attach_mock_scorer(g2, _MockFinBERTScorer(raise_on_call=True))
         r = g2.classify("Stock surge and profit growth reported")
         assert not r.used_finbert  # fell back to rules
         assert r.sentiment == "positive"
+        assert r.finbert_negative is None
 
     def test_finbert_skipped_for_non_english(self):
-        """非英语文本跳过 FinBERT，直接返回 neutral。"""
+        """非英语文本跳过 FinBERT,直接返回 neutral。"""
         g2 = G2Classifier(G2Config(use_finbert=True))
-        g2._pipeline = _mock_finbert_pipeline("positive", 0.99)
-        g2._finbert_available = True
+        _attach_mock_scorer(g2, _MockFinBERTScorer("positive", 0.99))
         r = g2.classify("苹果公司公布第四季度财报超预期增长数据")
         assert not r.used_finbert
         assert r.sentiment == "neutral"
 
     def test_finbert_not_available_uses_rules(self):
-        """transformers/torch 未安装时使用规则引擎。"""
+        """scorer 不可用时使用规则引擎 (模拟 transformers/torch 未装场景)。"""
         g2 = G2Classifier(G2Config(use_finbert=True))
-        g2._finbert_available = False
+        g2._scorer = None
+        g2._scorer_available = False  # 显式禁用
         r = g2.classify("Stock crash and decline continues for market")
         assert not r.used_finbert
         assert r.sentiment == "negative"
@@ -1074,10 +1106,9 @@ class TestG2Batch:
         assert results[1].topic == "earnings"
 
     def test_batch_finbert_mock(self):
-        """批量 FinBERT 推理 mock。"""
+        """批量 FinBERT 推理 mock (P3 重构: 用 FinBERTScorer mock)。"""
         g2 = G2Classifier(G2Config(use_finbert=True))
-        g2._pipeline = _mock_finbert_pipeline("positive", 0.88)
-        g2._finbert_available = True
+        _attach_mock_scorer(g2, _MockFinBERTScorer("positive", 0.88))
         items = [
             {"headline": "Apple beats earnings expectations"},
             {"headline": "Tesla surges on strong demand"},
@@ -1086,12 +1117,13 @@ class TestG2Batch:
         assert len(results) == 2
         assert all(r.used_finbert for r in results)
         assert all(r.sentiment == "positive" for r in results)
+        # 3-way softmax 写入 G2Result
+        assert all(r.finbert_negative is not None for r in results)
 
     def test_batch_finbert_mixed_classifiable(self):
         """批量中混合可分类和不可分类文本。"""
         g2 = G2Classifier(G2Config(use_finbert=True))
-        g2._pipeline = _mock_finbert_pipeline("negative", 0.80)
-        g2._finbert_available = True
+        _attach_mock_scorer(g2, _MockFinBERTScorer("negative", 0.80))
         items = [
             {"headline": "Stock crash amid loss reported"},
             {"headline": "苹果公司公布财报超预期增长"},  # non-English
@@ -1106,8 +1138,7 @@ class TestG2Batch:
     def test_batch_finbert_fallback_on_error(self):
         """批量 FinBERT 异常时整体降级到规则引擎。"""
         g2 = G2Classifier(G2Config(use_finbert=True))
-        g2._finbert_available = True
-        g2._pipeline = MagicMock(side_effect=RuntimeError("batch error"))
+        _attach_mock_scorer(g2, _MockFinBERTScorer(raise_on_call=True))
         items = [
             {"headline": "Stock surge and profit growth"},
             {"headline": "Market crash and loss decline"},


### PR DESCRIPTION
## Summary

完成两个 Phase 1 P0 feature room，共 15 milestone，37 commits：

- **04-factor-storage** (8 milestone, room lifecycle completed)：Alpha158 因子 registry + 表达式引擎 + ParquetFactorStore + IC/ICIR evaluator + LocalFactorProvider + 集成测试
- **02-small-models** (7 milestone, room lifecycle completed)：FinBERT / Fin-E5 / LightGBM 本地模型体系 + LocalSentimentProvider + g2 P3 重构 (singleton 共享) + ml_score precomputed factor
- **[skills] dev**: Phase 3.5 review 修复展示格式规范化

## Test plan
- [x] 全量回归 907 pass, 11 perf skipped (@pytest.mark.perf, RUN_PERF_TESTS=1 opt-in)
- [x] 每个 milestone 单独 pytest 绿 + commit 前跑全量回归防破坏
- [x] Integration-heavy milestone (04-factor-storage m7, 02-small-models m2b/m4/m6) 跑 dual review (Plan sub-agent + Codex) 发现的 CRITICAL/HIGH 全修
- [x] m1 锁契约 (model_io API / 4 DB 新列 / fixtures) 跨 6 milestone 0 修改
- [x] factor-storage 基线 665 tests 全程守住不回归

## 改动规模
- 58 files changed, +13,380 / -349
- 新增模块: `src/stockbee/factor_data/`, `src/stockbee/small_models/`
- 扩展: `src/stockbee/news_data/{g2_classifier,news_store,sync}.py` (P3 refactor + 3 新列)

## 已知遗留
- GH #32 追踪 m4 `evaluate_ml_score` `shift*_CALENDAR_MULTIPLIER` 长假期 buffer 不足 (LOW, 04-alpha-mining 时统一换交易日历修)

## 为什么一个 PR 而不是拆两个
两个 feature room 顺序完成,37 commits 都在同一分支线性推进;拆分需要 cherry-pick 重写历史,意义不大。commit 级粒度已经能回滚单个 milestone。

🤖 Generated with [Claude Code](https://claude.com/claude-code)